### PR TITLE
feat(production-control): Phase 1 — AMX camera preset control

### DIFF
--- a/docs/plan_prod.md
+++ b/docs/plan_prod.md
@@ -199,7 +199,7 @@ Goal: operator can switch the active video source on the Roland mixer. Tapping a
 ### Tasks
 
 #### 2.1 Roland adapter
-- [ ] Implement `src/adapters/mixer/roland.js`
+- [x] Implement `src/adapters/mixer/roland.js`
   - TCP connection to Roland V-series (host + port from `connectionConfig`)
   - `switchSource(connection, inputNumber)` — send Roland TCP command
   - `getActiveSource(connection)` — maintain or poll current active input state
@@ -207,26 +207,27 @@ Goal: operator can switch the active video source on the Roland mixer. Tapping a
   - Reconnect logic
 
 #### 2.2 REST API — mixers and switching
-- [ ] `GET    /production/mixers` — list configured mixers
-- [ ] `POST   /production/mixers` — create mixer
-- [ ] `PUT    /production/mixers/:id` — update mixer
-- [ ] `DELETE /production/mixers/:id` — delete mixer
-- [ ] `POST   /production/mixers/:id/switch/:inputNumber` — switch source
-- [ ] `GET    /production/mixers/:id/active` — current active input
+- [x] `GET    /production/mixers` — list configured mixers
+- [x] `POST   /production/mixers` — create mixer
+- [x] `PUT    /production/mixers/:id` — update mixer
+- [x] `DELETE /production/mixers/:id` — delete mixer
+- [x] `POST   /production/mixers/:id/switch/:inputNumber` — switch source
+- [x] `GET    /production/mixers/:id/active` — current active input
+- [x] `POST   /production/mixers/:id/test` — TCP reachability test (inline, no persistent connection)
 
 #### 2.3 Configuration UI — mixers
-- [ ] Mixer list: name, type badge, connection status indicator
-- [ ] Add/edit mixer form:
+- [x] Mixer list: name, type badge, connection status indicator
+- [x] Add/edit mixer form:
   - Name, type selector (`roland` / ..., extensible)
   - Roland-specific fields: host, port
   - Connection test button — attempts TCP connect, reports success/fail inline
-- [ ] Delete mixer with confirmation
+- [x] Delete mixer with confirmation
 
 #### 2.4 Operator UI — mixer integration
-- [ ] `LIVE` badge on the camera card whose mixer input is currently active
-- [ ] Quick-cut mode toggle: when enabled, tapping a camera card immediately switches the mixer to that camera's input
-- [ ] When quick-cut is off, tapping a camera only triggers presets; mixer switching is a separate explicit action
-- [ ] Roland connection status indicator in the operator UI
+- [x] `LIVE` badge on the camera card whose mixer input is currently active
+- [x] Quick-cut mode toggle: when enabled, tapping a camera card immediately switches the mixer to that camera's input
+- [x] When quick-cut is off, tapping a camera only triggers presets; mixer switching is a separate explicit action
+- [x] Roland connection status indicator in the operator UI (mixer status bar with connected dot + active PGM input)
 
 ---
 

--- a/docs/plan_prod.md
+++ b/docs/plan_prod.md
@@ -215,11 +215,19 @@ Goal: operator can switch the active video source on the Roland mixer. Tapping a
 - [x] `GET    /production/mixers/:id/active` — current active input
 - [x] `POST   /production/mixers/:id/test` — TCP reachability test (inline, no persistent connection)
 
-#### 2.3 Configuration UI — mixers
+#### 2.3 AMX mixer adapter
+- [x] Implement `src/adapters/mixer/amx.js`
+  - TCP connection to AMX NetLinx master
+  - `connectionConfig.inputs[]` maps input numbers to AMX command strings
+  - `switchSource(handle, inputNumber, mixer)` looks up command by input number, sends verbatim
+  - `getSwitchCommand(connectionConfig, inputNumber)` exported for bridge routing
+
+#### 2.4 Configuration UI — mixers
 - [x] Mixer list: name, type badge, connection status indicator
 - [x] Add/edit mixer form:
-  - Name, type selector (`roland` / ..., extensible)
+  - Name, type selector (`roland` / `amx`, extensible)
   - Roland-specific fields: host, port
+  - AMX-specific fields: host, port, input command rows (number + free-text command)
   - Connection test button — attempts TCP connect, reports success/fail inline
 - [x] Delete mixer with confirmation
 
@@ -287,45 +295,45 @@ No ports are opened on the streaming computer. All connections are outbound.
 ### Tasks
 
 #### 4.1 Bridge agent core
-- [ ] New package `packages/lcyt-bridge` (ESM Node.js)
-- [ ] SSE client connecting to `/bridge/commands?token=xxx` (`eventsource` npm package)
-- [ ] HTTP POST client for status reporting to `/bridge/status`
-- [ ] AMX TCP connection + command relay
-- [ ] Roland TCP connection + command relay
-- [ ] Auto-reconnect for SSE and TCP connections on drop
-- [ ] Config loading from `.env` in same directory as exe (`dotenv`)
+- [x] New package `packages/lcyt-bridge` (ESM Node.js)
+- [x] SSE client connecting to `/bridge/commands?token=xxx` (`eventsource` npm package)
+- [x] HTTP POST client for status reporting to `/bridge/status`
+- [x] AMX TCP connection + command relay
+- [x] Roland TCP connection + command relay
+- [x] Auto-reconnect for SSE and TCP connections on drop
+- [x] Config loading from `.env` in same directory as exe (`dotenv`)
 
 #### 4.2 System tray UI
-- [ ] System tray icon using `node-systray`
-- [ ] Right-click context menu:
+- [x] System tray icon using `node-systray`
+- [x] Right-click context menu:
   - **Status** — small status window showing: backend ✓/✗, AMX ✓/✗, Roland ✓/✗, last command timestamp
   - **Reconnect** — force reconnect all connections
   - **Quit** — clean shutdown, close all TCP connections
-- [ ] Tray icon reflects overall health (connected / degraded / disconnected)
+- [x] Tray icon reflects overall health (connected / degraded / disconnected)
 
 #### 4.3 Backend — bridge endpoints
-- [ ] `GET  /bridge/commands` — SSE endpoint, authenticated by bridge token
-- [ ] `POST /bridge/status` — receives heartbeat and command results from bridge
-- [ ] Duplicate connection handling: if a token connects while already connected, kick the first connection
-- [ ] Log reconnection events
+- [x] `GET  /bridge/commands` — SSE endpoint, authenticated by bridge token
+- [x] `POST /bridge/status` — receives heartbeat and command results from bridge
+- [x] Duplicate connection handling: if a token connects while already connected, kick the first connection
+- [x] Log reconnection events
 
 #### 4.4 Settings → Bridges tab
-- [ ] List of bridge instances
+- [x] List of bridge instances
   - **0 bridges**: setup prompt and "Add bridge" button only
   - **1 bridge**: status (connected/disconnected, last seen), "Add bridge" button, delete button — no instance name shown
   - **2+ bridges**: instance names visible on all rows, status per instance, delete buttons
-- [ ] "Add bridge" flow: name input (with org name as default suggestion) → generates token → shows "Download .env" button
-- [ ] Token never shown as plain text — download only
-- [ ] Delete instance:
+- [x] "Add bridge" flow: name input (with org name as default suggestion) → generates token → shows "Download .env" button
+- [x] Token never shown as plain text — download only
+- [x] Delete instance:
   - If cameras or mixers are assigned to it: warn ("X cameras and Y mixers will lose their bridge assignment") — user must confirm
   - On delete: remove instance, set `bridgeInstanceId` to null on affected cameras/mixers
 
 #### 4.5 Progressive disclosure — bridge names in rest of UI
-- [ ] Camera and mixer config cards: show bridge instance name only when 2+ instances exist
-- [ ] Operator UI camera cards: show instance name as secondary label only when 2+ instances exist
+- [x] Camera and mixer config cards: show bridge instance name only when 2+ instances exist
+- [x] Operator UI camera cards: show instance name as secondary label only when 2+ instances exist
 
 #### 4.6 Windows executable build
-- [ ] Build script using `pkg` to produce `lcyt-bridge.exe` (Node.js bundled, no install required)
+- [x] Build script using `pkg` to produce `lcyt-bridge.exe` (Node.js bundled, no install required)
 - [ ] Test on a clean Windows machine with no Node.js installed
 - [ ] Document release process: build exe, make available for download from Settings → Bridges
 

--- a/docs/plan_prod.md
+++ b/docs/plan_prod.md
@@ -1,0 +1,418 @@
+# Production Control — LCYT Feature Plan
+
+## Overview
+
+A new package `packages/production-control` inside the `live-captions-yt` monorepo. It adds a unified production control layer to LCYT, allowing one operator to control cameras (PTZ presets) and video mixer source switching from the same interface used for captions. AI (Claude via MCP) can participate as a co-pilot or take partial control.
+
+The architecture follows the same pluggable adapter pattern already used in LCYT for caption destinations: declare a device type, implement one adapter file, configure instances. Adding new hardware later = add one adapter, register it, nothing else changes.
+
+---
+
+## Architecture
+
+### Package location
+
+```
+packages/production-control/
+  src/
+    adapters/
+      camera/
+        amx.js         ← AMX NetLinx TCP (Phase 1)
+        visca-ip.js    ← VISCA over IP (Phase 6)
+        none.js        ← mixer-only stub
+      mixer/
+        roland.js      ← Roland V-series TCP (Phase 2)
+        atem.js        ← Blackmagic ATEM (Phase 6)
+        obs.js         ← OBS WebSocket (Phase 6)
+    registry.js        ← loads devices from DB, holds live connections
+    api.js             ← Express router plugin with REST routes + SSE endpoint
+    mcp-tools.js       ← MCP tool definitions (Phase 3)
+```
+
+### Data model
+
+```
+BridgeInstance
+  id              UUID PK
+  name            TEXT           ← e.g. "Main church", "Chapel"
+  token           TEXT unique    ← auth token, never shown in UI after generation
+  status          TEXT           ← 'connected' | 'disconnected'
+  lastSeen        TIMESTAMPTZ
+  createdAt       TIMESTAMPTZ
+
+Camera
+  id              UUID PK
+  name            TEXT
+  mixerInput      INTEGER        ← which input number on the mixer
+  controlType     TEXT           ← 'amx' | 'visca-ip' | 'none' | ...
+  controlConfig   JSONB          ← type-specific, see per-adapter docs below
+  bridgeInstanceId UUID FK → BridgeInstance (nullable)
+  sortOrder       INTEGER
+  createdAt       TIMESTAMPTZ
+
+Mixer
+  id              UUID PK
+  name            TEXT
+  type            TEXT           ← 'roland' | 'atem' | 'obs' | ...
+  connectionConfig JSONB         ← host, port, credentials, etc.
+  bridgeInstanceId UUID FK → BridgeInstance (nullable)
+  createdAt       TIMESTAMPTZ
+```
+
+### AMX controlConfig structure
+
+Presets and their command strings live inside `controlConfig` — fully user-defined, the adapter sends exactly what is configured:
+
+```json
+{
+  "host": "192.168.2.50",
+  "port": 1319,
+  "presets": [
+    { "id": "wide",  "name": "Wide shot",  "command": "SEND_COMMAND dvCam,'PRESET-1'" },
+    { "id": "close", "name": "Close-up",   "command": "SEND_COMMAND dvCam,'PRESET-2'" },
+    { "id": "cross", "name": "Cross",      "command": "SEND_COMMAND dvCam,'PRESET-3'" }
+  ]
+}
+```
+
+No command syntax is validated or interpreted — the adapter simply sends the string over TCP verbatim. Any AMX installation with any firmware or command structure works without code changes.
+
+### Adapter interface contract
+
+Every camera control adapter exports:
+
+```js
+export async function connect(config)
+export async function disconnect(connection)
+export async function callPreset(connection, camera, presetId)
+// looks up presetId in camera.controlConfig.presets → sends command string
+```
+
+Every mixer adapter exports:
+
+```js
+export async function connect(config)
+export async function disconnect(connection)
+export async function switchSource(connection, mixerInputNumber)
+export async function getActiveSource(connection) // → mixerInputNumber | null
+```
+
+### Camera capability model
+
+`controlType` determines what the operator UI renders for each camera:
+
+| controlType        | Preset buttons | Mixer source selectable |
+|--------------------|---------------|------------------------|
+| `amx`, `visca-ip`  | ✅             | ✅                      |
+| `none`             | ❌             | ✅                      |
+
+### Bridge communication (SSE + HTTP POST)
+
+```
+Backend → Bridge:   SSE stream   GET /bridge/commands?token=xxx
+Bridge → Backend:   HTTP POST    POST /bridge/status
+```
+
+Backend pushes command events over SSE. Bridge executes them via TCP, then POSTs status back. Works through standard NGINX proxying (`proxy_buffering off`, long `proxy_read_timeout`) — no WebSocket configuration needed.
+
+### Progressive disclosure for bridge names
+
+Bridge instance names are only shown in the UI when 2 or more bridge instances exist. With a single bridge, the concept of "instances" is invisible to the user.
+
+| Bridge count | UI behaviour |
+|---|---|
+| 0 | Setup prompt in Settings → Bridges |
+| 1 | Status only — connected/disconnected, last seen. No name shown. |
+| 2+ | Instance names appear on status view, camera/mixer config cards, and operator UI camera cards |
+
+### Duplicate connection handling
+
+If a second bridge connects using the same token as an already-connected instance, the first connection is kicked immediately. The backend logs the reconnection event. This handles the common case of a streaming computer crashing and restarting without requiring manual intervention.
+
+---
+
+## Phase 1 — AMX Camera Preset Control
+
+Goal: operator can trigger named camera presets via the LCYT UI. AMX sends IR signals via receivers next to each camera.
+
+### Tasks
+
+#### 1.1 Package scaffold
+- [x] Create `packages/production-control/` with `package.json` (ESM, `"type": "module"`)
+- [x] Add as workspace package in monorepo root `package.json`
+- [x] Set up basic Express router export from `src/api.js`
+- [x] Register router in the main LCYT backend
+
+#### 1.2 Database migrations
+- [x] Create migration: `bridge_instances` table
+- [x] Create migration: `cameras` table (with nullable `bridge_instance_id` FK)
+- [x] Create migration: `mixers` table (with nullable `bridge_instance_id` FK)
+- [x] Seed script with example camera configs for dev including sample AMX command strings
+
+#### 1.3 AMX adapter
+- [x] Implement `src/adapters/camera/amx.js`
+  - TCP connection to AMX NetLinx master (host + port from `controlConfig`)
+  - `callPreset(connection, camera, presetId)` — looks up preset in `camera.controlConfig.presets`, sends `preset.command` verbatim over TCP
+  - Connection keepalive / reconnect on drop
+  - Error handling: device unreachable, TCP write failure
+- [x] Implement `src/adapters/camera/none.js` — no-op stub for mixer-only cameras
+- [x] Unit tests for preset lookup and command dispatch (no live hardware needed)
+
+#### 1.4 Device registry
+- [x] `src/registry.js` — loads cameras + mixers from DB on startup
+- [x] Holds live connection handles keyed by device id
+- [x] `getCameraAdapter(camera)` — returns correct adapter module for `controlType`
+- [x] `getMixerAdapter(mixer)` — returns correct adapter module for `type`
+- [x] Graceful startup: log warnings for unreachable devices, do not crash
+
+#### 1.5 REST API — cameras
+- [x] `GET    /production/cameras` — list all cameras with full config
+- [x] `POST   /production/cameras` — create camera
+- [x] `PUT    /production/cameras/:id` — update camera
+- [x] `DELETE /production/cameras/:id` — delete camera
+- [x] `POST   /production/cameras/:id/preset/:presetId` — trigger preset → calls adapter
+
+#### 1.6 Configuration UI — cameras
+- [x] Camera list: name, control type badge, mixer input number, preset count
+- [x] Add/edit camera form:
+  - Name, mixer input number, sort order
+  - Control type selector (`amx` / `none` / ..., extensible dropdown)
+  - AMX-specific section (shown when type = `amx`): host, port
+  - Preset command editor — list of rows, each with preset name + free-text AMX command string
+  - Add / remove preset rows
+  - No command validation — store and send as-is
+  - Placeholder text shows example AMX command format
+- [x] Delete camera with confirmation
+
+#### 1.7 Operator UI — camera preset panel
+- [x] Camera grid: one card per camera showing name and preset buttons
+- [x] Mixer-only cameras (`none`) show card without preset buttons
+- [x] Visual feedback on preset trigger: pending → success / error
+- [x] Responsive layout suitable for tablet use during a service
+
+---
+
+## Phase 2 — Roland Mixer Source Switching
+
+Goal: operator can switch the active video source on the Roland mixer. Tapping a camera can optionally also cut the mixer to that camera's input.
+
+### Tasks
+
+#### 2.1 Roland adapter
+- [ ] Implement `src/adapters/mixer/roland.js`
+  - TCP connection to Roland V-series (host + port from `connectionConfig`)
+  - `switchSource(connection, inputNumber)` — send Roland TCP command
+  - `getActiveSource(connection)` — maintain or poll current active input state
+  - Document the specific Roland TCP command strings as named constants in the file
+  - Reconnect logic
+
+#### 2.2 REST API — mixers and switching
+- [ ] `GET    /production/mixers` — list configured mixers
+- [ ] `POST   /production/mixers` — create mixer
+- [ ] `PUT    /production/mixers/:id` — update mixer
+- [ ] `DELETE /production/mixers/:id` — delete mixer
+- [ ] `POST   /production/mixers/:id/switch/:inputNumber` — switch source
+- [ ] `GET    /production/mixers/:id/active` — current active input
+
+#### 2.3 Configuration UI — mixers
+- [ ] Mixer list: name, type badge, connection status indicator
+- [ ] Add/edit mixer form:
+  - Name, type selector (`roland` / ..., extensible)
+  - Roland-specific fields: host, port
+  - Connection test button — attempts TCP connect, reports success/fail inline
+- [ ] Delete mixer with confirmation
+
+#### 2.4 Operator UI — mixer integration
+- [ ] `LIVE` badge on the camera card whose mixer input is currently active
+- [ ] Quick-cut mode toggle: when enabled, tapping a camera card immediately switches the mixer to that camera's input
+- [ ] When quick-cut is off, tapping a camera only triggers presets; mixer switching is a separate explicit action
+- [ ] Roland connection status indicator in the operator UI
+
+---
+
+## Phase 3 — MCP Tools
+
+Goal: Claude can read production state and execute camera/mixer commands as co-pilot or in automated flows.
+
+### Tasks
+
+#### 3.1 MCP tool definitions
+- [ ] `production_get_state` — returns all cameras (names, presets, mixer inputs) and which input is currently active on each mixer
+- [ ] `camera_call_preset(cameraId, presetId)` — trigger a named preset; response includes human-readable camera and preset names
+- [ ] `mixer_switch_source(mixerId, inputNumber)` — cut mixer to input number
+- [ ] `mixer_switch_to_camera(cameraId)` — convenience: resolves camera's `mixerInput` and switches
+- [ ] Register all tools in the LCYT MCP server
+
+#### 3.2 Tool quality
+- [ ] All tool descriptions written so Claude understands when and how to use them
+- [ ] State responses use human-readable names throughout, not just UUIDs
+- [ ] Error messages are descriptive: "AMX device unreachable", "unknown preset id", etc.
+
+---
+
+## Phase 4 — lcyt-bridge (Windows Agent)
+
+Goal: a lightweight Windows agent that runs on the streaming computer, connects to the LCYT backend via SSE, and relays commands to AMX and Roland over TCP on the local network.
+
+### Network topology
+
+```
+Internet
+    │
+    ▼
+Streaming computer (Windows)
+    ├── NIC 1: internet-facing LAN  ──→ LCYT backend (VPS)
+    └── NIC 2: isolated AV network  ──→ AMX master
+                                    ──→ Roland mixer (confirm which NIC)
+
+lcyt-bridge.exe runs on the streaming computer:
+    ├── SSE client   → GET /bridge/commands   (outbound, no inbound ports needed)
+    ├── HTTP POST    → POST /bridge/status
+    ├── TCP socket   → AMX    (via NIC 2, isolated AV network)
+    └── TCP socket   → Roland (via whichever NIC reaches it — confirm before build)
+```
+
+No ports are opened on the streaming computer. All connections are outbound.
+
+### Config generation flow
+
+1. Admin goes to Settings → Bridges → "Add bridge"
+2. Enters a name for the instance (e.g. "Main church") — default suggestion is the organisation name
+3. Backend generates a token, creates the `BridgeInstance` record
+4. Admin clicks "Download .env" — backend serves a pre-filled config file
+5. Token is never shown as plain text in the UI — download only
+6. User places `.env` next to `lcyt-bridge.exe` and runs it
+
+### Tasks
+
+#### 4.1 Bridge agent core
+- [ ] New package `packages/lcyt-bridge` (ESM Node.js)
+- [ ] SSE client connecting to `/bridge/commands?token=xxx` (`eventsource` npm package)
+- [ ] HTTP POST client for status reporting to `/bridge/status`
+- [ ] AMX TCP connection + command relay
+- [ ] Roland TCP connection + command relay
+- [ ] Auto-reconnect for SSE and TCP connections on drop
+- [ ] Config loading from `.env` in same directory as exe (`dotenv`)
+
+#### 4.2 System tray UI
+- [ ] System tray icon using `node-systray`
+- [ ] Right-click context menu:
+  - **Status** — small status window showing: backend ✓/✗, AMX ✓/✗, Roland ✓/✗, last command timestamp
+  - **Reconnect** — force reconnect all connections
+  - **Quit** — clean shutdown, close all TCP connections
+- [ ] Tray icon reflects overall health (connected / degraded / disconnected)
+
+#### 4.3 Backend — bridge endpoints
+- [ ] `GET  /bridge/commands` — SSE endpoint, authenticated by bridge token
+- [ ] `POST /bridge/status` — receives heartbeat and command results from bridge
+- [ ] Duplicate connection handling: if a token connects while already connected, kick the first connection
+- [ ] Log reconnection events
+
+#### 4.4 Settings → Bridges tab
+- [ ] List of bridge instances
+  - **0 bridges**: setup prompt and "Add bridge" button only
+  - **1 bridge**: status (connected/disconnected, last seen), "Add bridge" button, delete button — no instance name shown
+  - **2+ bridges**: instance names visible on all rows, status per instance, delete buttons
+- [ ] "Add bridge" flow: name input (with org name as default suggestion) → generates token → shows "Download .env" button
+- [ ] Token never shown as plain text — download only
+- [ ] Delete instance:
+  - If cameras or mixers are assigned to it: warn ("X cameras and Y mixers will lose their bridge assignment") — user must confirm
+  - On delete: remove instance, set `bridgeInstanceId` to null on affected cameras/mixers
+
+#### 4.5 Progressive disclosure — bridge names in rest of UI
+- [ ] Camera and mixer config cards: show bridge instance name only when 2+ instances exist
+- [ ] Operator UI camera cards: show instance name as secondary label only when 2+ instances exist
+
+#### 4.6 Windows executable build
+- [ ] Build script using `pkg` to produce `lcyt-bridge.exe` (Node.js bundled, no install required)
+- [ ] Test on a clean Windows machine with no Node.js installed
+- [ ] Document release process: build exe, make available for download from Settings → Bridges
+
+---
+
+## Phase 5 — Testing
+
+Goal: automated test coverage for everything that can be tested in the development environment. Hardware-dependent behaviour (real AMX, real Roland TCP) is explicitly out of scope for automated tests and documented as requiring manual verification in the church environment.
+
+### In scope (dev environment, no hardware needed)
+
+#### 5.1 Unit tests — adapters
+- [ ] AMX adapter: preset lookup by id, command string dispatch, missing preset error
+- [ ] `none` adapter: no-op behaviour, no errors thrown
+- [ ] Adapter registry: correct adapter module returned for each `controlType` and mixer `type`
+- [ ] Command string passthrough — verify no transformation occurs between config and TCP send
+
+#### 5.2 Unit tests — bridge instance logic
+- [ ] Token generation produces unique values
+- [ ] Progressive disclosure logic: name visibility threshold at exactly 2 instances
+- [ ] Duplicate connection detection: second connection with same token kicks first
+
+#### 5.3 Integration tests — REST API (test DB)
+- [ ] Camera CRUD endpoints
+- [ ] Mixer CRUD endpoints
+- [ ] `POST /cameras/:id/preset/:presetId` — correct adapter called, correct command string passed
+- [ ] `POST /mixers/:id/switch/:inputNumber` — correct adapter called
+- [ ] Bridge token auth on SSE endpoint — valid token accepted, invalid rejected
+- [ ] `POST /bridge/status` — status recorded against correct instance
+
+#### 5.4 Integration tests — bridge agent (mocked backend)
+- [ ] Bridge connects to mock SSE endpoint, receives command event, calls correct TCP handler
+- [ ] Bridge POSTs status after command execution
+- [ ] Bridge reconnects after SSE stream drop
+- [ ] Bridge reconnects TCP after connection drop
+
+#### 5.5 Integration tests — Settings UI
+- [ ] Add bridge: instance created, `.env` download available
+- [ ] Delete bridge with no assignments: removed cleanly
+- [ ] Delete bridge with assigned cameras/mixers: warning shown, assignment nulled on confirm
+- [ ] Bridge name visibility: hidden with 1 instance, visible with 2+
+
+### Out of scope for automated tests (manual verification in church)
+
+- Actual TCP communication with AMX NetLinx master
+- Actual TCP communication with Roland mixer
+- IR signal delivery to cameras via AMX
+- End-to-end preset → camera movement latency
+- Bridge behaviour across two physical NICs
+
+---
+
+## Phase 6 — Additional Adapters
+
+Goal: support further hardware without touching existing code. Each adapter is one self-contained file implementing the standard interface.
+
+### Tasks
+
+#### 6.1 VISCA-IP camera adapter
+- [ ] `src/adapters/camera/visca-ip.js`
+- [ ] VISCA over IP (UDP or TCP depending on camera model)
+- [ ] Same `connect` / `callPreset` interface
+- [ ] Add `visca-ip` as selectable type in camera config UI with its specific fields
+
+#### 6.2 ATEM mixer adapter
+- [ ] `src/adapters/mixer/atem.js`
+- [ ] Use `atem-connection` npm library
+- [ ] Same `connect` / `switchSource` / `getActiveSource` interface
+- [ ] Add `atem` as selectable type in mixer config UI
+
+#### 6.3 OBS mixer adapter
+- [ ] `src/adapters/mixer/obs.js`
+- [ ] OBS WebSocket v5 (`obs-websocket-js` library)
+- [ ] `switchSource` maps to scene switching or scene item activation
+- [ ] Add `obs` as selectable type in mixer config UI
+
+#### 6.4 Adapter registry cleanup
+- [ ] `src/adapters/index.js` — central map of `type → adapter module`
+- [ ] Adding a new adapter = one new file + one entry here, nothing else changes
+- [ ] Write `ADAPTERS.md` documenting the interface contract for future implementors
+
+---
+
+## Open Questions
+
+- **AMX command format**: review the provided NetLinx code to confirm exact TCP command strings. Use them as placeholder examples in the preset command editor so users know the expected format.
+- **Roland protocol reference**: confirm the Roland model in use, verify TCP port (typically 8023), obtain protocol PDF from Roland support if needed.
+- **Network path to Roland**: is the Roland on the same isolated AV network as AMX, or on the internet-facing LAN? Determines which NIC the bridge uses for Roland TCP connections.
+- **Multi-mixer operator UI**: data model supports multiple mixers — clarify if operator UI needs a mixer selector or can assume one primary active mixer.
+- **Active source on Roland**: decide whether to poll `getActiveSource` periodically or maintain persistent TCP state. Document the chosen approach in the adapter.
+- **Tailscale as alternative to lcyt-bridge**: if church IT permits a VPN, Tailscale on the streaming computer would give the VPS direct network access to AMX/Roland, eliminating the bridge agent entirely. Worth evaluating before starting Phase 4.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "packages/lcyt-web",
         "packages/lcyt-mcp-stdio",
         "packages/lcyt-mcp-sse",
-        "packages/lcyt-site"
+        "packages/lcyt-site",
+        "packages/production-control"
       ],
       "devDependencies": {
         "playwright": "^1.58.2"
@@ -498,6 +499,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -514,6 +516,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -530,6 +533,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -546,6 +550,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -562,6 +567,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -578,6 +584,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -594,6 +601,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -610,6 +618,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -626,6 +635,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -642,6 +652,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -658,6 +669,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -674,6 +686,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -690,6 +703,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -706,6 +720,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -722,6 +737,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -738,6 +754,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -754,6 +771,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -786,6 +804,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -818,6 +837,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -850,6 +870,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -866,6 +887,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -882,6 +904,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -898,6 +921,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7170,6 +7194,10 @@
         "node": ">=6"
       }
     },
+    "node_modules/production-control": {
+      "resolved": "packages/production-control",
+      "link": true
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -8978,6 +9006,13 @@
       "devDependencies": {
         "@vitejs/plugin-react": "^4.0.0",
         "vite": "^5.0.0"
+      }
+    },
+    "packages/production-control": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "packages/lcyt-web",
     "packages/lcyt-mcp-stdio",
     "packages/lcyt-mcp-sse",
-    "packages/lcyt-site"
+    "packages/lcyt-site",
+    "packages/production-control"
   ],
   "scripts": {
     "test": "npm test --workspaces",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "packages/lcyt-mcp-stdio",
     "packages/lcyt-mcp-sse",
     "packages/lcyt-site",
-    "packages/production-control"
+    "packages/production-control",
+    "packages/lcyt-bridge"
   ],
   "scripts": {
     "test": "npm test --workspaces",

--- a/packages/lcyt-backend/src/server.js
+++ b/packages/lcyt-backend/src/server.js
@@ -31,6 +31,7 @@ import { HlsManager } from './hls-manager.js';
 import { createPreviewRouter } from './routes/preview.js';
 import { PreviewManager } from './preview-manager.js';
 import { createDskRtmpRouter } from './routes/dsk-rtmp.js';
+import { initProductionControl, createProductionRouter } from 'production-control';
 
 // ---------------------------------------------------------------------------
 // JWT secret
@@ -126,6 +127,9 @@ if (process.env.RTMP_RELAY_ACTIVE === '1') {
 
 const db = initDb();
 const store = new SessionStore({ db });
+
+// Production control — run DB migrations and start device registry
+const { registry: productionRegistry } = await initProductionControl(db);
 
 // Stat tracking: map from `${apiKey}:${slot}` → rtmp_stream_stats row id
 const _rtmpStatIds = new Map();
@@ -348,9 +352,10 @@ app.use('/stream-hls', createStreamHlsRouter(db, hlsManager));
 app.use('/preview', createPreviewRouter(previewManager));
 app.use('/dsk-rtmp', createDskRtmpRouter(relayManager));
 app.use('/youtube', createYouTubeRouter(auth));
+app.use('/production', createProductionRouter(db, productionRegistry));
 
 // ---------------------------------------------------------------------------
 // Exports (for testing and graceful shutdown wiring in index.js)
 // ---------------------------------------------------------------------------
 
-export { app, db, store, relayManager, radioManager, hlsManager, previewManager };
+export { app, db, store, relayManager, radioManager, hlsManager, previewManager, productionRegistry };

--- a/packages/lcyt-backend/src/server.js
+++ b/packages/lcyt-backend/src/server.js
@@ -128,8 +128,11 @@ if (process.env.RTMP_RELAY_ACTIVE === '1') {
 const db = initDb();
 const store = new SessionStore({ db });
 
-// Production control — run DB migrations and start device registry
-const { registry: productionRegistry } = await initProductionControl(db);
+// Production control — run DB migrations, start device registry and bridge manager
+const {
+  registry: productionRegistry,
+  bridgeManager: productionBridgeManager,
+} = await initProductionControl(db);
 
 // Stat tracking: map from `${apiKey}:${slot}` → rtmp_stream_stats row id
 const _rtmpStatIds = new Map();
@@ -352,10 +355,12 @@ app.use('/stream-hls', createStreamHlsRouter(db, hlsManager));
 app.use('/preview', createPreviewRouter(previewManager));
 app.use('/dsk-rtmp', createDskRtmpRouter(relayManager));
 app.use('/youtube', createYouTubeRouter(auth));
-app.use('/production', createProductionRouter(db, productionRegistry));
+app.use('/production', createProductionRouter(db, productionRegistry, productionBridgeManager, {
+  publicUrl: process.env.PUBLIC_URL,
+}));
 
 // ---------------------------------------------------------------------------
 // Exports (for testing and graceful shutdown wiring in index.js)
 // ---------------------------------------------------------------------------
 
-export { app, db, store, relayManager, radioManager, hlsManager, previewManager, productionRegistry };
+export { app, db, store, relayManager, radioManager, hlsManager, previewManager, productionRegistry, productionBridgeManager };

--- a/packages/lcyt-bridge/.env.sample
+++ b/packages/lcyt-bridge/.env.sample
@@ -1,0 +1,10 @@
+# lcyt-bridge configuration
+# Copy this file to .env and fill in your values.
+# Place .env next to lcyt-bridge.exe before running.
+
+# URL of the LCYT backend API
+BACKEND_URL=https://api.lcyt.fi
+
+# Bridge authentication token — generated in Settings → Bridges
+# Never share this token publicly.
+BRIDGE_TOKEN=your_bridge_token_here

--- a/packages/lcyt-bridge/package.json
+++ b/packages/lcyt-bridge/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "lcyt-bridge",
+  "version": "0.1.0",
+  "description": "LCYT bridge agent — relays production control commands to AMX and Roland over TCP",
+  "type": "module",
+  "main": "src/index.js",
+  "bin": {
+    "lcyt-bridge": "src/index.js"
+  },
+  "scripts": {
+    "start": "node src/index.js",
+    "build:win": "pkg . --target node20-win-x64 --output dist/lcyt-bridge.exe",
+    "build:mac": "pkg . --target node20-macos-x64 --output dist/lcyt-bridge-mac",
+    "build:linux": "pkg . --target node20-linux-x64 --output dist/lcyt-bridge-linux"
+  },
+  "pkg": {
+    "assets": [
+      "node_modules/node-systray/resources/**/*"
+    ],
+    "scripts": []
+  },
+  "dependencies": {
+    "dotenv": "^16.0.0",
+    "eventsource": "^2.0.2",
+    "node-systray": "^2.0.0"
+  },
+  "devDependencies": {
+    "pkg": "^5.8.1"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "author": "Juha Itäleino <jsilvanus@gmail.com>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jsilvanus/live-captions-yt.git",
+    "directory": "packages/lcyt-bridge"
+  }
+}

--- a/packages/lcyt-bridge/src/bridge.js
+++ b/packages/lcyt-bridge/src/bridge.js
@@ -1,0 +1,159 @@
+/**
+ * lcyt-bridge core — SSE client + command dispatcher + status reporter.
+ *
+ * Connects to GET /production/bridge/commands?token=xxx on the LCYT backend.
+ * Dispatches tcp_send commands to the TcpPool.
+ * Reports results via POST /production/bridge/status.
+ */
+
+import { EventEmitter } from 'node:events';
+import { TcpPool } from './tcp-pool.js';
+
+const RECONNECT_DELAY_MS = 5_000;
+const RECONNECT_DELAY_MAX_MS = 60_000;
+
+export class Bridge extends EventEmitter {
+  /**
+   * @param {{ backendUrl: string, token: string }} config
+   */
+  constructor({ backendUrl, token }) {
+    super();
+    this._backendUrl = backendUrl.replace(/\/$/, '');
+    this._token = token;
+    this._tcpPool = new TcpPool();
+    this._es = null;
+    this._destroyed = false;
+    this._reconnectDelay = RECONNECT_DELAY_MS;
+    this._reconnectTimer = null;
+
+    // Forward TCP pool events
+    this._tcpPool.on('connected',    (key) => { this.emit('tcp:connected', key); });
+    this._tcpPool.on('disconnected', (key) => { this.emit('tcp:disconnected', key); });
+    this._tcpPool.on('error',        (key, err) => { this.emit('tcp:error', key, err); });
+  }
+
+  /** Start the SSE connection. */
+  start() {
+    this._connect();
+  }
+
+  /** Trigger reconnect of all SSE and TCP connections. */
+  reconnectAll() {
+    if (this._es) { try { this._es.close(); } catch { /* ignore */ } }
+    this._tcpPool.reconnectAll();
+    this._connect();
+  }
+
+  /** Graceful shutdown. */
+  destroy() {
+    this._destroyed = true;
+    if (this._reconnectTimer) clearTimeout(this._reconnectTimer);
+    if (this._es) { try { this._es.close(); } catch { /* ignore */ } }
+    this._tcpPool.destroy();
+  }
+
+  /** @returns {{ sse: boolean, tcp: Array<{ key: string, connected: boolean }> }} */
+  status() {
+    return {
+      sse: this._es?.readyState === 1 /* OPEN */,
+      tcp: this._tcpPool.status(),
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+
+  async _connect() {
+    if (this._destroyed) return;
+
+    // Dynamic import of eventsource (CommonJS package)
+    let EventSource;
+    try {
+      const mod = await import('eventsource');
+      EventSource = mod.default ?? mod.EventSource;
+    } catch (e) {
+      this.emit('error', new Error(`Cannot load eventsource: ${e.message}`));
+      return;
+    }
+
+    const url = `${this._backendUrl}/production/bridge/commands?token=${encodeURIComponent(this._token)}`;
+    this.emit('connecting', url);
+
+    const es = new EventSource(url);
+    this._es = es;
+
+    es.onopen = () => {
+      this._reconnectDelay = RECONNECT_DELAY_MS; // reset backoff on success
+      this.emit('connected');
+    };
+
+    es.addEventListener('connected', () => {
+      this.emit('connected');
+    });
+
+    es.addEventListener('command', (evt) => {
+      this._handleCommand(evt.data);
+    });
+
+    es.onerror = (err) => {
+      this.emit('disconnected');
+      es.close();
+      this._es = null;
+      if (!this._destroyed) {
+        this.emit('reconnecting', this._reconnectDelay);
+        this._reconnectTimer = setTimeout(() => {
+          this._reconnectTimer = null;
+          this._reconnectDelay = Math.min(this._reconnectDelay * 2, RECONNECT_DELAY_MAX_MS);
+          this._connect();
+        }, this._reconnectDelay);
+      }
+    };
+  }
+
+  async _handleCommand(rawData) {
+    let cmd;
+    try {
+      cmd = JSON.parse(rawData);
+    } catch {
+      this.emit('error', new Error(`Received non-JSON command: ${rawData}`));
+      return;
+    }
+
+    if (cmd.type === 'tcp_send') {
+      const { requestId, host, port, payload } = cmd;
+      try {
+        await this._tcpPool.send(host, Number(port), payload);
+        await this._postStatus({ requestId, ok: true });
+        this.emit('command:ok', { host, port, payload });
+      } catch (err) {
+        await this._postStatus({ requestId, ok: false, error: err.message });
+        this.emit('command:error', { host, port, error: err.message });
+      }
+    } else {
+      this.emit('error', new Error(`Unknown command type: ${cmd.type}`));
+    }
+  }
+
+  async _postStatus(body) {
+    try {
+      await fetch(`${this._backendUrl}/production/bridge/status`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Bridge-Token': this._token,
+        },
+        body: JSON.stringify(body),
+      });
+    } catch (err) {
+      this.emit('error', new Error(`Status POST failed: ${err.message}`));
+    }
+  }
+
+  /** Send a periodic heartbeat to the backend. */
+  startHeartbeat(intervalMs = 30_000) {
+    const timer = setInterval(() => {
+      if (this._destroyed) { clearInterval(timer); return; }
+      this._postStatus({ type: 'heartbeat' });
+    }, intervalMs);
+    return timer;
+  }
+}

--- a/packages/lcyt-bridge/src/index.js
+++ b/packages/lcyt-bridge/src/index.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * lcyt-bridge — production control relay agent
+ *
+ * Reads config from .env in the same directory as the executable (or cwd).
+ * Required variables: BACKEND_URL, BRIDGE_TOKEN
+ *
+ * Run:  node src/index.js
+ * Exe:  lcyt-bridge.exe (built with pkg)
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse as parseDotenv } from 'dotenv';
+
+// ---------------------------------------------------------------------------
+// Load .env from the same directory as the executable (or fallback to cwd)
+// ---------------------------------------------------------------------------
+
+function loadConfig() {
+  // When running as a pkg exe, process.execPath is the .exe; src/index.js is
+  // compiled in, so __dirname points inside the pkg snapshot. We use
+  // process.execPath's directory for the real .env location.
+  const exeDir = process.pkg
+    ? dirname(process.execPath)
+    : dirname(fileURLToPath(import.meta.url));
+
+  const envPath = join(exeDir, '.env');
+
+  let vars = {};
+  if (existsSync(envPath)) {
+    try {
+      vars = parseDotenv(readFileSync(envPath, 'utf8'));
+    } catch (e) {
+      console.warn(`[lcyt-bridge] Could not parse .env at ${envPath}: ${e.message}`);
+    }
+  }
+
+  // Merge with process.env (process.env takes precedence over .env file)
+  const get = (key) => process.env[key] ?? vars[key];
+
+  const backendUrl = get('BACKEND_URL');
+  const token      = get('BRIDGE_TOKEN');
+
+  if (!backendUrl) {
+    console.error('[lcyt-bridge] BACKEND_URL is required. Set it in .env or as an environment variable.');
+    process.exit(1);
+  }
+  if (!token) {
+    console.error('[lcyt-bridge] BRIDGE_TOKEN is required. Set it in .env or as an environment variable.');
+    process.exit(1);
+  }
+
+  return { backendUrl, token };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+const config = loadConfig();
+
+console.info(`[lcyt-bridge] v${getVersion()} starting`);
+console.info(`[lcyt-bridge] Backend: ${config.backendUrl}`);
+
+const { Bridge } = await import('./bridge.js');
+const { createTray } = await import('./tray.js');
+
+const bridge = new Bridge(config);
+
+// System tray (optional — gracefully skipped if unavailable)
+createTray({
+  bridge,
+  onQuit() {
+    console.info('[lcyt-bridge] Quit requested from tray');
+    bridge.destroy();
+    process.exit(0);
+  },
+});
+
+// Start the bridge
+bridge.start();
+bridge.startHeartbeat(30_000);
+
+// Graceful shutdown on Ctrl+C / SIGTERM
+function shutdown() {
+  console.info('[lcyt-bridge] Shutting down…');
+  bridge.destroy();
+  process.exit(0);
+}
+process.on('SIGINT',  shutdown);
+process.on('SIGTERM', shutdown);
+
+console.info('[lcyt-bridge] Running. Press Ctrl+C to quit.');
+
+// ---------------------------------------------------------------------------
+
+function getVersion() {
+  try {
+    const __dir = dirname(fileURLToPath(import.meta.url));
+    const pkg   = JSON.parse(readFileSync(join(__dir, '..', 'package.json'), 'utf8'));
+    return pkg.version ?? '?';
+  } catch {
+    return '?';
+  }
+}

--- a/packages/lcyt-bridge/src/tcp-pool.js
+++ b/packages/lcyt-bridge/src/tcp-pool.js
@@ -1,0 +1,119 @@
+/**
+ * TCP connection pool.
+ * Maintains persistent connections keyed by "host:port".
+ * On close or error, schedules a reconnect automatically.
+ */
+
+import { createConnection } from 'node:net';
+import { EventEmitter } from 'node:events';
+
+const RECONNECT_DELAY_MS = 5_000;
+const KEEPALIVE_INTERVAL_MS = 30_000;
+
+export class TcpPool extends EventEmitter {
+  constructor() {
+    super();
+    /** @type {Map<string, { socket: import('net').Socket, connected: boolean, destroyed: boolean, timer: NodeJS.Timeout|null }>} */
+    this._pool = new Map();
+  }
+
+  /**
+   * Ensure a connection to host:port exists (idempotent).
+   * @param {string} host
+   * @param {number} port
+   */
+  ensure(host, port) {
+    const key = `${host}:${port}`;
+    if (this._pool.has(key)) return;
+    this._open(host, port);
+  }
+
+  /**
+   * Send data to host:port. Creates a connection if none exists.
+   * @param {string} host
+   * @param {number} port
+   * @param {string} payload
+   * @returns {Promise<void>}
+   */
+  async send(host, port, payload) {
+    const key = `${host}:${port}`;
+    let entry = this._pool.get(key);
+    if (!entry) {
+      this._open(host, port);
+      entry = this._pool.get(key);
+    }
+    if (!entry.connected || !entry.socket) {
+      throw new Error(`TCP ${key} is not connected`);
+    }
+    return new Promise((resolve, reject) => {
+      entry.socket.write(payload, 'utf8', (err) => {
+        if (err) return reject(new Error(`TCP write to ${key} failed: ${err.message}`));
+        resolve();
+      });
+    });
+  }
+
+  /**
+   * Return status of all connections.
+   * @returns {Array<{ key: string, connected: boolean }>}
+   */
+  status() {
+    return [...this._pool.entries()].map(([key, e]) => ({ key, connected: e.connected }));
+  }
+
+  /**
+   * Reconnect all connections.
+   */
+  reconnectAll() {
+    for (const [key, entry] of this._pool.entries()) {
+      if (entry.timer) clearTimeout(entry.timer);
+      try { entry.socket?.destroy(); } catch { /* ignore */ }
+      const [host, port] = key.split(':');
+      this._open(host, Number(port));
+    }
+  }
+
+  /** Cleanly destroy all connections. */
+  destroy() {
+    for (const entry of this._pool.values()) {
+      entry.destroyed = true;
+      if (entry.timer) clearTimeout(entry.timer);
+      try { entry.socket?.destroy(); } catch { /* ignore */ }
+    }
+    this._pool.clear();
+  }
+
+  // ---------------------------------------------------------------------------
+
+  _open(host, port) {
+    const key = `${host}:${port}`;
+    const entry = { socket: null, connected: false, destroyed: false, timer: null };
+    this._pool.set(key, entry);
+
+    const socket = createConnection({ host, port }, () => {
+      entry.connected = true;
+      socket.setKeepAlive(true, KEEPALIVE_INTERVAL_MS);
+      this.emit('connected', key);
+    });
+
+    socket.on('error', (err) => {
+      entry.connected = false;
+      this.emit('error', key, err);
+    });
+
+    socket.on('close', () => {
+      entry.connected = false;
+      entry.socket = null;
+      this.emit('disconnected', key);
+      if (!entry.destroyed) {
+        entry.timer = setTimeout(() => {
+          entry.timer = null;
+          this._pool.delete(key);
+          this._open(host, port);
+        }, RECONNECT_DELAY_MS);
+      }
+    });
+
+    entry.socket = socket;
+  }
+}

--- a/packages/lcyt-bridge/src/tray.js
+++ b/packages/lcyt-bridge/src/tray.js
@@ -1,0 +1,105 @@
+/**
+ * System tray integration for lcyt-bridge (Windows / macOS).
+ * Uses node-systray. If it fails to load (e.g. headless Linux CI),
+ * the bridge runs in console-only mode without crashing.
+ *
+ * Menu layout:
+ *   Backend: Connected / Disconnected
+ *   TCP: <n> connection(s)
+ *   ─────────────────────
+ *   Reconnect All
+ *   ─────────────────────
+ *   Quit
+ */
+
+const ICON_CONNECTED    = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='; // 1×1 green placeholder
+const ICON_DISCONNECTED = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwADhQGAWjR9awAAAABJRU5ErkJggg=='; // 1×1 grey placeholder
+
+let SysTray;
+try {
+  const mod = await import('node-systray');
+  SysTray = mod.default ?? mod.SysTray;
+} catch {
+  // node-systray not available (headless, pkg issue, etc.) — skip tray
+}
+
+const IDX_STATUS_SSE = 0;
+const IDX_STATUS_TCP = 1;
+const IDX_RECONNECT  = 3;
+const IDX_QUIT       = 5;
+
+export function createTray({ bridge, onQuit }) {
+  if (!SysTray) {
+    console.info('[lcyt-bridge] System tray not available — running in console mode.');
+    // Still wire up status logging
+    _wireConsoleLog(bridge);
+    return { update: () => {} };
+  }
+
+  const tray = new SysTray({
+    menu: {
+      icon:    ICON_DISCONNECTED,
+      title:   '',
+      tooltip: 'lcyt-bridge',
+      items: [
+        { title: 'Backend: Connecting…', tooltip: '', checked: false, enabled: false },
+        { title: 'TCP: 0 connections',   tooltip: '', checked: false, enabled: false },
+        SysTray.separator,
+        { title: 'Reconnect All', tooltip: 'Reconnect SSE and all TCP connections', checked: false, enabled: true },
+        SysTray.separator,
+        { title: 'Quit',          tooltip: '', checked: false, enabled: true },
+      ],
+    },
+    debug: false,
+    copyDir: false,
+  });
+
+  tray.onClick((action) => {
+    if (action.seq_id === IDX_RECONNECT) bridge.reconnectAll();
+    if (action.seq_id === IDX_QUIT)      onQuit();
+  });
+
+  function update(sseConnected, tcpStatus) {
+    const tcpCount     = tcpStatus.length;
+    const tcpConnected = tcpStatus.filter(t => t.connected).length;
+    const healthy      = sseConnected && tcpConnected === tcpCount;
+
+    tray.sendAction({
+      type: 'update-item',
+      item: { title: `Backend: ${sseConnected ? '✓ Connected' : '✗ Disconnected'}`, seq_id: IDX_STATUS_SSE },
+    });
+    tray.sendAction({
+      type: 'update-item',
+      item: { title: `TCP: ${tcpConnected}/${tcpCount} connected`, seq_id: IDX_STATUS_TCP },
+    });
+    tray.sendAction({
+      type: 'update-menu',
+      menu: { icon: healthy ? ICON_CONNECTED : ICON_DISCONNECTED },
+    });
+  }
+
+  _wireBridgeEvents(bridge, update);
+  return { update };
+}
+
+function _wireBridgeEvents(bridge, update) {
+  let sseConnected = false;
+
+  bridge.on('connected',    ()      => { sseConnected = true;  update(sseConnected, bridge.status().tcp); });
+  bridge.on('disconnected', ()      => { sseConnected = false; update(sseConnected, bridge.status().tcp); });
+  bridge.on('tcp:connected',    () => update(sseConnected, bridge.status().tcp));
+  bridge.on('tcp:disconnected', () => update(sseConnected, bridge.status().tcp));
+}
+
+function _wireConsoleLog(bridge) {
+  bridge.on('connecting',    (url)      => console.info(`[bridge] Connecting to ${url}`));
+  bridge.on('connected',     ()         => console.info('[bridge] SSE connected'));
+  bridge.on('disconnected',  ()         => console.warn('[bridge] SSE disconnected'));
+  bridge.on('reconnecting',  (ms)       => console.info(`[bridge] Reconnecting in ${ms}ms`));
+  bridge.on('tcp:connected', (key)      => console.info(`[bridge] TCP connected: ${key}`));
+  bridge.on('tcp:disconnected', (key)   => console.warn(`[bridge] TCP disconnected: ${key}`));
+  bridge.on('tcp:error',     (key, err) => console.error(`[bridge] TCP error ${key}: ${err.message}`));
+  bridge.on('command:ok',    ({ host, port }) => console.info(`[bridge] Command OK → ${host}:${port}`));
+  bridge.on('command:error', ({ host, port, error }) => console.error(`[bridge] Command FAIL → ${host}:${port}: ${error}`));
+  bridge.on('error',         (err)      => console.error(`[bridge] Error: ${err.message}`));
+}

--- a/packages/lcyt-web/src/components/ProductionBridgesPage.jsx
+++ b/packages/lcyt-web/src/components/ProductionBridgesPage.jsx
@@ -65,7 +65,17 @@ function AddBridgeForm({ onCreated, onCancel, backendUrl, headers }) {
   );
 }
 
-/** Shown immediately after creation — displays the .env download button */
+const BRIDGE_DOWNLOADS = [
+  { label: 'Windows (.exe)', file: 'lcyt-bridge.exe' },
+  { label: 'macOS',          file: 'lcyt-bridge-mac' },
+  { label: 'Linux',          file: 'lcyt-bridge-linux' },
+];
+
+function bridgeDownloadUrl(file) {
+  return `${window.location.origin}/bridge-downloads/${file}`;
+}
+
+/** Shown immediately after creation — displays exe + .env download buttons */
 function EnvDownloadBanner({ bridge, onDismiss }) {
   function downloadEnv() {
     const blob = new Blob([bridge.envContent], { type: 'text/plain' });
@@ -86,15 +96,20 @@ function EnvDownloadBanner({ bridge, onDismiss }) {
       marginBottom: 16,
     }}>
       <p style={{ margin: '0 0 10px', fontSize: 14 }}>
-        <strong>{bridge.name}</strong> created. Download the configuration file and place it
-        next to <code>lcyt-bridge.exe</code>.
+        <strong>{bridge.name}</strong> created. Download the app and its configuration file,
+        place them in the same folder, then launch the app.
       </p>
       <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+        {BRIDGE_DOWNLOADS.map(({ label, file }) => (
+          <a key={file} className="btn btn--ghost btn--sm" href={bridgeDownloadUrl(file)} download={file}>
+            ↓ {label}
+          </a>
+        ))}
         <button className="btn btn--primary btn--sm" onClick={downloadEnv}>
-          ↓ Download .env
+          ↓ Config (.env)
         </button>
-        <span style={{ fontSize: 12, color: 'var(--color-text-muted)' }}>
-          The token is only available in this file — keep it private.
+        <span style={{ fontSize: 12, color: 'var(--color-text-muted)', marginLeft: 4 }}>
+          Keep .env private — it contains your bridge token.
         </span>
         <button className="btn btn--ghost btn--sm" style={{ marginLeft: 'auto' }} onClick={onDismiss}>
           Dismiss
@@ -281,12 +296,19 @@ export function ProductionBridgesPage() {
       {loading ? (
         <p style={{ color: 'var(--color-text-muted)' }}>Loading…</p>
       ) : bridges.length === 0 ? (
-        <div style={{ color: 'var(--color-text-muted)', fontSize: 14 }}>
-          <p>No bridges configured.</p>
-          <p style={{ fontSize: 13 }}>
+        <div style={{ fontSize: 14 }}>
+          <p style={{ color: 'var(--color-text-muted)' }}>No bridges configured.</p>
+          <p style={{ fontSize: 13, color: 'var(--color-text-muted)' }}>
             A bridge is a small program that runs on your streaming computer and relays
             commands to AMX and Roland hardware on the local AV network.
           </p>
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginTop: 4 }}>
+            {BRIDGE_DOWNLOADS.map(({ label, file }) => (
+              <a key={file} className="btn btn--ghost btn--sm" href={bridgeDownloadUrl(file)} download={file}>
+                ↓ {label}
+              </a>
+            ))}
+          </div>
         </div>
       ) : (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>

--- a/packages/lcyt-web/src/components/ProductionBridgesPage.jsx
+++ b/packages/lcyt-web/src/components/ProductionBridgesPage.jsx
@@ -1,0 +1,316 @@
+import { useState, useEffect, useCallback } from 'react';
+
+function ConnectionDot({ connected }) {
+  return (
+    <span
+      title={connected ? 'Connected' : 'Disconnected'}
+      style={{
+        display: 'inline-block',
+        width: 8, height: 8, borderRadius: '50%', flexShrink: 0,
+        background: connected ? 'var(--color-success)' : 'var(--color-text-muted)',
+        boxShadow: connected ? '0 0 5px var(--color-success)' : 'none',
+      }}
+    />
+  );
+}
+
+function AddBridgeForm({ onCreated, onCancel, backendUrl, headers }) {
+  const [name, setName] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+
+  async function handleCreate() {
+    if (!name.trim()) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const r = await fetch(`${backendUrl}/production/bridge/instances`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ name: name.trim() }),
+      });
+      const data = await r.json();
+      if (!r.ok) throw new Error(data.error || `HTTP ${r.status}`);
+      onCreated(data); // { id, name, envContent }
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div className="settings-field">
+        <label className="settings-field__label">Bridge name *</label>
+        <input
+          className="settings-field__input"
+          value={name}
+          onChange={e => setName(e.target.value)}
+          placeholder="e.g. Main church"
+          autoFocus
+          onKeyDown={e => e.key === 'Enter' && handleCreate()}
+        />
+      </div>
+      {error && <div style={{ color: 'var(--color-error)', fontSize: 13 }}>{error}</div>}
+      <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+        <button className="btn btn--ghost" onClick={onCancel}>Cancel</button>
+        <button
+          className="btn btn--primary"
+          onClick={handleCreate}
+          disabled={!name.trim() || saving}
+        >{saving ? 'Creating…' : 'Create'}</button>
+      </div>
+    </div>
+  );
+}
+
+/** Shown immediately after creation — displays the .env download button */
+function EnvDownloadBanner({ bridge, onDismiss }) {
+  function downloadEnv() {
+    const blob = new Blob([bridge.envContent], { type: 'text/plain' });
+    const url  = URL.createObjectURL(blob);
+    const a    = document.createElement('a');
+    a.href     = url;
+    a.download = `lcyt-bridge-${bridge.name.replace(/\s+/g, '-')}.env`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  return (
+    <div style={{
+      border: '1px solid var(--color-success)',
+      borderRadius: 6,
+      padding: 16,
+      background: 'var(--color-success-bg, rgba(16,185,129,0.08))',
+      marginBottom: 16,
+    }}>
+      <p style={{ margin: '0 0 10px', fontSize: 14 }}>
+        <strong>{bridge.name}</strong> created. Download the configuration file and place it
+        next to <code>lcyt-bridge.exe</code>.
+      </p>
+      <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+        <button className="btn btn--primary btn--sm" onClick={downloadEnv}>
+          ↓ Download .env
+        </button>
+        <span style={{ fontSize: 12, color: 'var(--color-text-muted)' }}>
+          The token is only available in this file — keep it private.
+        </span>
+        <button className="btn btn--ghost btn--sm" style={{ marginLeft: 'auto' }} onClick={onDismiss}>
+          Dismiss
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function BridgeRow({ bridge, showName, onDelete, onRedownload }) {
+  const lastSeen = bridge.lastSeen
+    ? new Date(bridge.lastSeen + 'Z').toLocaleString()
+    : 'Never';
+
+  return (
+    <div style={{
+      display: 'flex',
+      alignItems: 'center',
+      gap: 10,
+      padding: '8px 10px',
+      border: '1px solid var(--color-border)',
+      borderRadius: 4,
+    }}>
+      <ConnectionDot connected={bridge.status === 'connected'} />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        {showName && <span style={{ fontWeight: 600, marginRight: 8 }}>{bridge.name}</span>}
+        <span style={{ fontSize: 12, color: 'var(--color-text-muted)' }}>
+          {bridge.status === 'connected' ? 'Connected' : `Last seen: ${lastSeen}`}
+        </span>
+      </div>
+      <button
+        className="btn btn--sm btn--ghost"
+        onClick={() => onRedownload(bridge)}
+        title="Re-download .env"
+      >↓ .env</button>
+      <button
+        className="btn btn--sm btn--ghost btn--danger"
+        onClick={() => onDelete(bridge)}
+      >Delete</button>
+    </div>
+  );
+}
+
+function DeleteConfirmModal({ bridge, cameras, mixers, onConfirm, onCancel }) {
+  const hasAssignments = cameras > 0 || mixers > 0;
+  return (
+    <div style={{
+      position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)',
+      display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000,
+    }}>
+      <div style={{
+        background: 'var(--color-surface)', borderRadius: 8, padding: 24,
+        maxWidth: 400, width: '90%',
+      }}>
+        <p style={{ margin: '0 0 8px', fontWeight: 600 }}>
+          Delete bridge{bridge.name ? ` "${bridge.name}"` : ''}?
+        </p>
+        {hasAssignments && (
+          <p style={{ margin: '0 0 16px', fontSize: 13, color: 'var(--color-text-muted)' }}>
+            {cameras > 0 && <>{cameras} camera{cameras !== 1 ? 's' : ''}</>}
+            {cameras > 0 && mixers > 0 && ' and '}
+            {mixers  > 0 && <>{mixers} mixer{mixers !== 1 ? 's' : ''}</>}
+            {' '}will lose their bridge assignment.
+          </p>
+        )}
+        <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+          <button className="btn btn--ghost" onClick={onCancel}>Cancel</button>
+          <button className="btn btn--danger" onClick={onConfirm}>Delete</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ProductionBridgesPage() {
+  const params = new URLSearchParams(window.location.search);
+  const backendUrl = params.get('server') || localStorage.getItem('lcyt-backend-url') || '';
+  const apiKey     = params.get('apikey') || '';
+
+  const [bridges, setBridges] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [adding, setAdding] = useState(false);
+  const [newBridge, setNewBridge] = useState(null);     // { id, name, envContent } shown after create
+  const [confirmDelete, setConfirmDelete] = useState(null); // { bridge, cameras, mixers }
+
+  const headers = { 'Content-Type': 'application/json', ...(apiKey ? { 'X-Admin-Key': apiKey } : {}) };
+
+  const fetchBridges = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const r = await fetch(`${backendUrl}/production/bridge/instances`, { headers });
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      setBridges(await r.json());
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [backendUrl, apiKey]);
+
+  useEffect(() => { fetchBridges(); }, [fetchBridges]);
+
+  async function handleCreated(data) {
+    setAdding(false);
+    setNewBridge(data);
+    fetchBridges();
+  }
+
+  async function confirmDeleteBridge(bridge) {
+    // Count assigned cameras/mixers
+    try {
+      const r = await fetch(
+        `${backendUrl}/production/bridge/instances/${bridge.id}`,
+        { method: 'DELETE', headers }
+      );
+      if (r.status === 409) {
+        const body = await r.json();
+        setConfirmDelete({ bridge, cameras: body.cameras, mixers: body.mixers });
+        return;
+      }
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      fetchBridges();
+    } catch (e) {
+      setError(e.message);
+    }
+  }
+
+  async function forceDelete(bridge) {
+    try {
+      const r = await fetch(
+        `${backendUrl}/production/bridge/instances/${bridge.id}?force=1`,
+        { method: 'DELETE', headers }
+      );
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      setConfirmDelete(null);
+      fetchBridges();
+    } catch (e) {
+      setError(e.message);
+    }
+  }
+
+  function handleRedownload(bridge) {
+    window.open(`${backendUrl}/production/bridge/instances/${bridge.id}/env`, '_blank');
+  }
+
+  const showNames = bridges.length >= 2;
+
+  return (
+    <div style={{ padding: 20, maxWidth: 700, margin: '0 auto' }}>
+      <div style={{ display: 'flex', alignItems: 'center', marginBottom: 16, gap: 12 }}>
+        <h2 style={{ margin: 0, fontSize: 18 }}>Bridges</h2>
+        {!adding && (
+          <button className="btn btn--primary btn--sm" onClick={() => setAdding(true)}>
+            + Add bridge
+          </button>
+        )}
+      </div>
+
+      {error && (
+        <div style={{ color: 'var(--color-error)', marginBottom: 12, fontSize: 13 }}>{error}</div>
+      )}
+
+      {newBridge && (
+        <EnvDownloadBanner bridge={newBridge} onDismiss={() => setNewBridge(null)} />
+      )}
+
+      {adding && (
+        <div style={{
+          border: '1px solid var(--color-border)', borderRadius: 6,
+          padding: 16, marginBottom: 16, background: 'var(--color-surface-alt)',
+        }}>
+          <h3 style={{ margin: '0 0 12px', fontSize: 15 }}>Add bridge</h3>
+          <AddBridgeForm
+            onCreated={handleCreated}
+            onCancel={() => setAdding(false)}
+            backendUrl={backendUrl}
+            headers={headers}
+          />
+        </div>
+      )}
+
+      {loading ? (
+        <p style={{ color: 'var(--color-text-muted)' }}>Loading…</p>
+      ) : bridges.length === 0 ? (
+        <div style={{ color: 'var(--color-text-muted)', fontSize: 14 }}>
+          <p>No bridges configured.</p>
+          <p style={{ fontSize: 13 }}>
+            A bridge is a small program that runs on your streaming computer and relays
+            commands to AMX and Roland hardware on the local AV network.
+          </p>
+        </div>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          {bridges.map(b => (
+            <BridgeRow
+              key={b.id}
+              bridge={b}
+              showName={showNames}
+              onDelete={confirmDeleteBridge}
+              onRedownload={handleRedownload}
+            />
+          ))}
+        </div>
+      )}
+
+      {confirmDelete && (
+        <DeleteConfirmModal
+          bridge={confirmDelete.bridge}
+          cameras={confirmDelete.cameras}
+          mixers={confirmDelete.mixers}
+          onConfirm={() => forceDelete(confirmDelete.bridge)}
+          onCancel={() => setConfirmDelete(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/lcyt-web/src/components/ProductionCamerasPage.jsx
+++ b/packages/lcyt-web/src/components/ProductionCamerasPage.jsx
@@ -24,26 +24,24 @@ function PresetRow({ preset, onChange, onRemove }) {
         onChange={e => onChange({ ...preset, command: e.target.value })}
         style={{ flex: 1, fontFamily: 'monospace', fontSize: 12 }}
       />
-      <button
-        className="btn btn--sm btn--ghost"
-        onClick={onRemove}
-        title="Remove preset"
-        style={{ flexShrink: 0 }}
-      >✕</button>
+      <button className="btn btn--sm btn--ghost" onClick={onRemove} title="Remove preset" style={{ flexShrink: 0 }}>
+        ✕
+      </button>
     </div>
   );
 }
 
-function CameraForm({ initial, onSave, onCancel }) {
-  const [name, setName] = useState(initial?.name ?? '');
-  const [mixerInput, setMixerInput] = useState(initial?.mixerInput ?? '');
-  const [controlType, setControlType] = useState(initial?.controlType ?? 'none');
-  const [host, setHost] = useState(initial?.controlConfig?.host ?? '');
-  const [port, setPort] = useState(initial?.controlConfig?.port ?? 1319);
-  const [presets, setPresets] = useState(
+function CameraForm({ initial, bridges, onSave, onCancel }) {
+  const [name,             setName]             = useState(initial?.name ?? '');
+  const [mixerInput,       setMixerInput]       = useState(initial?.mixerInput ?? '');
+  const [controlType,      setControlType]      = useState(initial?.controlType ?? 'none');
+  const [host,             setHost]             = useState(initial?.controlConfig?.host ?? '');
+  const [port,             setPort]             = useState(initial?.controlConfig?.port ?? 1319);
+  const [presets,          setPresets]          = useState(
     initial?.controlConfig?.presets?.map(p => ({ ...p, id: p.id || crypto.randomUUID() })) ?? []
   );
-  const [sortOrder, setSortOrder] = useState(initial?.sortOrder ?? 0);
+  const [sortOrder,        setSortOrder]        = useState(initial?.sortOrder ?? 0);
+  const [bridgeInstanceId, setBridgeInstanceId] = useState(initial?.bridgeInstanceId ?? '');
 
   function buildControlConfig() {
     if (controlType === 'amx') {
@@ -60,62 +58,38 @@ function CameraForm({ initial, onSave, onCancel }) {
       controlType,
       controlConfig: buildControlConfig(),
       sortOrder: Number(sortOrder),
+      bridgeInstanceId: bridgeInstanceId || null,
     });
   }
 
-  function updatePreset(idx, updated) {
-    setPresets(prev => prev.map((p, i) => i === idx ? updated : p));
-  }
-  function removePreset(idx) {
-    setPresets(prev => prev.filter((_, i) => i !== idx));
-  }
+  function updatePreset(idx, updated) { setPresets(prev => prev.map((p, i) => i === idx ? updated : p)); }
+  function removePreset(idx)          { setPresets(prev => prev.filter((_, i) => i !== idx)); }
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
       <div className="settings-field">
         <label className="settings-field__label">Camera name *</label>
-        <input
-          className="settings-field__input"
-          value={name}
-          onChange={e => setName(e.target.value)}
-          placeholder="e.g. Altar"
-          autoFocus
-        />
+        <input className="settings-field__input" value={name} onChange={e => setName(e.target.value)}
+          placeholder="e.g. Altar" autoFocus />
       </div>
 
       <div style={{ display: 'flex', gap: 12 }}>
         <div className="settings-field" style={{ flex: 1 }}>
           <label className="settings-field__label">Mixer input #</label>
-          <input
-            className="settings-field__input"
-            type="number"
-            min={1}
-            value={mixerInput}
-            onChange={e => setMixerInput(e.target.value)}
-            placeholder="e.g. 1"
-          />
+          <input className="settings-field__input" type="number" min={1}
+            value={mixerInput} onChange={e => setMixerInput(e.target.value)} placeholder="e.g. 1" />
         </div>
         <div className="settings-field" style={{ flex: 1 }}>
           <label className="settings-field__label">Sort order</label>
-          <input
-            className="settings-field__input"
-            type="number"
-            value={sortOrder}
-            onChange={e => setSortOrder(e.target.value)}
-          />
+          <input className="settings-field__input" type="number"
+            value={sortOrder} onChange={e => setSortOrder(e.target.value)} />
         </div>
       </div>
 
       <div className="settings-field">
         <label className="settings-field__label">Control type</label>
-        <select
-          className="settings-field__input"
-          value={controlType}
-          onChange={e => setControlType(e.target.value)}
-        >
-          {CONTROL_TYPES.map(ct => (
-            <option key={ct.value} value={ct.value}>{ct.label}</option>
-          ))}
+        <select className="settings-field__input" value={controlType} onChange={e => setControlType(e.target.value)}>
+          {CONTROL_TYPES.map(ct => <option key={ct.value} value={ct.value}>{ct.label}</option>)}
         </select>
       </div>
 
@@ -124,33 +98,23 @@ function CameraForm({ initial, onSave, onCancel }) {
           <div style={{ display: 'flex', gap: 12 }}>
             <div className="settings-field" style={{ flex: 2 }}>
               <label className="settings-field__label">AMX host (IP)</label>
-              <input
-                className="settings-field__input"
-                value={host}
-                onChange={e => setHost(e.target.value)}
-                placeholder="192.168.2.50"
-              />
+              <input className="settings-field__input" value={host} onChange={e => setHost(e.target.value)}
+                placeholder="192.168.2.50" />
             </div>
             <div className="settings-field" style={{ flex: 1 }}>
               <label className="settings-field__label">TCP port</label>
-              <input
-                className="settings-field__input"
-                type="number"
-                value={port}
-                onChange={e => setPort(e.target.value)}
-                placeholder="1319"
-              />
+              <input className="settings-field__input" type="number" value={port}
+                onChange={e => setPort(e.target.value)} placeholder="1319" />
             </div>
           </div>
 
           <div className="settings-field">
             <label className="settings-field__label">
               Presets
-              <button
-                className="btn btn--sm btn--ghost"
-                style={{ marginLeft: 8 }}
-                onClick={() => setPresets(prev => [...prev, EMPTY_PRESET()])}
-              >+ Add preset</button>
+              <button className="btn btn--sm btn--ghost" style={{ marginLeft: 8 }}
+                onClick={() => setPresets(prev => [...prev, EMPTY_PRESET()])}>
+                + Add preset
+              </button>
             </label>
             {presets.length === 0 && (
               <p style={{ color: 'var(--color-text-muted)', fontSize: 12, margin: '4px 0' }}>
@@ -158,41 +122,54 @@ function CameraForm({ initial, onSave, onCancel }) {
               </p>
             )}
             {presets.map((p, i) => (
-              <PresetRow
-                key={p.id}
-                preset={p}
+              <PresetRow key={p.id} preset={p}
                 onChange={updated => updatePreset(i, updated)}
-                onRemove={() => removePreset(i)}
-              />
+                onRemove={() => removePreset(i)} />
             ))}
           </div>
         </>
       )}
 
+      {/* Bridge selector — only shown when bridges exist */}
+      {bridges.length > 0 && (
+        <div className="settings-field">
+          <label className="settings-field__label">
+            Bridge{bridges.length >= 2 ? ' instance' : ''}
+            <span style={{ fontSize: 11, color: 'var(--color-text-muted)', marginLeft: 6, fontWeight: 400 }}>
+              (required for hardware on isolated AV network)
+            </span>
+          </label>
+          <select className="settings-field__input" value={bridgeInstanceId}
+            onChange={e => setBridgeInstanceId(e.target.value)}>
+            <option value="">None (direct TCP from backend)</option>
+            {bridges.map(b => (
+              <option key={b.id} value={b.id}>
+                {bridges.length >= 2 ? b.name : 'Use bridge'}
+                {b.status === 'connected' ? ' ●' : ' ○'}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
       <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 4 }}>
         <button className="btn btn--ghost" onClick={onCancel}>Cancel</button>
-        <button
-          className="btn btn--primary"
-          onClick={handleSave}
-          disabled={!name.trim()}
-        >Save</button>
+        <button className="btn btn--primary" onClick={handleSave} disabled={!name.trim()}>Save</button>
       </div>
     </div>
   );
 }
 
-function CameraRow({ camera, onEdit, onDelete }) {
+function CameraRow({ camera, bridges, onEdit, onDelete }) {
   const presetCount = camera.controlConfig?.presets?.length ?? 0;
-  const typeBadge = CONTROL_TYPES.find(ct => ct.value === camera.controlType)?.label ?? camera.controlType;
+  const typeBadge   = CONTROL_TYPES.find(ct => ct.value === camera.controlType)?.label ?? camera.controlType;
+  // Progressive disclosure: show bridge name only when 2+ bridges exist
+  const bridge      = bridges.length >= 2 ? bridges.find(b => b.id === camera.bridgeInstanceId) : null;
 
   return (
     <div style={{
-      display: 'flex',
-      alignItems: 'center',
-      gap: 10,
-      padding: '8px 10px',
-      border: '1px solid var(--color-border)',
-      borderRadius: 4,
+      display: 'flex', alignItems: 'center', gap: 10, padding: '8px 10px',
+      border: '1px solid var(--color-border)', borderRadius: 4,
     }}>
       <div style={{ flex: 1, minWidth: 0 }}>
         <span style={{ fontWeight: 600 }}>{camera.name}</span>
@@ -201,14 +178,15 @@ function CameraRow({ camera, onEdit, onDelete }) {
             Input {camera.mixerInput}
           </span>
         )}
+        {bridge && (
+          <span style={{ marginLeft: 8, fontSize: 11, color: 'var(--color-text-muted)' }}>
+            via {bridge.name}
+          </span>
+        )}
       </div>
       <span style={{
-        fontSize: 11,
-        padding: '2px 6px',
-        borderRadius: 3,
-        background: 'var(--color-surface-alt)',
-        color: 'var(--color-text-muted)',
-        whiteSpace: 'nowrap',
+        fontSize: 11, padding: '2px 6px', borderRadius: 3,
+        background: 'var(--color-surface-alt)', color: 'var(--color-text-muted)', whiteSpace: 'nowrap',
       }}>{typeBadge}</span>
       {camera.controlType !== 'none' && (
         <span style={{ fontSize: 11, color: 'var(--color-text-muted)', whiteSpace: 'nowrap' }}>
@@ -222,25 +200,31 @@ function CameraRow({ camera, onEdit, onDelete }) {
 }
 
 export function ProductionCamerasPage() {
-  const params = new URLSearchParams(window.location.search);
+  const params     = new URLSearchParams(window.location.search);
   const backendUrl = params.get('server') || localStorage.getItem('lcyt-backend-url') || '';
-  const apiKey = params.get('apikey') || '';
+  const apiKey     = params.get('apikey') || '';
 
-  const [cameras, setCameras] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-  const [editing, setEditing] = useState(null);   // null | 'new' | camera object
+  const [cameras,       setCameras]       = useState([]);
+  const [bridges,       setBridges]       = useState([]);
+  const [loading,       setLoading]       = useState(true);
+  const [error,         setError]         = useState(null);
+  const [editing,       setEditing]       = useState(null);
   const [confirmDelete, setConfirmDelete] = useState(null);
 
   const headers = { 'Content-Type': 'application/json', ...(apiKey ? { 'X-Admin-Key': apiKey } : {}) };
 
-  const fetchCameras = useCallback(async () => {
+  const fetchAll = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      const r = await fetch(`${backendUrl}/production/cameras`, { headers });
-      if (!r.ok) throw new Error(`HTTP ${r.status}`);
-      setCameras(await r.json());
+      const [camRes, bridgeRes] = await Promise.all([
+        fetch(`${backendUrl}/production/cameras`, { headers }),
+        fetch(`${backendUrl}/production/bridge/instances`, { headers }),
+      ]);
+      if (!camRes.ok)    throw new Error(`cameras: HTTP ${camRes.status}`);
+      if (!bridgeRes.ok) throw new Error(`bridges: HTTP ${bridgeRes.status}`);
+      setCameras(await camRes.json());
+      setBridges(await bridgeRes.json());
     } catch (e) {
       setError(e.message);
     } finally {
@@ -248,22 +232,18 @@ export function ProductionCamerasPage() {
     }
   }, [backendUrl, apiKey]);
 
-  useEffect(() => { fetchCameras(); }, [fetchCameras]);
+  useEffect(() => { fetchAll(); }, [fetchAll]);
 
   async function handleSave(data) {
     const isNew = editing === 'new';
-    const url = isNew
+    const url   = isNew
       ? `${backendUrl}/production/cameras`
       : `${backendUrl}/production/cameras/${editing.id}`;
     try {
-      const r = await fetch(url, {
-        method: isNew ? 'POST' : 'PUT',
-        headers,
-        body: JSON.stringify(data),
-      });
+      const r = await fetch(url, { method: isNew ? 'POST' : 'PUT', headers, body: JSON.stringify(data) });
       if (!r.ok) throw new Error(`HTTP ${r.status}`);
       setEditing(null);
-      fetchCameras();
+      fetchAll();
     } catch (e) {
       setError(e.message);
     }
@@ -271,13 +251,10 @@ export function ProductionCamerasPage() {
 
   async function handleDelete(camera) {
     try {
-      const r = await fetch(`${backendUrl}/production/cameras/${camera.id}`, {
-        method: 'DELETE',
-        headers,
-      });
+      const r = await fetch(`${backendUrl}/production/cameras/${camera.id}`, { method: 'DELETE', headers });
       if (!r.ok) throw new Error(`HTTP ${r.status}`);
       setConfirmDelete(null);
-      fetchCameras();
+      fetchAll();
     } catch (e) {
       setError(e.message);
     }
@@ -287,30 +264,24 @@ export function ProductionCamerasPage() {
     <div style={{ padding: 20, maxWidth: 700, margin: '0 auto' }}>
       <div style={{ display: 'flex', alignItems: 'center', marginBottom: 16, gap: 12 }}>
         <h2 style={{ margin: 0, fontSize: 18 }}>Cameras</h2>
-        <button
-          className="btn btn--primary btn--sm"
-          onClick={() => setEditing('new')}
-          disabled={!!editing}
-        >+ Add camera</button>
+        <button className="btn btn--primary btn--sm" onClick={() => setEditing('new')} disabled={!!editing}>
+          + Add camera
+        </button>
       </div>
 
-      {error && (
-        <div style={{ color: 'var(--color-error)', marginBottom: 12, fontSize: 13 }}>{error}</div>
-      )}
+      {error && <div style={{ color: 'var(--color-error)', marginBottom: 12, fontSize: 13 }}>{error}</div>}
 
       {editing && (
         <div style={{
-          border: '1px solid var(--color-border)',
-          borderRadius: 6,
-          padding: 16,
-          marginBottom: 16,
-          background: 'var(--color-surface-alt)',
+          border: '1px solid var(--color-border)', borderRadius: 6, padding: 16,
+          marginBottom: 16, background: 'var(--color-surface-alt)',
         }}>
           <h3 style={{ margin: '0 0 12px', fontSize: 15 }}>
             {editing === 'new' ? 'Add camera' : `Edit: ${editing.name}`}
           </h3>
           <CameraForm
             initial={editing === 'new' ? null : editing}
+            bridges={bridges}
             onSave={handleSave}
             onCancel={() => setEditing(null)}
           />
@@ -324,12 +295,8 @@ export function ProductionCamerasPage() {
       ) : (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
           {cameras.map(cam => (
-            <CameraRow
-              key={cam.id}
-              camera={cam}
-              onEdit={c => setEditing(c)}
-              onDelete={c => setConfirmDelete(c)}
-            />
+            <CameraRow key={cam.id} camera={cam} bridges={bridges}
+              onEdit={c => setEditing(c)} onDelete={c => setConfirmDelete(c)} />
           ))}
         </div>
       )}
@@ -339,13 +306,8 @@ export function ProductionCamerasPage() {
           position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)',
           display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000,
         }}>
-          <div style={{
-            background: 'var(--color-surface)', borderRadius: 8, padding: 24,
-            maxWidth: 360, width: '90%',
-          }}>
-            <p style={{ margin: '0 0 16px' }}>
-              Delete camera <strong>{confirmDelete.name}</strong>?
-            </p>
+          <div style={{ background: 'var(--color-surface)', borderRadius: 8, padding: 24, maxWidth: 360, width: '90%' }}>
+            <p style={{ margin: '0 0 16px' }}>Delete camera <strong>{confirmDelete.name}</strong>?</p>
             <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
               <button className="btn btn--ghost" onClick={() => setConfirmDelete(null)}>Cancel</button>
               <button className="btn btn--danger" onClick={() => handleDelete(confirmDelete)}>Delete</button>

--- a/packages/lcyt-web/src/components/ProductionCamerasPage.jsx
+++ b/packages/lcyt-web/src/components/ProductionCamerasPage.jsx
@@ -1,0 +1,358 @@
+import { useState, useEffect, useCallback } from 'react';
+
+const CONTROL_TYPES = [
+  { value: 'none', label: 'None (mixer only)' },
+  { value: 'amx',  label: 'AMX NetLinx' },
+];
+
+const EMPTY_PRESET = () => ({ id: crypto.randomUUID(), name: '', command: '' });
+
+function PresetRow({ preset, onChange, onRemove }) {
+  return (
+    <div style={{ display: 'flex', gap: 6, alignItems: 'center', marginBottom: 4 }}>
+      <input
+        className="settings-field__input"
+        placeholder="Preset name (e.g. Wide)"
+        value={preset.name}
+        onChange={e => onChange({ ...preset, name: e.target.value })}
+        style={{ width: 140 }}
+      />
+      <input
+        className="settings-field__input"
+        placeholder="AMX command (e.g. SEND_COMMAND dvCam,'PRESET-1')"
+        value={preset.command}
+        onChange={e => onChange({ ...preset, command: e.target.value })}
+        style={{ flex: 1, fontFamily: 'monospace', fontSize: 12 }}
+      />
+      <button
+        className="btn btn--sm btn--ghost"
+        onClick={onRemove}
+        title="Remove preset"
+        style={{ flexShrink: 0 }}
+      >✕</button>
+    </div>
+  );
+}
+
+function CameraForm({ initial, onSave, onCancel }) {
+  const [name, setName] = useState(initial?.name ?? '');
+  const [mixerInput, setMixerInput] = useState(initial?.mixerInput ?? '');
+  const [controlType, setControlType] = useState(initial?.controlType ?? 'none');
+  const [host, setHost] = useState(initial?.controlConfig?.host ?? '');
+  const [port, setPort] = useState(initial?.controlConfig?.port ?? 1319);
+  const [presets, setPresets] = useState(
+    initial?.controlConfig?.presets?.map(p => ({ ...p, id: p.id || crypto.randomUUID() })) ?? []
+  );
+  const [sortOrder, setSortOrder] = useState(initial?.sortOrder ?? 0);
+
+  function buildControlConfig() {
+    if (controlType === 'amx') {
+      return { host, port: Number(port), presets: presets.map(({ id, name, command }) => ({ id, name, command })) };
+    }
+    return {};
+  }
+
+  function handleSave() {
+    if (!name.trim()) return;
+    onSave({
+      name: name.trim(),
+      mixerInput: mixerInput !== '' ? Number(mixerInput) : null,
+      controlType,
+      controlConfig: buildControlConfig(),
+      sortOrder: Number(sortOrder),
+    });
+  }
+
+  function updatePreset(idx, updated) {
+    setPresets(prev => prev.map((p, i) => i === idx ? updated : p));
+  }
+  function removePreset(idx) {
+    setPresets(prev => prev.filter((_, i) => i !== idx));
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div className="settings-field">
+        <label className="settings-field__label">Camera name *</label>
+        <input
+          className="settings-field__input"
+          value={name}
+          onChange={e => setName(e.target.value)}
+          placeholder="e.g. Altar"
+          autoFocus
+        />
+      </div>
+
+      <div style={{ display: 'flex', gap: 12 }}>
+        <div className="settings-field" style={{ flex: 1 }}>
+          <label className="settings-field__label">Mixer input #</label>
+          <input
+            className="settings-field__input"
+            type="number"
+            min={1}
+            value={mixerInput}
+            onChange={e => setMixerInput(e.target.value)}
+            placeholder="e.g. 1"
+          />
+        </div>
+        <div className="settings-field" style={{ flex: 1 }}>
+          <label className="settings-field__label">Sort order</label>
+          <input
+            className="settings-field__input"
+            type="number"
+            value={sortOrder}
+            onChange={e => setSortOrder(e.target.value)}
+          />
+        </div>
+      </div>
+
+      <div className="settings-field">
+        <label className="settings-field__label">Control type</label>
+        <select
+          className="settings-field__input"
+          value={controlType}
+          onChange={e => setControlType(e.target.value)}
+        >
+          {CONTROL_TYPES.map(ct => (
+            <option key={ct.value} value={ct.value}>{ct.label}</option>
+          ))}
+        </select>
+      </div>
+
+      {controlType === 'amx' && (
+        <>
+          <div style={{ display: 'flex', gap: 12 }}>
+            <div className="settings-field" style={{ flex: 2 }}>
+              <label className="settings-field__label">AMX host (IP)</label>
+              <input
+                className="settings-field__input"
+                value={host}
+                onChange={e => setHost(e.target.value)}
+                placeholder="192.168.2.50"
+              />
+            </div>
+            <div className="settings-field" style={{ flex: 1 }}>
+              <label className="settings-field__label">TCP port</label>
+              <input
+                className="settings-field__input"
+                type="number"
+                value={port}
+                onChange={e => setPort(e.target.value)}
+                placeholder="1319"
+              />
+            </div>
+          </div>
+
+          <div className="settings-field">
+            <label className="settings-field__label">
+              Presets
+              <button
+                className="btn btn--sm btn--ghost"
+                style={{ marginLeft: 8 }}
+                onClick={() => setPresets(prev => [...prev, EMPTY_PRESET()])}
+              >+ Add preset</button>
+            </label>
+            {presets.length === 0 && (
+              <p style={{ color: 'var(--color-text-muted)', fontSize: 12, margin: '4px 0' }}>
+                No presets. Click "Add preset" to add one.
+              </p>
+            )}
+            {presets.map((p, i) => (
+              <PresetRow
+                key={p.id}
+                preset={p}
+                onChange={updated => updatePreset(i, updated)}
+                onRemove={() => removePreset(i)}
+              />
+            ))}
+          </div>
+        </>
+      )}
+
+      <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 4 }}>
+        <button className="btn btn--ghost" onClick={onCancel}>Cancel</button>
+        <button
+          className="btn btn--primary"
+          onClick={handleSave}
+          disabled={!name.trim()}
+        >Save</button>
+      </div>
+    </div>
+  );
+}
+
+function CameraRow({ camera, onEdit, onDelete }) {
+  const presetCount = camera.controlConfig?.presets?.length ?? 0;
+  const typeBadge = CONTROL_TYPES.find(ct => ct.value === camera.controlType)?.label ?? camera.controlType;
+
+  return (
+    <div style={{
+      display: 'flex',
+      alignItems: 'center',
+      gap: 10,
+      padding: '8px 10px',
+      border: '1px solid var(--color-border)',
+      borderRadius: 4,
+    }}>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <span style={{ fontWeight: 600 }}>{camera.name}</span>
+        {camera.mixerInput != null && (
+          <span style={{ marginLeft: 8, color: 'var(--color-text-muted)', fontSize: 12 }}>
+            Input {camera.mixerInput}
+          </span>
+        )}
+      </div>
+      <span style={{
+        fontSize: 11,
+        padding: '2px 6px',
+        borderRadius: 3,
+        background: 'var(--color-surface-alt)',
+        color: 'var(--color-text-muted)',
+        whiteSpace: 'nowrap',
+      }}>{typeBadge}</span>
+      {camera.controlType !== 'none' && (
+        <span style={{ fontSize: 11, color: 'var(--color-text-muted)', whiteSpace: 'nowrap' }}>
+          {presetCount} preset{presetCount !== 1 ? 's' : ''}
+        </span>
+      )}
+      <button className="btn btn--sm btn--ghost" onClick={() => onEdit(camera)}>Edit</button>
+      <button className="btn btn--sm btn--ghost btn--danger" onClick={() => onDelete(camera)}>Delete</button>
+    </div>
+  );
+}
+
+export function ProductionCamerasPage() {
+  const params = new URLSearchParams(window.location.search);
+  const backendUrl = params.get('server') || localStorage.getItem('lcyt-backend-url') || '';
+  const apiKey = params.get('apikey') || '';
+
+  const [cameras, setCameras] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [editing, setEditing] = useState(null);   // null | 'new' | camera object
+  const [confirmDelete, setConfirmDelete] = useState(null);
+
+  const headers = { 'Content-Type': 'application/json', ...(apiKey ? { 'X-Admin-Key': apiKey } : {}) };
+
+  const fetchCameras = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const r = await fetch(`${backendUrl}/production/cameras`, { headers });
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      setCameras(await r.json());
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [backendUrl, apiKey]);
+
+  useEffect(() => { fetchCameras(); }, [fetchCameras]);
+
+  async function handleSave(data) {
+    const isNew = editing === 'new';
+    const url = isNew
+      ? `${backendUrl}/production/cameras`
+      : `${backendUrl}/production/cameras/${editing.id}`;
+    try {
+      const r = await fetch(url, {
+        method: isNew ? 'POST' : 'PUT',
+        headers,
+        body: JSON.stringify(data),
+      });
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      setEditing(null);
+      fetchCameras();
+    } catch (e) {
+      setError(e.message);
+    }
+  }
+
+  async function handleDelete(camera) {
+    try {
+      const r = await fetch(`${backendUrl}/production/cameras/${camera.id}`, {
+        method: 'DELETE',
+        headers,
+      });
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      setConfirmDelete(null);
+      fetchCameras();
+    } catch (e) {
+      setError(e.message);
+    }
+  }
+
+  return (
+    <div style={{ padding: 20, maxWidth: 700, margin: '0 auto' }}>
+      <div style={{ display: 'flex', alignItems: 'center', marginBottom: 16, gap: 12 }}>
+        <h2 style={{ margin: 0, fontSize: 18 }}>Cameras</h2>
+        <button
+          className="btn btn--primary btn--sm"
+          onClick={() => setEditing('new')}
+          disabled={!!editing}
+        >+ Add camera</button>
+      </div>
+
+      {error && (
+        <div style={{ color: 'var(--color-error)', marginBottom: 12, fontSize: 13 }}>{error}</div>
+      )}
+
+      {editing && (
+        <div style={{
+          border: '1px solid var(--color-border)',
+          borderRadius: 6,
+          padding: 16,
+          marginBottom: 16,
+          background: 'var(--color-surface-alt)',
+        }}>
+          <h3 style={{ margin: '0 0 12px', fontSize: 15 }}>
+            {editing === 'new' ? 'Add camera' : `Edit: ${editing.name}`}
+          </h3>
+          <CameraForm
+            initial={editing === 'new' ? null : editing}
+            onSave={handleSave}
+            onCancel={() => setEditing(null)}
+          />
+        </div>
+      )}
+
+      {loading ? (
+        <p style={{ color: 'var(--color-text-muted)' }}>Loading…</p>
+      ) : cameras.length === 0 ? (
+        <p style={{ color: 'var(--color-text-muted)' }}>No cameras configured yet.</p>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          {cameras.map(cam => (
+            <CameraRow
+              key={cam.id}
+              camera={cam}
+              onEdit={c => setEditing(c)}
+              onDelete={c => setConfirmDelete(c)}
+            />
+          ))}
+        </div>
+      )}
+
+      {confirmDelete && (
+        <div style={{
+          position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000,
+        }}>
+          <div style={{
+            background: 'var(--color-surface)', borderRadius: 8, padding: 24,
+            maxWidth: 360, width: '90%',
+          }}>
+            <p style={{ margin: '0 0 16px' }}>
+              Delete camera <strong>{confirmDelete.name}</strong>?
+            </p>
+            <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+              <button className="btn btn--ghost" onClick={() => setConfirmDelete(null)}>Cancel</button>
+              <button className="btn btn--danger" onClick={() => handleDelete(confirmDelete)}>Delete</button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/lcyt-web/src/components/ProductionMixersPage.jsx
+++ b/packages/lcyt-web/src/components/ProductionMixersPage.jsx
@@ -1,0 +1,320 @@
+import { useState, useEffect, useCallback } from 'react';
+
+const MIXER_TYPES = [
+  { value: 'roland', label: 'Roland V-series' },
+];
+
+function ConnectionDot({ connected }) {
+  return (
+    <span
+      title={connected ? 'Connected' : 'Disconnected'}
+      style={{
+        display: 'inline-block',
+        width: 8,
+        height: 8,
+        borderRadius: '50%',
+        background: connected ? 'var(--color-success)' : 'var(--color-text-muted)',
+        boxShadow: connected ? '0 0 5px var(--color-success)' : 'none',
+        flexShrink: 0,
+      }}
+    />
+  );
+}
+
+function MixerForm({ initial, onSave, onCancel, backendUrl, headers }) {
+  const [name, setName] = useState(initial?.name ?? '');
+  const [type, setType] = useState(initial?.type ?? 'roland');
+  const [host, setHost] = useState(initial?.connectionConfig?.host ?? '');
+  const [port, setPort] = useState(initial?.connectionConfig?.port ?? 8023);
+  const [testResult, setTestResult] = useState(null);   // null | { ok, error?, host, port }
+  const [testing, setTesting] = useState(false);
+
+  function buildConnectionConfig() {
+    return { host, port: Number(port) };
+  }
+
+  async function handleTest() {
+    if (!initial?.id) {
+      setTestResult({ ok: false, error: 'Save the mixer first to test its connection.' });
+      return;
+    }
+    setTesting(true);
+    setTestResult(null);
+    try {
+      const r = await fetch(`${backendUrl}/production/mixers/${initial.id}/test`, {
+        method: 'POST',
+        headers,
+      });
+      setTestResult(await r.json());
+    } catch (e) {
+      setTestResult({ ok: false, error: e.message });
+    } finally {
+      setTesting(false);
+    }
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div className="settings-field">
+        <label className="settings-field__label">Mixer name *</label>
+        <input
+          className="settings-field__input"
+          value={name}
+          onChange={e => setName(e.target.value)}
+          placeholder="e.g. Main switcher"
+          autoFocus
+        />
+      </div>
+
+      <div className="settings-field">
+        <label className="settings-field__label">Type</label>
+        <select
+          className="settings-field__input"
+          value={type}
+          onChange={e => setType(e.target.value)}
+        >
+          {MIXER_TYPES.map(mt => (
+            <option key={mt.value} value={mt.value}>{mt.label}</option>
+          ))}
+        </select>
+      </div>
+
+      {type === 'roland' && (
+        <div style={{ display: 'flex', gap: 12 }}>
+          <div className="settings-field" style={{ flex: 2 }}>
+            <label className="settings-field__label">Host (IP)</label>
+            <input
+              className="settings-field__input"
+              value={host}
+              onChange={e => setHost(e.target.value)}
+              placeholder="192.168.2.100"
+            />
+          </div>
+          <div className="settings-field" style={{ flex: 1 }}>
+            <label className="settings-field__label">TCP port</label>
+            <input
+              className="settings-field__input"
+              type="number"
+              value={port}
+              onChange={e => setPort(e.target.value)}
+              placeholder="8023"
+            />
+          </div>
+        </div>
+      )}
+
+      {testResult && (
+        <div style={{
+          padding: '6px 10px',
+          borderRadius: 4,
+          fontSize: 12,
+          background: testResult.ok ? 'var(--color-success-bg, #d1fae5)' : 'var(--color-error-bg, #fee2e2)',
+          color: testResult.ok ? 'var(--color-success-text, #065f46)' : 'var(--color-error)',
+        }}>
+          {testResult.ok
+            ? `✓ Connected to ${testResult.host}:${testResult.port}`
+            : `✗ ${testResult.error}`}
+        </div>
+      )}
+
+      <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 4, flexWrap: 'wrap' }}>
+        <button
+          className="btn btn--ghost btn--sm"
+          onClick={handleTest}
+          disabled={testing}
+          style={{ marginRight: 'auto' }}
+        >
+          {testing ? 'Testing…' : 'Test connection'}
+        </button>
+        <button className="btn btn--ghost" onClick={onCancel}>Cancel</button>
+        <button
+          className="btn btn--primary"
+          onClick={() => onSave({ name: name.trim(), type, connectionConfig: buildConnectionConfig() })}
+          disabled={!name.trim()}
+        >Save</button>
+      </div>
+    </div>
+  );
+}
+
+function MixerRow({ mixer, onEdit, onDelete }) {
+  const typeLabel = MIXER_TYPES.find(t => t.value === mixer.type)?.label ?? mixer.type;
+  const cfg = mixer.connectionConfig || {};
+
+  return (
+    <div style={{
+      display: 'flex',
+      alignItems: 'center',
+      gap: 10,
+      padding: '8px 10px',
+      border: '1px solid var(--color-border)',
+      borderRadius: 4,
+    }}>
+      <ConnectionDot connected={mixer.connected} />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <span style={{ fontWeight: 600 }}>{mixer.name}</span>
+        {cfg.host && (
+          <span style={{ marginLeft: 8, color: 'var(--color-text-muted)', fontSize: 12 }}>
+            {cfg.host}:{cfg.port ?? 8023}
+          </span>
+        )}
+      </div>
+      <span style={{
+        fontSize: 11,
+        padding: '2px 6px',
+        borderRadius: 3,
+        background: 'var(--color-surface-alt)',
+        color: 'var(--color-text-muted)',
+        whiteSpace: 'nowrap',
+      }}>{typeLabel}</span>
+      {mixer.activeSource != null && (
+        <span style={{ fontSize: 11, color: 'var(--color-text-muted)', whiteSpace: 'nowrap' }}>
+          PGM: {mixer.activeSource}
+        </span>
+      )}
+      <button className="btn btn--sm btn--ghost" onClick={() => onEdit(mixer)}>Edit</button>
+      <button className="btn btn--sm btn--ghost btn--danger" onClick={() => onDelete(mixer)}>Delete</button>
+    </div>
+  );
+}
+
+export function ProductionMixersPage() {
+  const params = new URLSearchParams(window.location.search);
+  const backendUrl = params.get('server') || localStorage.getItem('lcyt-backend-url') || '';
+  const apiKey = params.get('apikey') || '';
+
+  const [mixers, setMixers] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [editing, setEditing] = useState(null);
+  const [confirmDelete, setConfirmDelete] = useState(null);
+
+  const headers = { 'Content-Type': 'application/json', ...(apiKey ? { 'X-Admin-Key': apiKey } : {}) };
+
+  const fetchMixers = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const r = await fetch(`${backendUrl}/production/mixers`, { headers });
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      setMixers(await r.json());
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [backendUrl, apiKey]);
+
+  useEffect(() => { fetchMixers(); }, [fetchMixers]);
+
+  async function handleSave(data) {
+    const isNew = editing === 'new';
+    const url = isNew
+      ? `${backendUrl}/production/mixers`
+      : `${backendUrl}/production/mixers/${editing.id}`;
+    try {
+      const r = await fetch(url, {
+        method: isNew ? 'POST' : 'PUT',
+        headers,
+        body: JSON.stringify(data),
+      });
+      if (!r.ok) {
+        const body = await r.json().catch(() => ({}));
+        throw new Error(body.error || `HTTP ${r.status}`);
+      }
+      setEditing(null);
+      fetchMixers();
+    } catch (e) {
+      setError(e.message);
+    }
+  }
+
+  async function handleDelete(mixer) {
+    try {
+      const r = await fetch(`${backendUrl}/production/mixers/${mixer.id}`, {
+        method: 'DELETE',
+        headers,
+      });
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      setConfirmDelete(null);
+      fetchMixers();
+    } catch (e) {
+      setError(e.message);
+    }
+  }
+
+  return (
+    <div style={{ padding: 20, maxWidth: 700, margin: '0 auto' }}>
+      <div style={{ display: 'flex', alignItems: 'center', marginBottom: 16, gap: 12 }}>
+        <h2 style={{ margin: 0, fontSize: 18 }}>Mixers</h2>
+        <button
+          className="btn btn--primary btn--sm"
+          onClick={() => setEditing('new')}
+          disabled={!!editing}
+        >+ Add mixer</button>
+      </div>
+
+      {error && (
+        <div style={{ color: 'var(--color-error)', marginBottom: 12, fontSize: 13 }}>{error}</div>
+      )}
+
+      {editing && (
+        <div style={{
+          border: '1px solid var(--color-border)',
+          borderRadius: 6,
+          padding: 16,
+          marginBottom: 16,
+          background: 'var(--color-surface-alt)',
+        }}>
+          <h3 style={{ margin: '0 0 12px', fontSize: 15 }}>
+            {editing === 'new' ? 'Add mixer' : `Edit: ${editing.name}`}
+          </h3>
+          <MixerForm
+            initial={editing === 'new' ? null : editing}
+            onSave={handleSave}
+            onCancel={() => setEditing(null)}
+            backendUrl={backendUrl}
+            headers={headers}
+          />
+        </div>
+      )}
+
+      {loading ? (
+        <p style={{ color: 'var(--color-text-muted)' }}>Loading…</p>
+      ) : mixers.length === 0 ? (
+        <p style={{ color: 'var(--color-text-muted)' }}>No mixers configured yet.</p>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          {mixers.map(m => (
+            <MixerRow
+              key={m.id}
+              mixer={m}
+              onEdit={mx => setEditing(mx)}
+              onDelete={mx => setConfirmDelete(mx)}
+            />
+          ))}
+        </div>
+      )}
+
+      {confirmDelete && (
+        <div style={{
+          position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000,
+        }}>
+          <div style={{
+            background: 'var(--color-surface)', borderRadius: 8, padding: 24,
+            maxWidth: 360, width: '90%',
+          }}>
+            <p style={{ margin: '0 0 16px' }}>
+              Delete mixer <strong>{confirmDelete.name}</strong>?
+            </p>
+            <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+              <button className="btn btn--ghost" onClick={() => setConfirmDelete(null)}>Cancel</button>
+              <button className="btn btn--danger" onClick={() => handleDelete(confirmDelete)}>Delete</button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/lcyt-web/src/components/ProductionMixersPage.jsx
+++ b/packages/lcyt-web/src/components/ProductionMixersPage.jsx
@@ -2,49 +2,83 @@ import { useState, useEffect, useCallback } from 'react';
 
 const MIXER_TYPES = [
   { value: 'roland', label: 'Roland V-series' },
+  { value: 'amx',    label: 'AMX NetLinx' },
 ];
+
+const EMPTY_INPUT = (n) => ({ number: n, command: '' });
 
 function ConnectionDot({ connected }) {
   return (
     <span
       title={connected ? 'Connected' : 'Disconnected'}
       style={{
-        display: 'inline-block',
-        width: 8,
-        height: 8,
-        borderRadius: '50%',
+        display: 'inline-block', width: 8, height: 8, borderRadius: '50%', flexShrink: 0,
         background: connected ? 'var(--color-success)' : 'var(--color-text-muted)',
         boxShadow: connected ? '0 0 5px var(--color-success)' : 'none',
-        flexShrink: 0,
       }}
     />
   );
 }
 
-function MixerForm({ initial, onSave, onCancel, backendUrl, headers }) {
-  const [name, setName] = useState(initial?.name ?? '');
-  const [type, setType] = useState(initial?.type ?? 'roland');
-  const [host, setHost] = useState(initial?.connectionConfig?.host ?? '');
-  const [port, setPort] = useState(initial?.connectionConfig?.port ?? 8023);
-  const [testResult, setTestResult] = useState(null);   // null | { ok, error?, host, port }
-  const [testing, setTesting] = useState(false);
+function InputRow({ entry, onChange, onRemove }) {
+  return (
+    <div style={{ display: 'flex', gap: 6, alignItems: 'center', marginBottom: 4 }}>
+      <input
+        className="settings-field__input"
+        type="number"
+        min={1}
+        placeholder="#"
+        value={entry.number}
+        onChange={e => onChange({ ...entry, number: Number(e.target.value) })}
+        style={{ width: 60 }}
+      />
+      <input
+        className="settings-field__input"
+        placeholder="AMX command (e.g. SEND_COMMAND dvRouter,'INPUT-1')"
+        value={entry.command}
+        onChange={e => onChange({ ...entry, command: e.target.value })}
+        style={{ flex: 1, fontFamily: 'monospace', fontSize: 12 }}
+      />
+      <button className="btn btn--sm btn--ghost" onClick={onRemove} title="Remove input" style={{ flexShrink: 0 }}>
+        ✕
+      </button>
+    </div>
+  );
+}
+
+function MixerForm({ initial, bridges, onSave, onCancel, backendUrl, headers }) {
+  const [name,             setName]             = useState(initial?.name ?? '');
+  const [type,             setType]             = useState(initial?.type ?? 'roland');
+  const [host,             setHost]             = useState(initial?.connectionConfig?.host ?? '');
+  const [port,             setPort]             = useState(
+    initial?.connectionConfig?.port ?? (initial?.type === 'amx' ? 1319 : 8023)
+  );
+  const [inputs,           setInputs]           = useState(
+    initial?.connectionConfig?.inputs?.map(i => ({ ...i })) ?? []
+  );
+  const [bridgeInstanceId, setBridgeInstanceId] = useState(initial?.bridgeInstanceId ?? '');
+  const [testResult,       setTestResult]       = useState(null);
+  const [testing,          setTesting]          = useState(false);
+
+  // Update default port when type changes
+  function handleTypeChange(newType) {
+    setType(newType);
+    if (!initial?.connectionConfig?.port) {
+      setPort(newType === 'amx' ? 1319 : 8023);
+    }
+  }
 
   function buildConnectionConfig() {
-    return { host, port: Number(port) };
+    if (type === 'roland') return { host, port: Number(port) };
+    if (type === 'amx')    return { host, port: Number(port), inputs };
+    return {};
   }
 
   async function handleTest() {
-    if (!initial?.id) {
-      setTestResult({ ok: false, error: 'Save the mixer first to test its connection.' });
-      return;
-    }
-    setTesting(true);
-    setTestResult(null);
+    if (!initial?.id) { setTestResult({ ok: false, error: 'Save the mixer first to test.' }); return; }
+    setTesting(true); setTestResult(null);
     try {
-      const r = await fetch(`${backendUrl}/production/mixers/${initial.id}/test`, {
-        method: 'POST',
-        headers,
-      });
+      const r = await fetch(`${backendUrl}/production/mixers/${initial.id}/test`, { method: 'POST', headers });
       setTestResult(await r.json());
     } catch (e) {
       setTestResult({ ok: false, error: e.message });
@@ -53,120 +87,149 @@ function MixerForm({ initial, onSave, onCancel, backendUrl, headers }) {
     }
   }
 
+  function addInput() {
+    const nextNum = inputs.length > 0 ? Math.max(...inputs.map(i => i.number)) + 1 : 1;
+    setInputs(prev => [...prev, EMPTY_INPUT(nextNum)]);
+  }
+  function updateInput(idx, updated) { setInputs(prev => prev.map((i, n) => n === idx ? updated : i)); }
+  function removeInput(idx)          { setInputs(prev => prev.filter((_, n) => n !== idx)); }
+
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
       <div className="settings-field">
         <label className="settings-field__label">Mixer name *</label>
-        <input
-          className="settings-field__input"
-          value={name}
-          onChange={e => setName(e.target.value)}
-          placeholder="e.g. Main switcher"
-          autoFocus
-        />
+        <input className="settings-field__input" value={name} onChange={e => setName(e.target.value)}
+          placeholder="e.g. Main switcher" autoFocus />
       </div>
 
       <div className="settings-field">
         <label className="settings-field__label">Type</label>
-        <select
-          className="settings-field__input"
-          value={type}
-          onChange={e => setType(e.target.value)}
-        >
-          {MIXER_TYPES.map(mt => (
-            <option key={mt.value} value={mt.value}>{mt.label}</option>
-          ))}
+        <select className="settings-field__input" value={type} onChange={e => handleTypeChange(e.target.value)}>
+          {MIXER_TYPES.map(mt => <option key={mt.value} value={mt.value}>{mt.label}</option>)}
         </select>
       </div>
 
-      {type === 'roland' && (
-        <div style={{ display: 'flex', gap: 12 }}>
-          <div className="settings-field" style={{ flex: 2 }}>
-            <label className="settings-field__label">Host (IP)</label>
-            <input
-              className="settings-field__input"
-              value={host}
-              onChange={e => setHost(e.target.value)}
-              placeholder="192.168.2.100"
-            />
+      {/* Host + port — shown for all types */}
+      <div style={{ display: 'flex', gap: 12 }}>
+        <div className="settings-field" style={{ flex: 2 }}>
+          <label className="settings-field__label">Host (IP)</label>
+          <input className="settings-field__input" value={host} onChange={e => setHost(e.target.value)}
+            placeholder={type === 'amx' ? '192.168.2.50' : '192.168.2.100'} />
+        </div>
+        <div className="settings-field" style={{ flex: 1 }}>
+          <label className="settings-field__label">TCP port</label>
+          <input className="settings-field__input" type="number" value={port}
+            onChange={e => setPort(e.target.value)}
+            placeholder={type === 'amx' ? '1319' : '8023'} />
+        </div>
+      </div>
+
+      {/* AMX-specific: input command rows */}
+      {type === 'amx' && (
+        <div className="settings-field">
+          <label className="settings-field__label">
+            Input commands
+            <button className="btn btn--sm btn--ghost" style={{ marginLeft: 8 }} onClick={addInput}>
+              + Add input
+            </button>
+          </label>
+          {inputs.length === 0 && (
+            <p style={{ color: 'var(--color-text-muted)', fontSize: 12, margin: '4px 0' }}>
+              No inputs. Click "Add input" to add one.
+            </p>
+          )}
+          <div style={{ fontSize: 11, color: 'var(--color-text-muted)', marginBottom: 4 }}>
+            Input # → AMX command sent to switch to that input
           </div>
-          <div className="settings-field" style={{ flex: 1 }}>
-            <label className="settings-field__label">TCP port</label>
-            <input
-              className="settings-field__input"
-              type="number"
-              value={port}
-              onChange={e => setPort(e.target.value)}
-              placeholder="8023"
-            />
-          </div>
+          {inputs.map((inp, i) => (
+            <InputRow key={i} entry={inp}
+              onChange={updated => updateInput(i, updated)}
+              onRemove={() => removeInput(i)} />
+          ))}
+        </div>
+      )}
+
+      {/* Bridge selector — only shown when bridges exist */}
+      {bridges.length > 0 && (
+        <div className="settings-field">
+          <label className="settings-field__label">
+            Bridge{bridges.length >= 2 ? ' instance' : ''}
+            <span style={{ fontSize: 11, color: 'var(--color-text-muted)', marginLeft: 6, fontWeight: 400 }}>
+              (required for hardware on isolated AV network)
+            </span>
+          </label>
+          <select className="settings-field__input" value={bridgeInstanceId}
+            onChange={e => setBridgeInstanceId(e.target.value)}>
+            <option value="">None (direct TCP from backend)</option>
+            {bridges.map(b => (
+              <option key={b.id} value={b.id}>
+                {bridges.length >= 2 ? b.name : 'Use bridge'}
+                {b.status === 'connected' ? ' ●' : ' ○'}
+              </option>
+            ))}
+          </select>
         </div>
       )}
 
       {testResult && (
         <div style={{
-          padding: '6px 10px',
-          borderRadius: 4,
-          fontSize: 12,
+          padding: '6px 10px', borderRadius: 4, fontSize: 12,
           background: testResult.ok ? 'var(--color-success-bg, #d1fae5)' : 'var(--color-error-bg, #fee2e2)',
           color: testResult.ok ? 'var(--color-success-text, #065f46)' : 'var(--color-error)',
         }}>
-          {testResult.ok
-            ? `✓ Connected to ${testResult.host}:${testResult.port}`
-            : `✗ ${testResult.error}`}
+          {testResult.ok ? `✓ Connected to ${testResult.host}:${testResult.port}` : `✗ ${testResult.error}`}
         </div>
       )}
 
       <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 4, flexWrap: 'wrap' }}>
-        <button
-          className="btn btn--ghost btn--sm"
-          onClick={handleTest}
-          disabled={testing}
-          style={{ marginRight: 'auto' }}
-        >
+        <button className="btn btn--ghost btn--sm" onClick={handleTest} disabled={testing} style={{ marginRight: 'auto' }}>
           {testing ? 'Testing…' : 'Test connection'}
         </button>
         <button className="btn btn--ghost" onClick={onCancel}>Cancel</button>
-        <button
-          className="btn btn--primary"
-          onClick={() => onSave({ name: name.trim(), type, connectionConfig: buildConnectionConfig() })}
-          disabled={!name.trim()}
-        >Save</button>
+        <button className="btn btn--primary"
+          onClick={() => onSave({ name: name.trim(), type, connectionConfig: buildConnectionConfig(), bridgeInstanceId: bridgeInstanceId || null })}
+          disabled={!name.trim()}>
+          Save
+        </button>
       </div>
     </div>
   );
 }
 
-function MixerRow({ mixer, onEdit, onDelete }) {
+function MixerRow({ mixer, bridges, onEdit, onDelete }) {
   const typeLabel = MIXER_TYPES.find(t => t.value === mixer.type)?.label ?? mixer.type;
-  const cfg = mixer.connectionConfig || {};
+  const cfg       = mixer.connectionConfig || {};
+  // Progressive disclosure: bridge name only when 2+ bridges exist
+  const bridge    = bridges.length >= 2 ? bridges.find(b => b.id === mixer.bridgeInstanceId) : null;
 
   return (
     <div style={{
-      display: 'flex',
-      alignItems: 'center',
-      gap: 10,
-      padding: '8px 10px',
-      border: '1px solid var(--color-border)',
-      borderRadius: 4,
+      display: 'flex', alignItems: 'center', gap: 10, padding: '8px 10px',
+      border: '1px solid var(--color-border)', borderRadius: 4,
     }}>
       <ConnectionDot connected={mixer.connected} />
       <div style={{ flex: 1, minWidth: 0 }}>
         <span style={{ fontWeight: 600 }}>{mixer.name}</span>
         {cfg.host && (
           <span style={{ marginLeft: 8, color: 'var(--color-text-muted)', fontSize: 12 }}>
-            {cfg.host}:{cfg.port ?? 8023}
+            {cfg.host}:{cfg.port ?? (mixer.type === 'amx' ? 1319 : 8023)}
+          </span>
+        )}
+        {bridge && (
+          <span style={{ marginLeft: 8, fontSize: 11, color: 'var(--color-text-muted)' }}>
+            via {bridge.name}
           </span>
         )}
       </div>
       <span style={{
-        fontSize: 11,
-        padding: '2px 6px',
-        borderRadius: 3,
-        background: 'var(--color-surface-alt)',
-        color: 'var(--color-text-muted)',
-        whiteSpace: 'nowrap',
+        fontSize: 11, padding: '2px 6px', borderRadius: 3,
+        background: 'var(--color-surface-alt)', color: 'var(--color-text-muted)', whiteSpace: 'nowrap',
       }}>{typeLabel}</span>
+      {mixer.type === 'amx' && (
+        <span style={{ fontSize: 11, color: 'var(--color-text-muted)', whiteSpace: 'nowrap' }}>
+          {cfg.inputs?.length ?? 0} input{(cfg.inputs?.length ?? 0) !== 1 ? 's' : ''}
+        </span>
+      )}
       {mixer.activeSource != null && (
         <span style={{ fontSize: 11, color: 'var(--color-text-muted)', whiteSpace: 'nowrap' }}>
           PGM: {mixer.activeSource}
@@ -179,25 +242,31 @@ function MixerRow({ mixer, onEdit, onDelete }) {
 }
 
 export function ProductionMixersPage() {
-  const params = new URLSearchParams(window.location.search);
+  const params     = new URLSearchParams(window.location.search);
   const backendUrl = params.get('server') || localStorage.getItem('lcyt-backend-url') || '';
-  const apiKey = params.get('apikey') || '';
+  const apiKey     = params.get('apikey') || '';
 
-  const [mixers, setMixers] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-  const [editing, setEditing] = useState(null);
+  const [mixers,        setMixers]        = useState([]);
+  const [bridges,       setBridges]       = useState([]);
+  const [loading,       setLoading]       = useState(true);
+  const [error,         setError]         = useState(null);
+  const [editing,       setEditing]       = useState(null);
   const [confirmDelete, setConfirmDelete] = useState(null);
 
   const headers = { 'Content-Type': 'application/json', ...(apiKey ? { 'X-Admin-Key': apiKey } : {}) };
 
-  const fetchMixers = useCallback(async () => {
+  const fetchAll = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      const r = await fetch(`${backendUrl}/production/mixers`, { headers });
-      if (!r.ok) throw new Error(`HTTP ${r.status}`);
-      setMixers(await r.json());
+      const [mixRes, bridgeRes] = await Promise.all([
+        fetch(`${backendUrl}/production/mixers`,           { headers }),
+        fetch(`${backendUrl}/production/bridge/instances`, { headers }),
+      ]);
+      if (!mixRes.ok)    throw new Error(`mixers: HTTP ${mixRes.status}`);
+      if (!bridgeRes.ok) throw new Error(`bridges: HTTP ${bridgeRes.status}`);
+      setMixers(await mixRes.json());
+      setBridges(await bridgeRes.json());
     } catch (e) {
       setError(e.message);
     } finally {
@@ -205,25 +274,18 @@ export function ProductionMixersPage() {
     }
   }, [backendUrl, apiKey]);
 
-  useEffect(() => { fetchMixers(); }, [fetchMixers]);
+  useEffect(() => { fetchAll(); }, [fetchAll]);
 
   async function handleSave(data) {
     const isNew = editing === 'new';
-    const url = isNew
+    const url   = isNew
       ? `${backendUrl}/production/mixers`
       : `${backendUrl}/production/mixers/${editing.id}`;
     try {
-      const r = await fetch(url, {
-        method: isNew ? 'POST' : 'PUT',
-        headers,
-        body: JSON.stringify(data),
-      });
-      if (!r.ok) {
-        const body = await r.json().catch(() => ({}));
-        throw new Error(body.error || `HTTP ${r.status}`);
-      }
+      const r = await fetch(url, { method: isNew ? 'POST' : 'PUT', headers, body: JSON.stringify(data) });
+      if (!r.ok) { const b = await r.json().catch(() => ({})); throw new Error(b.error || `HTTP ${r.status}`); }
       setEditing(null);
-      fetchMixers();
+      fetchAll();
     } catch (e) {
       setError(e.message);
     }
@@ -231,13 +293,10 @@ export function ProductionMixersPage() {
 
   async function handleDelete(mixer) {
     try {
-      const r = await fetch(`${backendUrl}/production/mixers/${mixer.id}`, {
-        method: 'DELETE',
-        headers,
-      });
+      const r = await fetch(`${backendUrl}/production/mixers/${mixer.id}`, { method: 'DELETE', headers });
       if (!r.ok) throw new Error(`HTTP ${r.status}`);
       setConfirmDelete(null);
-      fetchMixers();
+      fetchAll();
     } catch (e) {
       setError(e.message);
     }
@@ -247,30 +306,24 @@ export function ProductionMixersPage() {
     <div style={{ padding: 20, maxWidth: 700, margin: '0 auto' }}>
       <div style={{ display: 'flex', alignItems: 'center', marginBottom: 16, gap: 12 }}>
         <h2 style={{ margin: 0, fontSize: 18 }}>Mixers</h2>
-        <button
-          className="btn btn--primary btn--sm"
-          onClick={() => setEditing('new')}
-          disabled={!!editing}
-        >+ Add mixer</button>
+        <button className="btn btn--primary btn--sm" onClick={() => setEditing('new')} disabled={!!editing}>
+          + Add mixer
+        </button>
       </div>
 
-      {error && (
-        <div style={{ color: 'var(--color-error)', marginBottom: 12, fontSize: 13 }}>{error}</div>
-      )}
+      {error && <div style={{ color: 'var(--color-error)', marginBottom: 12, fontSize: 13 }}>{error}</div>}
 
       {editing && (
         <div style={{
-          border: '1px solid var(--color-border)',
-          borderRadius: 6,
-          padding: 16,
-          marginBottom: 16,
-          background: 'var(--color-surface-alt)',
+          border: '1px solid var(--color-border)', borderRadius: 6, padding: 16,
+          marginBottom: 16, background: 'var(--color-surface-alt)',
         }}>
           <h3 style={{ margin: '0 0 12px', fontSize: 15 }}>
             {editing === 'new' ? 'Add mixer' : `Edit: ${editing.name}`}
           </h3>
           <MixerForm
             initial={editing === 'new' ? null : editing}
+            bridges={bridges}
             onSave={handleSave}
             onCancel={() => setEditing(null)}
             backendUrl={backendUrl}
@@ -286,12 +339,8 @@ export function ProductionMixersPage() {
       ) : (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
           {mixers.map(m => (
-            <MixerRow
-              key={m.id}
-              mixer={m}
-              onEdit={mx => setEditing(mx)}
-              onDelete={mx => setConfirmDelete(mx)}
-            />
+            <MixerRow key={m.id} mixer={m} bridges={bridges}
+              onEdit={mx => setEditing(mx)} onDelete={mx => setConfirmDelete(mx)} />
           ))}
         </div>
       )}
@@ -301,13 +350,8 @@ export function ProductionMixersPage() {
           position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)',
           display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000,
         }}>
-          <div style={{
-            background: 'var(--color-surface)', borderRadius: 8, padding: 24,
-            maxWidth: 360, width: '90%',
-          }}>
-            <p style={{ margin: '0 0 16px' }}>
-              Delete mixer <strong>{confirmDelete.name}</strong>?
-            </p>
+          <div style={{ background: 'var(--color-surface)', borderRadius: 8, padding: 24, maxWidth: 360, width: '90%' }}>
+            <p style={{ margin: '0 0 16px' }}>Delete mixer <strong>{confirmDelete.name}</strong>?</p>
             <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
               <button className="btn btn--ghost" onClick={() => setConfirmDelete(null)}>Cancel</button>
               <button className="btn btn--danger" onClick={() => handleDelete(confirmDelete)}>Delete</button>

--- a/packages/lcyt-web/src/components/ProductionOperatorPage.jsx
+++ b/packages/lcyt-web/src/components/ProductionOperatorPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 
 const PRESET_STATE = {
   idle:    'idle',
@@ -7,14 +7,18 @@ const PRESET_STATE = {
   error:   'error',
 };
 
+// ---------------------------------------------------------------------------
+// Preset button
+// ---------------------------------------------------------------------------
+
 function PresetButton({ preset, state, onClick }) {
-  const colors = {
-    [PRESET_STATE.idle]:    { bg: 'var(--color-surface-alt)', border: 'var(--color-border)', text: 'var(--color-text)' },
-    [PRESET_STATE.pending]: { bg: 'var(--color-surface-alt)', border: 'var(--color-border)', text: 'var(--color-text-muted)' },
-    [PRESET_STATE.ok]:      { bg: 'var(--color-success)',     border: 'var(--color-success)', text: '#fff' },
-    [PRESET_STATE.error]:   { bg: 'var(--color-error)',       border: 'var(--color-error)',   text: '#fff' },
+  const styles = {
+    [PRESET_STATE.idle]:    { bg: 'var(--color-surface-alt)', border: 'var(--color-border)',    text: 'var(--color-text)' },
+    [PRESET_STATE.pending]: { bg: 'var(--color-surface-alt)', border: 'var(--color-border)',    text: 'var(--color-text-muted)' },
+    [PRESET_STATE.ok]:      { bg: 'var(--color-success)',     border: 'var(--color-success)',   text: '#fff' },
+    [PRESET_STATE.error]:   { bg: 'var(--color-error)',       border: 'var(--color-error)',     text: '#fff' },
   };
-  const c = colors[state] ?? colors[PRESET_STATE.idle];
+  const s = styles[state] ?? styles[PRESET_STATE.idle];
 
   return (
     <button
@@ -23,9 +27,9 @@ function PresetButton({ preset, state, onClick }) {
       style={{
         padding: '10px 14px',
         borderRadius: 6,
-        border: `2px solid ${c.border}`,
-        background: c.bg,
-        color: c.text,
+        border: `2px solid ${s.border}`,
+        background: s.bg,
+        color: s.text,
         fontSize: 14,
         fontWeight: 500,
         cursor: state === PRESET_STATE.pending ? 'wait' : 'pointer',
@@ -38,8 +42,11 @@ function PresetButton({ preset, state, onClick }) {
   );
 }
 
-function CameraCard({ camera, backendUrl, headers }) {
-  // Map of presetId → PRESET_STATE
+// ---------------------------------------------------------------------------
+// Camera card
+// ---------------------------------------------------------------------------
+
+function CameraCard({ camera, isLive, quickCutEnabled, backendUrl, headers, onCutToCamera }) {
   const [presetStates, setPresetStates] = useState({});
 
   const presets = camera.controlConfig?.presets ?? [];
@@ -52,48 +59,68 @@ function CameraCard({ camera, backendUrl, headers }) {
         `${backendUrl}/production/cameras/${camera.id}/preset/${encodeURIComponent(presetId)}`,
         { method: 'POST', headers }
       );
-      const nextState = r.ok ? PRESET_STATE.ok : PRESET_STATE.error;
-      setPresetStates(prev => ({ ...prev, [presetId]: nextState }));
-      // Reset to idle after brief feedback
-      setTimeout(() => {
-        setPresetStates(prev => ({ ...prev, [presetId]: PRESET_STATE.idle }));
-      }, 1500);
+      const next = r.ok ? PRESET_STATE.ok : PRESET_STATE.error;
+      setPresetStates(prev => ({ ...prev, [presetId]: next }));
+      setTimeout(() => setPresetStates(prev => ({ ...prev, [presetId]: PRESET_STATE.idle })), 1500);
     } catch {
       setPresetStates(prev => ({ ...prev, [presetId]: PRESET_STATE.error }));
-      setTimeout(() => {
-        setPresetStates(prev => ({ ...prev, [presetId]: PRESET_STATE.idle }));
-      }, 2000);
+      setTimeout(() => setPresetStates(prev => ({ ...prev, [presetId]: PRESET_STATE.idle })), 2000);
+    }
+  }
+
+  function handleCardClick() {
+    if (quickCutEnabled && camera.mixerInput != null) {
+      onCutToCamera(camera);
     }
   }
 
   return (
-    <div style={{
-      border: '1px solid var(--color-border)',
-      borderRadius: 8,
-      padding: 16,
-      display: 'flex',
-      flexDirection: 'column',
-      gap: 10,
-      background: 'var(--color-surface)',
-      minWidth: 180,
-    }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-        <span style={{ fontWeight: 700, fontSize: 15 }}>{camera.name}</span>
-        {camera.mixerInput != null && (
+    <div
+      onClick={quickCutEnabled && camera.mixerInput != null ? handleCardClick : undefined}
+      style={{
+        border: `2px solid ${isLive ? 'var(--color-error)' : 'var(--color-border)'}`,
+        borderRadius: 8,
+        padding: 16,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 10,
+        background: isLive ? 'var(--color-error-bg, rgba(239,68,68,0.08))' : 'var(--color-surface)',
+        cursor: quickCutEnabled && camera.mixerInput != null ? 'pointer' : 'default',
+        transition: 'border-color 0.15s, background 0.15s',
+        minWidth: 180,
+        position: 'relative',
+      }}
+    >
+      {/* Header row: name + LIVE badge + mixer input */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
+        <span style={{ fontWeight: 700, fontSize: 15, flex: 1 }}>{camera.name}</span>
+        {isLive && (
+          <span style={{
+            fontSize: 11,
+            fontWeight: 700,
+            padding: '2px 7px',
+            borderRadius: 3,
+            background: 'var(--color-error)',
+            color: '#fff',
+            letterSpacing: '0.05em',
+          }}>LIVE</span>
+        )}
+        {camera.mixerInput != null && !isLive && (
           <span style={{
             fontSize: 11,
             padding: '2px 6px',
             borderRadius: 3,
             background: 'var(--color-surface-alt)',
             color: 'var(--color-text-muted)',
-          }}>
-            In {camera.mixerInput}
-          </span>
+          }}>In {camera.mixerInput}</span>
         )}
       </div>
 
       {hasPresets ? (
-        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+        <div
+          onClick={e => e.stopPropagation()}  // prevent card click when clicking preset buttons
+          style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}
+        >
           {presets.map(preset => (
             <PresetButton
               key={preset.id}
@@ -108,9 +135,63 @@ function CameraCard({ camera, backendUrl, headers }) {
           {camera.controlType === 'none' ? 'Mixer input only' : 'No presets configured'}
         </span>
       )}
+
+      {/* Quick-cut hint */}
+      {quickCutEnabled && camera.mixerInput != null && !isLive && (
+        <span style={{ fontSize: 11, color: 'var(--color-text-muted)', marginTop: -4 }}>
+          Tap card to cut
+        </span>
+      )}
     </div>
   );
 }
+
+// ---------------------------------------------------------------------------
+// Mixer status bar
+// ---------------------------------------------------------------------------
+
+function MixerStatusBar({ mixers, onManualSwitch }) {
+  if (mixers.length === 0) return null;
+
+  return (
+    <div style={{
+      display: 'flex',
+      alignItems: 'center',
+      gap: 16,
+      padding: '8px 12px',
+      borderRadius: 6,
+      border: '1px solid var(--color-border)',
+      background: 'var(--color-surface)',
+      flexWrap: 'wrap',
+      marginBottom: 16,
+    }}>
+      {mixers.map(m => (
+        <div key={m.id} style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+          <span
+            style={{
+              width: 8, height: 8, borderRadius: '50%', flexShrink: 0,
+              background: m.connected ? 'var(--color-success)' : 'var(--color-text-muted)',
+              boxShadow: m.connected ? '0 0 5px var(--color-success)' : 'none',
+            }}
+          />
+          <span style={{ fontSize: 13 }}>
+            {mixers.length > 1 ? `${m.name}: ` : ''}
+            {m.connected
+              ? m.activeSource != null
+                ? <><strong>PGM {m.activeSource}</strong></>
+                : 'Connected'
+              : <span style={{ color: 'var(--color-text-muted)' }}>Disconnected</span>
+            }
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main page
+// ---------------------------------------------------------------------------
 
 export function ProductionOperatorPage() {
   const params = new URLSearchParams(window.location.search);
@@ -119,22 +200,33 @@ export function ProductionOperatorPage() {
   const token = params.get('token') || localStorage.getItem('lcyt-token') || '';
 
   const [cameras, setCameras] = useState([]);
+  const [mixers, setMixers] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [quickCut, setQuickCut] = useState(false);
+  const [switching, setSwitching] = useState(false);
+
+  // Poll mixer active source every 5 s so the LIVE badge stays accurate
+  const pollRef = useRef(null);
 
   const headers = {
     'Content-Type': 'application/json',
-    ...(token    ? { Authorization: `Bearer ${token}` } : {}),
-    ...(apiKey   ? { 'X-Admin-Key': apiKey } : {}),
+    ...(token  ? { Authorization: `Bearer ${token}` } : {}),
+    ...(apiKey ? { 'X-Admin-Key': apiKey } : {}),
   };
 
-  const fetchCameras = useCallback(async () => {
+  const fetchAll = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      const r = await fetch(`${backendUrl}/production/cameras`, { headers });
-      if (!r.ok) throw new Error(`HTTP ${r.status}`);
-      setCameras(await r.json());
+      const [camRes, mixRes] = await Promise.all([
+        fetch(`${backendUrl}/production/cameras`, { headers }),
+        fetch(`${backendUrl}/production/mixers`,  { headers }),
+      ]);
+      if (!camRes.ok) throw new Error(`cameras: HTTP ${camRes.status}`);
+      if (!mixRes.ok) throw new Error(`mixers: HTTP ${mixRes.status}`);
+      setCameras(await camRes.json());
+      setMixers(await mixRes.json());
     } catch (e) {
       setError(e.message);
     } finally {
@@ -142,21 +234,81 @@ export function ProductionOperatorPage() {
     }
   }, [backendUrl, apiKey, token]);
 
-  useEffect(() => { fetchCameras(); }, [fetchCameras]);
+  async function pollMixers() {
+    if (!backendUrl) return;
+    try {
+      const r = await fetch(`${backendUrl}/production/mixers`, { headers });
+      if (r.ok) setMixers(await r.json());
+    } catch { /* silent */ }
+  }
+
+  useEffect(() => {
+    fetchAll();
+    pollRef.current = setInterval(pollMixers, 5_000);
+    return () => clearInterval(pollRef.current);
+  }, [fetchAll]);
+
+  // Compute: which mixer input is live? (use first mixer that has an activeSource)
+  const activeMixerInput = mixers.find(m => m.activeSource != null)?.activeSource ?? null;
+
+  async function handleCutToCamera(camera) {
+    if (!camera.mixerInput || switching) return;
+    const mixer = mixers[0]; // For Phase 2, assume one primary mixer
+    if (!mixer) return;
+    setSwitching(true);
+    try {
+      const r = await fetch(
+        `${backendUrl}/production/mixers/${mixer.id}/switch/${camera.mixerInput}`,
+        { method: 'POST', headers }
+      );
+      if (r.ok) {
+        const { activeSource } = await r.json();
+        setMixers(prev => prev.map(m =>
+          m.id === mixer.id ? { ...m, activeSource } : m
+        ));
+      }
+    } catch { /* ignore */ } finally {
+      setSwitching(false);
+    }
+  }
 
   return (
     <div style={{ padding: 20 }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 20 }}>
-        <h2 style={{ margin: 0, fontSize: 20 }}>Production Control</h2>
-        <button className="btn btn--ghost btn--sm" onClick={fetchCameras} title="Refresh">↺</button>
+      {/* Toolbar */}
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        marginBottom: 16,
+        flexWrap: 'wrap',
+      }}>
+        <h2 style={{ margin: 0, fontSize: 20, flex: 1 }}>Production Control</h2>
+
+        {/* Quick-cut toggle */}
+        {mixers.length > 0 && (
+          <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 13, cursor: 'pointer', userSelect: 'none' }}>
+            <input
+              type="checkbox"
+              checked={quickCut}
+              onChange={e => setQuickCut(e.target.checked)}
+              style={{ accentColor: 'var(--color-error)' }}
+            />
+            Quick cut
+          </label>
+        )}
+
+        <button className="btn btn--ghost btn--sm" onClick={fetchAll} title="Refresh">↺</button>
       </div>
 
       {error && (
         <div style={{ color: 'var(--color-error)', marginBottom: 12, fontSize: 13 }}>{error}</div>
       )}
 
+      {/* Mixer status bar */}
+      <MixerStatusBar mixers={mixers} />
+
       {loading ? (
-        <p style={{ color: 'var(--color-text-muted)' }}>Loading cameras…</p>
+        <p style={{ color: 'var(--color-text-muted)' }}>Loading…</p>
       ) : cameras.length === 0 ? (
         <p style={{ color: 'var(--color-text-muted)' }}>
           No cameras configured. Add cameras in the camera configuration page.
@@ -171,10 +323,29 @@ export function ProductionOperatorPage() {
             <CameraCard
               key={cam.id}
               camera={cam}
+              isLive={cam.mixerInput != null && cam.mixerInput === activeMixerInput}
+              quickCutEnabled={quickCut}
               backendUrl={backendUrl}
               headers={headers}
+              onCutToCamera={handleCutToCamera}
             />
           ))}
+        </div>
+      )}
+
+      {switching && (
+        <div style={{
+          position: 'fixed',
+          bottom: 16,
+          right: 16,
+          background: 'var(--color-surface)',
+          border: '1px solid var(--color-border)',
+          borderRadius: 6,
+          padding: '6px 12px',
+          fontSize: 13,
+          color: 'var(--color-text-muted)',
+        }}>
+          Switching…
         </div>
       )}
     </div>

--- a/packages/lcyt-web/src/components/ProductionOperatorPage.jsx
+++ b/packages/lcyt-web/src/components/ProductionOperatorPage.jsx
@@ -1,0 +1,182 @@
+import { useState, useEffect, useCallback } from 'react';
+
+const PRESET_STATE = {
+  idle:    'idle',
+  pending: 'pending',
+  ok:      'ok',
+  error:   'error',
+};
+
+function PresetButton({ preset, state, onClick }) {
+  const colors = {
+    [PRESET_STATE.idle]:    { bg: 'var(--color-surface-alt)', border: 'var(--color-border)', text: 'var(--color-text)' },
+    [PRESET_STATE.pending]: { bg: 'var(--color-surface-alt)', border: 'var(--color-border)', text: 'var(--color-text-muted)' },
+    [PRESET_STATE.ok]:      { bg: 'var(--color-success)',     border: 'var(--color-success)', text: '#fff' },
+    [PRESET_STATE.error]:   { bg: 'var(--color-error)',       border: 'var(--color-error)',   text: '#fff' },
+  };
+  const c = colors[state] ?? colors[PRESET_STATE.idle];
+
+  return (
+    <button
+      disabled={state === PRESET_STATE.pending}
+      onClick={onClick}
+      style={{
+        padding: '10px 14px',
+        borderRadius: 6,
+        border: `2px solid ${c.border}`,
+        background: c.bg,
+        color: c.text,
+        fontSize: 14,
+        fontWeight: 500,
+        cursor: state === PRESET_STATE.pending ? 'wait' : 'pointer',
+        transition: 'background 0.2s, border-color 0.2s',
+        minWidth: 80,
+      }}
+    >
+      {state === PRESET_STATE.pending ? '…' : preset.name}
+    </button>
+  );
+}
+
+function CameraCard({ camera, backendUrl, headers }) {
+  // Map of presetId → PRESET_STATE
+  const [presetStates, setPresetStates] = useState({});
+
+  const presets = camera.controlConfig?.presets ?? [];
+  const hasPresets = camera.controlType !== 'none' && presets.length > 0;
+
+  async function triggerPreset(presetId) {
+    setPresetStates(prev => ({ ...prev, [presetId]: PRESET_STATE.pending }));
+    try {
+      const r = await fetch(
+        `${backendUrl}/production/cameras/${camera.id}/preset/${encodeURIComponent(presetId)}`,
+        { method: 'POST', headers }
+      );
+      const nextState = r.ok ? PRESET_STATE.ok : PRESET_STATE.error;
+      setPresetStates(prev => ({ ...prev, [presetId]: nextState }));
+      // Reset to idle after brief feedback
+      setTimeout(() => {
+        setPresetStates(prev => ({ ...prev, [presetId]: PRESET_STATE.idle }));
+      }, 1500);
+    } catch {
+      setPresetStates(prev => ({ ...prev, [presetId]: PRESET_STATE.error }));
+      setTimeout(() => {
+        setPresetStates(prev => ({ ...prev, [presetId]: PRESET_STATE.idle }));
+      }, 2000);
+    }
+  }
+
+  return (
+    <div style={{
+      border: '1px solid var(--color-border)',
+      borderRadius: 8,
+      padding: 16,
+      display: 'flex',
+      flexDirection: 'column',
+      gap: 10,
+      background: 'var(--color-surface)',
+      minWidth: 180,
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span style={{ fontWeight: 700, fontSize: 15 }}>{camera.name}</span>
+        {camera.mixerInput != null && (
+          <span style={{
+            fontSize: 11,
+            padding: '2px 6px',
+            borderRadius: 3,
+            background: 'var(--color-surface-alt)',
+            color: 'var(--color-text-muted)',
+          }}>
+            In {camera.mixerInput}
+          </span>
+        )}
+      </div>
+
+      {hasPresets ? (
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+          {presets.map(preset => (
+            <PresetButton
+              key={preset.id}
+              preset={preset}
+              state={presetStates[preset.id] ?? PRESET_STATE.idle}
+              onClick={() => triggerPreset(preset.id)}
+            />
+          ))}
+        </div>
+      ) : (
+        <span style={{ fontSize: 12, color: 'var(--color-text-muted)' }}>
+          {camera.controlType === 'none' ? 'Mixer input only' : 'No presets configured'}
+        </span>
+      )}
+    </div>
+  );
+}
+
+export function ProductionOperatorPage() {
+  const params = new URLSearchParams(window.location.search);
+  const backendUrl = params.get('server') || localStorage.getItem('lcyt-backend-url') || '';
+  const apiKey = params.get('apikey') || '';
+  const token = params.get('token') || localStorage.getItem('lcyt-token') || '';
+
+  const [cameras, setCameras] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const headers = {
+    'Content-Type': 'application/json',
+    ...(token    ? { Authorization: `Bearer ${token}` } : {}),
+    ...(apiKey   ? { 'X-Admin-Key': apiKey } : {}),
+  };
+
+  const fetchCameras = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const r = await fetch(`${backendUrl}/production/cameras`, { headers });
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      setCameras(await r.json());
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [backendUrl, apiKey, token]);
+
+  useEffect(() => { fetchCameras(); }, [fetchCameras]);
+
+  return (
+    <div style={{ padding: 20 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 20 }}>
+        <h2 style={{ margin: 0, fontSize: 20 }}>Production Control</h2>
+        <button className="btn btn--ghost btn--sm" onClick={fetchCameras} title="Refresh">↺</button>
+      </div>
+
+      {error && (
+        <div style={{ color: 'var(--color-error)', marginBottom: 12, fontSize: 13 }}>{error}</div>
+      )}
+
+      {loading ? (
+        <p style={{ color: 'var(--color-text-muted)' }}>Loading cameras…</p>
+      ) : cameras.length === 0 ? (
+        <p style={{ color: 'var(--color-text-muted)' }}>
+          No cameras configured. Add cameras in the camera configuration page.
+        </p>
+      ) : (
+        <div style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))',
+          gap: 12,
+        }}>
+          {cameras.map(cam => (
+            <CameraCard
+              key={cam.id}
+              camera={cam}
+              backendUrl={backendUrl}
+              headers={headers}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/lcyt-web/src/main.jsx
+++ b/packages/lcyt-web/src/main.jsx
@@ -17,6 +17,7 @@ import { EmbedViewerPage } from './components/EmbedViewerPage';
 import { ViewerPage } from './components/ViewerPage';
 import { ProductionCamerasPage } from './components/ProductionCamerasPage';
 import { ProductionMixersPage } from './components/ProductionMixersPage';
+import { ProductionBridgesPage } from './components/ProductionBridgesPage';
 import { ProductionOperatorPage } from './components/ProductionOperatorPage';
 
 const path = window.location.pathname;
@@ -38,6 +39,7 @@ function getPage() {
   if (path.startsWith('/view/'))                    return <ViewerPage />;
   if (path.startsWith('/production/cameras'))       return <ProductionCamerasPage />;
   if (path.startsWith('/production/mixers'))        return <ProductionMixersPage />;
+  if (path.startsWith('/production/bridges'))       return <ProductionBridgesPage />;
   if (path.startsWith('/production'))               return <ProductionOperatorPage />;
   return <App />;
 }

--- a/packages/lcyt-web/src/main.jsx
+++ b/packages/lcyt-web/src/main.jsx
@@ -16,6 +16,7 @@ import { DskPage } from './components/DskPage';
 import { EmbedViewerPage } from './components/EmbedViewerPage';
 import { ViewerPage } from './components/ViewerPage';
 import { ProductionCamerasPage } from './components/ProductionCamerasPage';
+import { ProductionMixersPage } from './components/ProductionMixersPage';
 import { ProductionOperatorPage } from './components/ProductionOperatorPage';
 
 const path = window.location.pathname;
@@ -36,6 +37,7 @@ function getPage() {
   if (path.startsWith('/embed/viewer'))   return <EmbedViewerPage />;
   if (path.startsWith('/view/'))                    return <ViewerPage />;
   if (path.startsWith('/production/cameras'))       return <ProductionCamerasPage />;
+  if (path.startsWith('/production/mixers'))        return <ProductionMixersPage />;
   if (path.startsWith('/production'))               return <ProductionOperatorPage />;
   return <App />;
 }

--- a/packages/lcyt-web/src/main.jsx
+++ b/packages/lcyt-web/src/main.jsx
@@ -15,6 +15,8 @@ import { EmbedRtmpPage } from './components/EmbedRtmpPage';
 import { DskPage } from './components/DskPage';
 import { EmbedViewerPage } from './components/EmbedViewerPage';
 import { ViewerPage } from './components/ViewerPage';
+import { ProductionCamerasPage } from './components/ProductionCamerasPage';
+import { ProductionOperatorPage } from './components/ProductionOperatorPage';
 
 const path = window.location.pathname;
 
@@ -32,7 +34,9 @@ function getPage() {
   if (path.startsWith('/embed/rtmp'))     return <EmbedRtmpPage />;
   if (path.startsWith('/dsk/'))           return <DskPage />;
   if (path.startsWith('/embed/viewer'))   return <EmbedViewerPage />;
-  if (path.startsWith('/view/'))          return <ViewerPage />;
+  if (path.startsWith('/view/'))                    return <ViewerPage />;
+  if (path.startsWith('/production/cameras'))       return <ProductionCamerasPage />;
+  if (path.startsWith('/production'))               return <ProductionOperatorPage />;
   return <App />;
 }
 

--- a/packages/production-control/package.json
+++ b/packages/production-control/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "production-control",
+  "version": "0.1.0",
+  "description": "Production control layer for LCYT — camera PTZ presets and mixer source switching",
+  "type": "module",
+  "main": "src/api.js",
+  "scripts": {
+    "test": "node --test test/*.test.js"
+  },
+  "dependencies": {},
+  "author": "Juha Itäleino <jsilvanus@gmail.com>",
+  "license": "MIT",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jsilvanus/live-captions-yt.git",
+    "directory": "packages/production-control"
+  }
+}

--- a/packages/production-control/src/adapters/camera/amx.js
+++ b/packages/production-control/src/adapters/camera/amx.js
@@ -1,0 +1,163 @@
+/**
+ * AMX NetLinx camera control adapter.
+ *
+ * controlConfig shape:
+ * {
+ *   host: string,
+ *   port: number,          // typically 1319
+ *   presets: [
+ *     { id: string, name: string, command: string }
+ *   ]
+ * }
+ *
+ * The `command` string is sent verbatim over TCP — no parsing or validation.
+ * Example: "SEND_COMMAND dvCam,'PRESET-1'"
+ */
+
+import { createConnection } from 'node:net';
+
+const RECONNECT_DELAY_MS = 5_000;
+const KEEPALIVE_INTERVAL_MS = 30_000;
+
+/**
+ * Open a TCP connection to the AMX NetLinx master.
+ * Returns a connection handle used by callPreset / disconnect.
+ *
+ * @param {object} config - camera.controlConfig
+ * @returns {Promise<object>} connection handle
+ */
+export async function connect(config) {
+  return new Promise((resolve, reject) => {
+    const { host, port } = config;
+    if (!host || !port) {
+      return reject(new Error('AMX adapter: controlConfig must include host and port'));
+    }
+
+    const handle = {
+      socket: null,
+      host,
+      port,
+      connected: false,
+      destroyed: false,
+      _reconnectTimer: null,
+      _keepaliveTimer: null,
+    };
+
+    function doConnect() {
+      const socket = createConnection({ host, port }, () => {
+        handle.connected = true;
+        socket.setKeepAlive(true, KEEPALIVE_INTERVAL_MS);
+        console.info(`[amx] Connected to ${host}:${port}`);
+      });
+
+      socket.on('error', (err) => {
+        handle.connected = false;
+        console.warn(`[amx] ${host}:${port} error: ${err.message}`);
+      });
+
+      socket.on('close', () => {
+        handle.connected = false;
+        if (!handle.destroyed) {
+          console.info(`[amx] ${host}:${port} disconnected — reconnecting in ${RECONNECT_DELAY_MS}ms`);
+          handle._reconnectTimer = setTimeout(doConnect, RECONNECT_DELAY_MS);
+        }
+      });
+
+      handle.socket = socket;
+    }
+
+    // Attempt first connection; resolve immediately so the backend can start
+    // without blocking on unreachable hardware.
+    const socket = createConnection({ host, port }, () => {
+      handle.connected = true;
+      handle.socket = socket;
+      socket.setKeepAlive(true, KEEPALIVE_INTERVAL_MS);
+      console.info(`[amx] Connected to ${host}:${port}`);
+      resolve(handle);
+    });
+
+    socket.once('error', (err) => {
+      // Initial connection failed — still resolve so the registry can store
+      // the handle and retry on next command or reconnect timer.
+      handle.connected = false;
+      handle.socket = socket;
+      console.warn(`[amx] Initial connect to ${host}:${port} failed: ${err.message} — will retry`);
+      // Schedule reconnect
+      handle._reconnectTimer = setTimeout(() => {
+        handle.socket = null;
+        doConnect.call({ handle });
+      }, RECONNECT_DELAY_MS);
+      resolve(handle);
+    });
+
+    socket.on('close', () => {
+      if (handle.destroyed) return;
+      handle.connected = false;
+      console.info(`[amx] ${host}:${port} closed — reconnecting in ${RECONNECT_DELAY_MS}ms`);
+      handle._reconnectTimer = setTimeout(() => {
+        const s = createConnection({ host, port }, () => {
+          handle.connected = true;
+          handle.socket = s;
+          s.setKeepAlive(true, KEEPALIVE_INTERVAL_MS);
+          console.info(`[amx] Reconnected to ${host}:${port}`);
+        });
+        s.on('error', (err) => {
+          handle.connected = false;
+          console.warn(`[amx] Reconnect error ${host}:${port}: ${err.message}`);
+        });
+        s.on('close', () => {
+          if (!handle.destroyed) {
+            handle.connected = false;
+            handle._reconnectTimer = setTimeout(arguments.callee, RECONNECT_DELAY_MS);
+          }
+        });
+        handle.socket = s;
+      }, RECONNECT_DELAY_MS);
+    });
+
+    handle.socket = socket;
+  });
+}
+
+/**
+ * Cleanly close the TCP connection.
+ * @param {object} handle
+ */
+export async function disconnect(handle) {
+  handle.destroyed = true;
+  if (handle._reconnectTimer) clearTimeout(handle._reconnectTimer);
+  if (handle.socket) {
+    handle.socket.destroy();
+    handle.socket = null;
+  }
+  handle.connected = false;
+}
+
+/**
+ * Trigger a named preset on the camera.
+ * Looks up presetId in camera.controlConfig.presets and sends the command string verbatim.
+ *
+ * @param {object} handle - from connect()
+ * @param {object} camera - camera row from DB (with controlConfig parsed as object)
+ * @param {string} presetId
+ * @throws if preset not found or TCP write fails
+ */
+export async function callPreset(handle, camera, presetId) {
+  const presets = camera.controlConfig?.presets ?? [];
+  const preset = presets.find(p => p.id === presetId);
+  if (!preset) {
+    throw new Error(`AMX adapter: unknown preset '${presetId}' for camera '${camera.name}'`);
+  }
+
+  if (!handle.connected || !handle.socket) {
+    throw new Error(`AMX adapter: device ${handle.host}:${handle.port} is not connected`);
+  }
+
+  return new Promise((resolve, reject) => {
+    const payload = preset.command + '\r\n';
+    handle.socket.write(payload, 'utf8', (err) => {
+      if (err) return reject(new Error(`AMX adapter: TCP write failed: ${err.message}`));
+      resolve();
+    });
+  });
+}

--- a/packages/production-control/src/adapters/camera/none.js
+++ b/packages/production-control/src/adapters/camera/none.js
@@ -1,0 +1,16 @@
+/**
+ * No-op camera adapter for mixer-only cameras.
+ * Satisfies the adapter interface but performs no TCP operations.
+ */
+
+export async function connect(_config) {
+  return { type: 'none', connected: true };
+}
+
+export async function disconnect(_handle) {
+  // nothing to close
+}
+
+export async function callPreset(_handle, camera, _presetId) {
+  throw new Error(`Camera '${camera.name}' has no camera control (controlType: none)`);
+}

--- a/packages/production-control/src/adapters/mixer/amx.js
+++ b/packages/production-control/src/adapters/mixer/amx.js
@@ -1,0 +1,134 @@
+/**
+ * AMX NetLinx mixer/switcher adapter.
+ *
+ * Used when an AMX NetLinx master controls a video router or switcher.
+ * The switch commands are user-defined strings (verbatim TCP), just like
+ * the camera AMX adapter. This lets any AMX-controlled matrix or router
+ * work without code changes.
+ *
+ * connectionConfig shape:
+ * {
+ *   host: string,
+ *   port: number,      // typically 1319
+ *   inputs: [
+ *     { number: 1, command: "SEND_COMMAND dvRouter,'INPUT-1'" },
+ *     { number: 2, command: "SEND_COMMAND dvRouter,'INPUT-2'" },
+ *     ...
+ *   ]
+ * }
+ *
+ * No command syntax is validated — the adapter sends exactly what is configured.
+ */
+
+import { createConnection } from 'node:net';
+
+const RECONNECT_DELAY_MS = 5_000;
+const KEEPALIVE_INTERVAL_MS = 30_000;
+
+export async function connect(config) {
+  return new Promise((resolve) => {
+    const { host, port = 1319 } = config;
+    if (!host) {
+      const handle = { connected: false, host: '', port, destroyed: false, _activeSource: null, _socket: null };
+      console.warn('[amx-mixer] connectionConfig.host is required');
+      resolve(handle);
+      return;
+    }
+
+    const handle = {
+      _socket: null,
+      host,
+      port,
+      connected: false,
+      destroyed: false,
+      _activeSource: null,
+      _reconnectTimer: null,
+    };
+
+    function openSocket(onFirstConnect) {
+      if (handle.destroyed) return;
+      const socket = createConnection({ host, port }, () => {
+        handle.connected = true;
+        socket.setKeepAlive(true, KEEPALIVE_INTERVAL_MS);
+        console.info(`[amx-mixer] Connected to ${host}:${port}`);
+        if (onFirstConnect) onFirstConnect();
+      });
+
+      socket.on('error', (err) => {
+        handle.connected = false;
+        console.warn(`[amx-mixer] ${host}:${port} error: ${err.message}`);
+      });
+
+      socket.on('close', () => {
+        handle.connected = false;
+        handle._socket = null;
+        if (!handle.destroyed) {
+          console.info(`[amx-mixer] ${host}:${port} disconnected — reconnecting in ${RECONNECT_DELAY_MS}ms`);
+          handle._reconnectTimer = setTimeout(() => openSocket(null), RECONNECT_DELAY_MS);
+        }
+      });
+
+      handle._socket = socket;
+    }
+
+    const resolveTimer = setTimeout(() => resolve(handle), 3_000);
+    openSocket(() => { clearTimeout(resolveTimer); resolve(handle); });
+  });
+}
+
+export async function disconnect(handle) {
+  handle.destroyed = true;
+  if (handle._reconnectTimer) clearTimeout(handle._reconnectTimer);
+  if (handle._socket) {
+    handle._socket.destroy();
+    handle._socket = null;
+  }
+  handle.connected = false;
+}
+
+/**
+ * Switch the video source to the given input number.
+ * Looks up inputNumber in connectionConfig.inputs, sends command verbatim.
+ *
+ * @param {object} handle
+ * @param {number} inputNumber  1-based input number
+ * @param {object} mixer        mixer row with connectionConfig already parsed
+ */
+export async function switchSource(handle, inputNumber, mixer) {
+  if (!handle.connected || !handle._socket) {
+    throw new Error(`AMX mixer ${handle.host}:${handle.port} is not connected`);
+  }
+  const command = getSwitchCommand(mixer.connectionConfig, inputNumber);
+  return new Promise((resolve, reject) => {
+    handle._socket.write(command, 'utf8', (err) => {
+      if (err) return reject(new Error(`AMX mixer TCP write failed: ${err.message}`));
+      handle._activeSource = inputNumber;
+      resolve();
+    });
+  });
+}
+
+/**
+ * Return the currently active input, or null if unknown.
+ * AMX does not report state — maintained in memory on each switchSource call.
+ */
+export function getActiveSource(handle) {
+  return handle._activeSource;
+}
+
+/**
+ * Build the TCP command string for switching to inputNumber.
+ * Used by bridge routing (generates the string without executing the TCP send).
+ *
+ * @param {object} connectionConfig
+ * @param {number} inputNumber
+ * @returns {string} command string with CRLF terminator
+ */
+export function getSwitchCommand(connectionConfig, inputNumber) {
+  const inputs = connectionConfig?.inputs ?? [];
+  const entry = inputs.find(i => i.number === inputNumber);
+  if (!entry) {
+    throw new Error(`AMX mixer: no command configured for input ${inputNumber}`);
+  }
+  return entry.command + '\r\n';
+}

--- a/packages/production-control/src/adapters/mixer/roland.js
+++ b/packages/production-control/src/adapters/mixer/roland.js
@@ -174,7 +174,7 @@ export async function disconnect(handle) {
  * @param {object} handle
  * @param {number} inputNumber - 1-based mixer input number
  */
-export async function switchSource(handle, inputNumber) {
+export async function switchSource(handle, inputNumber, _mixer) {
   if (!handle.connected || !handle._socket) {
     throw new Error(`Roland mixer ${handle.host}:${handle.port} is not connected`);
   }
@@ -198,6 +198,17 @@ export async function switchSource(handle, inputNumber) {
  */
 export function getActiveSource(handle) {
   return handle._activeSource;
+}
+
+/**
+ * Build the TCP command string for switching to inputNumber.
+ * Used by bridge routing (generates without executing the TCP send).
+ *
+ * @param {number} inputNumber
+ * @returns {string} newline-terminated JSON command
+ */
+export function getSwitchCommand(_connectionConfig, inputNumber) {
+  return CMD_SWITCH_PROGRAM(inputNumber);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/production-control/src/adapters/mixer/roland.js
+++ b/packages/production-control/src/adapters/mixer/roland.js
@@ -1,0 +1,220 @@
+/**
+ * Roland V-series mixer adapter — TCP remote control.
+ *
+ * connectionConfig shape:
+ * {
+ *   host: string,
+ *   port: number    // typically 8023
+ * }
+ *
+ * ─── Protocol notes ──────────────────────────────────────────────────────────
+ * This adapter targets the Roland V-8HD / V-60HD / V-160HD JSON-over-TCP
+ * remote control protocol (port 8023, newline-delimited JSON).
+ *
+ * IMPORTANT: Command format varies by model firmware. The named CMD_* constants
+ * below are the only place that needs to change for a different Roland model.
+ * Adapter logic (connect, reconnect, state tracking) is model-independent.
+ *
+ * To adapt for other models:
+ *   V-1HD:    Uses pipe-delimited text — update CMD_* to match its spec.
+ *   V-40HD:   Uses the same JSON format as V-8HD — no changes needed.
+ *   V-160HD:  JSON format; switch command may use "inputBus.index" (0-based).
+ *             Adjust CMD_SWITCH_PROGRAM to use `number: inputNumber - 1` if so.
+ *
+ * Verified protocol reference: Roland V-8HD firmware v1.x TCP remote control.
+ * Obtain the "Remote Control" PDF from Roland support to confirm for your model.
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+
+import { createConnection } from 'node:net';
+
+// ---------------------------------------------------------------------------
+// Protocol command constants — UPDATE THESE for different Roland models
+// ---------------------------------------------------------------------------
+
+/** Query the current program/preview tally state. */
+const CMD_GET_TALLY = (reqId = 1) =>
+  JSON.stringify({ method: 'get', id: reqId, params: { name: 'tally' } }) + '\r\n';
+
+/**
+ * Switch the program bus to the given input number (1-based).
+ * Roland V-8HD: inputBus.type 'V' = video input; number is 1-based.
+ */
+const CMD_SWITCH_PROGRAM = (inputNumber, reqId = 2) =>
+  JSON.stringify({
+    method: 'set',
+    id: reqId,
+    params: { name: 'program', inputBus: { type: 'V', number: inputNumber } },
+  }) + '\r\n';
+
+// ---------------------------------------------------------------------------
+// Reconnect / keepalive config
+// ---------------------------------------------------------------------------
+
+const RECONNECT_DELAY_MS = 5_000;
+const KEEPALIVE_INTERVAL_MS = 30_000;
+
+// ---------------------------------------------------------------------------
+// Adapter exports
+// ---------------------------------------------------------------------------
+
+/**
+ * Open a persistent TCP connection to the Roland mixer.
+ * Resolves immediately (even if device is unreachable) so the registry can
+ * store the handle and retry transparently.
+ *
+ * @param {object} config - mixer.connectionConfig
+ * @returns {Promise<object>} connection handle
+ */
+export async function connect(config) {
+  return new Promise((resolve) => {
+    const { host, port = 8023 } = config;
+    if (!host) {
+      const handle = { connected: false, host: '', port, destroyed: false, _activeSource: null, _socket: null };
+      console.warn('[roland] connectionConfig.host is required');
+      resolve(handle);
+      return;
+    }
+
+    const handle = {
+      _socket: null,
+      host,
+      port,
+      connected: false,
+      destroyed: false,
+      /** Maintained in memory; updated on every switchSource call. */
+      _activeSource: null,
+      _reconnectTimer: null,
+      _lineBuffer: '',
+    };
+
+    function openSocket(onFirstConnect) {
+      if (handle.destroyed) return;
+      const socket = createConnection({ host, port }, () => {
+        handle.connected = true;
+        socket.setKeepAlive(true, KEEPALIVE_INTERVAL_MS);
+        console.info(`[roland] Connected to ${host}:${port}`);
+        // Query current tally state so we know the active input at startup
+        socket.write(CMD_GET_TALLY(), 'utf8', (err) => {
+          if (err) console.warn(`[roland] GET_TALLY write failed: ${err.message}`);
+        });
+        if (onFirstConnect) onFirstConnect();
+      });
+
+      socket.setEncoding('utf8');
+      socket.on('data', (chunk) => {
+        handle._lineBuffer += chunk;
+        const lines = handle._lineBuffer.split('\n');
+        handle._lineBuffer = lines.pop(); // keep incomplete last line
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed) continue;
+          try {
+            const msg = JSON.parse(trimmed);
+            _handleMessage(handle, msg);
+          } catch {
+            // Non-JSON response or keepalive byte — ignore
+          }
+        }
+      });
+
+      socket.on('error', (err) => {
+        handle.connected = false;
+        console.warn(`[roland] ${host}:${port} error: ${err.message}`);
+      });
+
+      socket.on('close', () => {
+        handle.connected = false;
+        handle._socket = null;
+        if (!handle.destroyed) {
+          console.info(`[roland] ${host}:${port} disconnected — reconnecting in ${RECONNECT_DELAY_MS}ms`);
+          handle._reconnectTimer = setTimeout(() => openSocket(null), RECONNECT_DELAY_MS);
+        }
+      });
+
+      handle._socket = socket;
+    }
+
+    // Resolve immediately with the handle; openSocket manages connection state.
+    openSocket(() => resolve(handle));
+
+    // If first connect hasn't fired after a short timeout, still resolve
+    // (device unreachable — registry keeps the handle for later retry).
+    const resolveTimer = setTimeout(() => resolve(handle), 3_000);
+    // Cancel early resolve if we connected quickly
+    const origResolve = resolve;
+    // eslint-disable-next-line no-shadow
+    const guardedResolve = (h) => { clearTimeout(resolveTimer); origResolve(h); };
+    // Patch openSocket's onFirstConnect to use the guarded resolve
+    openSocket(() => guardedResolve(handle));
+  }).catch(() => ({
+    connected: false, host: config.host, port: config.port ?? 8023,
+    destroyed: false, _activeSource: null, _socket: null,
+  }));
+}
+
+/**
+ * Cleanly close the TCP connection.
+ * @param {object} handle
+ */
+export async function disconnect(handle) {
+  handle.destroyed = true;
+  if (handle._reconnectTimer) clearTimeout(handle._reconnectTimer);
+  if (handle._socket) {
+    handle._socket.destroy();
+    handle._socket = null;
+  }
+  handle.connected = false;
+}
+
+/**
+ * Switch the program bus to the given input number (1-based).
+ * Updates handle._activeSource optimistically before the ACK arrives.
+ *
+ * @param {object} handle
+ * @param {number} inputNumber - 1-based mixer input number
+ */
+export async function switchSource(handle, inputNumber) {
+  if (!handle.connected || !handle._socket) {
+    throw new Error(`Roland mixer ${handle.host}:${handle.port} is not connected`);
+  }
+  return new Promise((resolve, reject) => {
+    handle._socket.write(CMD_SWITCH_PROGRAM(inputNumber), 'utf8', (err) => {
+      if (err) return reject(new Error(`Roland TCP write failed: ${err.message}`));
+      // Optimistically update active source — confirmed by tally response if device sends one
+      handle._activeSource = inputNumber;
+      resolve();
+    });
+  });
+}
+
+/**
+ * Return the currently active program input number, or null if unknown.
+ * State is maintained in memory and updated on every switchSource call and
+ * on incoming tally messages from the device.
+ *
+ * @param {object} handle
+ * @returns {number|null}
+ */
+export function getActiveSource(handle) {
+  return handle._activeSource;
+}
+
+// ---------------------------------------------------------------------------
+// Internal — parse incoming Roland messages and update handle state
+// ---------------------------------------------------------------------------
+
+function _handleMessage(handle, msg) {
+  // Tally response: { id: 1, result: { program: { inputBus: { type:'V', number:N } } } }
+  // or notification: { method: 'notify', params: { name: 'tally', ... } }
+  try {
+    const tally =
+      msg?.result?.program?.inputBus?.number ??
+      msg?.params?.program?.inputBus?.number;
+    if (typeof tally === 'number') {
+      handle._activeSource = tally;
+    }
+  } catch {
+    // Malformed — ignore
+  }
+}

--- a/packages/production-control/src/api.js
+++ b/packages/production-control/src/api.js
@@ -3,45 +3,50 @@
  *
  * Usage in lcyt-backend/src/server.js:
  *   import { createProductionRouter, initProductionControl } from 'production-control';
- *   const { registry } = await initProductionControl(db);
- *   app.use('/production', createProductionRouter(db, registry));
+ *   const { registry, bridgeManager } = await initProductionControl(db);
+ *   app.use('/production', createProductionRouter(db, registry, bridgeManager));
  */
 
 import { Router } from 'express';
 import { runMigrations } from './db.js';
 import { DeviceRegistry } from './registry.js';
+import { BridgeManager } from './bridge-manager.js';
 import { createCamerasRouter } from './routes/cameras.js';
 import { createMixersRouter } from './routes/mixers.js';
+import { createBridgeRouter } from './routes/bridge.js';
 
 /**
- * Run DB migrations and start the device registry.
+ * Run DB migrations and start the device registry and bridge manager.
  * Call once at server startup before mounting routes.
  *
  * @param {import('better-sqlite3').Database} db
- * @returns {Promise<{ registry: DeviceRegistry }>}
+ * @returns {Promise<{ registry: DeviceRegistry, bridgeManager: BridgeManager }>}
  */
 export async function initProductionControl(db) {
   runMigrations(db);
+  const bridgeManager = new BridgeManager(db);
   const registry = new DeviceRegistry(db);
   await registry.start();
-  return { registry };
+  return { registry, bridgeManager };
 }
 
 /**
- * Create the Express router for production control endpoints.
+ * Create the Express router for all production control endpoints.
  * Mount at /production in the main server.
  *
  * @param {import('better-sqlite3').Database} db
  * @param {DeviceRegistry} registry
+ * @param {BridgeManager} bridgeManager
+ * @param {object} [opts]
+ * @param {string} [opts.publicUrl]  Server's public URL for .env generation
  * @returns {import('express').Router}
  */
-export function createProductionRouter(db, registry) {
+export function createProductionRouter(db, registry, bridgeManager, opts = {}) {
   const router = Router();
 
-  router.use('/cameras', createCamerasRouter(db, registry));
-  router.use('/mixers', createMixersRouter(db, registry));
-
-  // Phase 4: router.use('/bridge', createBridgeRouter(db));
+  router.use('/cameras', createCamerasRouter(db, registry, bridgeManager));
+  router.use('/mixers',  createMixersRouter(db, registry, bridgeManager));
+  router.use('/bridge',  createBridgeRouter(db, bridgeManager, opts.publicUrl));
 
   return router;
 }

--- a/packages/production-control/src/api.js
+++ b/packages/production-control/src/api.js
@@ -1,0 +1,46 @@
+/**
+ * Production control — Express router plugin.
+ *
+ * Usage in lcyt-backend/src/server.js:
+ *   import { createProductionRouter, initProductionControl } from 'production-control';
+ *   const { registry } = await initProductionControl(db);
+ *   app.use('/production', createProductionRouter(db, registry));
+ */
+
+import { Router } from 'express';
+import { runMigrations } from './db.js';
+import { DeviceRegistry } from './registry.js';
+import { createCamerasRouter } from './routes/cameras.js';
+
+/**
+ * Run DB migrations and start the device registry.
+ * Call once at server startup before mounting routes.
+ *
+ * @param {import('better-sqlite3').Database} db
+ * @returns {Promise<{ registry: DeviceRegistry }>}
+ */
+export async function initProductionControl(db) {
+  runMigrations(db);
+  const registry = new DeviceRegistry(db);
+  await registry.start();
+  return { registry };
+}
+
+/**
+ * Create the Express router for production control endpoints.
+ * Mount at /production in the main server.
+ *
+ * @param {import('better-sqlite3').Database} db
+ * @param {DeviceRegistry} registry
+ * @returns {import('express').Router}
+ */
+export function createProductionRouter(db, registry) {
+  const router = Router();
+
+  router.use('/cameras', createCamerasRouter(db, registry));
+
+  // Phase 2: router.use('/mixers', createMixersRouter(db, registry));
+  // Phase 4: router.use('/bridge', createBridgeRouter(db));
+
+  return router;
+}

--- a/packages/production-control/src/api.js
+++ b/packages/production-control/src/api.js
@@ -11,6 +11,7 @@ import { Router } from 'express';
 import { runMigrations } from './db.js';
 import { DeviceRegistry } from './registry.js';
 import { createCamerasRouter } from './routes/cameras.js';
+import { createMixersRouter } from './routes/mixers.js';
 
 /**
  * Run DB migrations and start the device registry.
@@ -38,8 +39,8 @@ export function createProductionRouter(db, registry) {
   const router = Router();
 
   router.use('/cameras', createCamerasRouter(db, registry));
+  router.use('/mixers', createMixersRouter(db, registry));
 
-  // Phase 2: router.use('/mixers', createMixersRouter(db, registry));
   // Phase 4: router.use('/bridge', createBridgeRouter(db));
 
   return router;

--- a/packages/production-control/src/bridge-manager.js
+++ b/packages/production-control/src/bridge-manager.js
@@ -1,0 +1,183 @@
+/**
+ * BridgeManager — manages SSE connections from lcyt-bridge agents.
+ *
+ * Each bridge authenticates with a token (looked up in prod_bridge_instances).
+ * Commands are pushed as SSE events; results arrive via POST /bridge/status.
+ *
+ * Command round-trip:
+ *   backend → SSE event { type:'tcp_send', requestId, host, port, payload }
+ *   bridge  → POST /bridge/status { requestId, ok, error? }
+ *   backend → resolves the pending Promise
+ */
+
+import { randomUUID } from 'node:crypto';
+
+const COMMAND_TIMEOUT_MS = 10_000;
+const HEARTBEAT_INTERVAL_MS = 20_000;
+
+export class BridgeManager {
+  /**
+   * @param {import('better-sqlite3').Database} db
+   */
+  constructor(db) {
+    this._db = db;
+    /** @type {Map<string, { res: object, instanceId: string, heartbeatTimer: NodeJS.Timeout }>} */
+    this._connections = new Map(); // instanceId → connection
+    /** @type {Map<string, { resolve: Function, reject: Function, timer: NodeJS.Timeout }>} */
+    this._pending = new Map(); // requestId → pending callback
+  }
+
+  /**
+   * Authenticate a bridge token. Returns the BridgeInstance row or null.
+   * @param {string} token
+   * @returns {object|null}
+   */
+  authenticate(token) {
+    if (!token) return null;
+    return this._db
+      .prepare('SELECT * FROM prod_bridge_instances WHERE token = ?')
+      .get(token) ?? null;
+  }
+
+  /**
+   * Register a new SSE connection from a bridge. Kicks any existing connection
+   * for the same instance (handles crash-reconnect without manual intervention).
+   *
+   * @param {string} instanceId
+   * @param {object} res  Express response object for the SSE stream
+   */
+  connect(instanceId, res) {
+    // Kick existing connection if present
+    const existing = this._connections.get(instanceId);
+    if (existing) {
+      console.info(`[bridge] Instance ${instanceId} reconnected — kicking previous connection`);
+      clearInterval(existing.heartbeatTimer);
+      try { existing.res.end(); } catch { /* already closed */ }
+    }
+
+    // Set up SSE headers
+    res.set({
+      'Content-Type':  'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection':    'keep-alive',
+      'X-Accel-Buffering': 'no', // nginx: disable buffering for SSE
+    });
+    res.flushHeaders();
+
+    // Send an initial connected event
+    this._write(res, 'connected', { instanceId });
+
+    // Heartbeat to keep the SSE stream alive through proxies
+    const heartbeatTimer = setInterval(() => {
+      try { res.write(': heartbeat\n\n'); } catch { this.disconnect(instanceId); }
+    }, HEARTBEAT_INTERVAL_MS);
+
+    this._connections.set(instanceId, { res, instanceId, heartbeatTimer });
+
+    // Update DB status
+    this._db.prepare(
+      "UPDATE prod_bridge_instances SET status = 'connected', last_seen = datetime('now') WHERE id = ?"
+    ).run(instanceId);
+
+    // Handle client disconnect
+    res.on('close', () => this.disconnect(instanceId));
+
+    console.info(`[bridge] Instance ${instanceId} connected`);
+  }
+
+  /**
+   * Deregister a bridge connection (called on SSE close or kick).
+   * @param {string} instanceId
+   */
+  disconnect(instanceId) {
+    const conn = this._connections.get(instanceId);
+    if (!conn) return;
+    clearInterval(conn.heartbeatTimer);
+    this._connections.delete(instanceId);
+    this._db.prepare(
+      "UPDATE prod_bridge_instances SET status = 'disconnected' WHERE id = ?"
+    ).run(instanceId);
+    console.info(`[bridge] Instance ${instanceId} disconnected`);
+  }
+
+  /**
+   * @param {string} instanceId
+   * @returns {boolean}
+   */
+  isConnected(instanceId) {
+    return this._connections.has(instanceId);
+  }
+
+  /**
+   * Send a TCP relay command to the bridge and await its status response.
+   *
+   * @param {string} instanceId
+   * @param {{ host: string, port: number, payload: string }} command
+   * @returns {Promise<{ ok: boolean, error?: string }>}
+   */
+  sendCommand(instanceId, command) {
+    const conn = this._connections.get(instanceId);
+    if (!conn) {
+      return Promise.reject(new Error(`Bridge ${instanceId} is not connected`));
+    }
+
+    const requestId = randomUUID();
+
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this._pending.delete(requestId);
+        reject(new Error('Bridge command timed out'));
+      }, COMMAND_TIMEOUT_MS);
+
+      this._pending.set(requestId, { resolve, reject, timer });
+
+      this._write(conn.res, 'command', {
+        type: 'tcp_send',
+        requestId,
+        host: command.host,
+        port: command.port,
+        payload: command.payload,
+      });
+    });
+  }
+
+  /**
+   * Called by POST /bridge/status when the bridge reports a result.
+   * Resolves or rejects the matching pending Promise.
+   *
+   * @param {string} instanceId
+   * @param {{ requestId?: string, type?: string, ok?: boolean, error?: string }} body
+   */
+  receiveStatus(instanceId, body) {
+    // Update last_seen on every POST (heartbeats and results)
+    this._db.prepare(
+      "UPDATE prod_bridge_instances SET last_seen = datetime('now') WHERE id = ?"
+    ).run(instanceId);
+
+    if (!body.requestId) return; // heartbeat or informational
+
+    const pending = this._pending.get(body.requestId);
+    if (!pending) return; // timed out or duplicate
+
+    clearTimeout(pending.timer);
+    this._pending.delete(body.requestId);
+
+    if (body.ok) {
+      pending.resolve({ ok: true });
+    } else {
+      pending.reject(new Error(body.error || 'Bridge relay failed'));
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal
+  // ---------------------------------------------------------------------------
+
+  _write(res, event, data) {
+    try {
+      res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+    } catch (err) {
+      console.warn(`[bridge] SSE write failed: ${err.message}`);
+    }
+  }
+}

--- a/packages/production-control/src/db.js
+++ b/packages/production-control/src/db.js
@@ -1,0 +1,104 @@
+/**
+ * Production control DB migrations.
+ * Call runMigrations(db) with the better-sqlite3 Database instance from lcyt-backend.
+ * All migrations are additive and idempotent — safe to run on existing databases.
+ */
+
+export function runMigrations(db) {
+  // bridge_instances — each physical bridge agent (streaming computer)
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS prod_bridge_instances (
+      id          TEXT PRIMARY KEY,
+      name        TEXT NOT NULL,
+      token       TEXT NOT NULL UNIQUE,
+      status      TEXT NOT NULL DEFAULT 'disconnected',
+      last_seen   TEXT,
+      created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+    )
+  `);
+
+  // cameras — one row per physical camera
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS prod_cameras (
+      id                  TEXT PRIMARY KEY,
+      name                TEXT NOT NULL,
+      mixer_input         INTEGER,
+      control_type        TEXT NOT NULL DEFAULT 'none',
+      control_config      TEXT NOT NULL DEFAULT '{}',
+      bridge_instance_id  TEXT REFERENCES prod_bridge_instances(id) ON DELETE SET NULL,
+      sort_order          INTEGER NOT NULL DEFAULT 0,
+      created_at          TEXT NOT NULL DEFAULT (datetime('now'))
+    )
+  `);
+
+  // mixers — one row per physical mixer / switcher
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS prod_mixers (
+      id                  TEXT PRIMARY KEY,
+      name                TEXT NOT NULL,
+      type                TEXT NOT NULL,
+      connection_config   TEXT NOT NULL DEFAULT '{}',
+      bridge_instance_id  TEXT REFERENCES prod_bridge_instances(id) ON DELETE SET NULL,
+      created_at          TEXT NOT NULL DEFAULT (datetime('now'))
+    )
+  `);
+}
+
+/**
+ * Seed the database with example cameras for development.
+ * Only inserts if no cameras exist yet.
+ * @param {import('better-sqlite3').Database} db
+ */
+export function seedDevData(db) {
+  const count = db.prepare('SELECT COUNT(*) AS n FROM prod_cameras').get().n;
+  if (count > 0) return;
+
+  const cameras = [
+    {
+      id: 'cam-altar',
+      name: 'Altar',
+      mixer_input: 1,
+      control_type: 'amx',
+      control_config: JSON.stringify({
+        host: '192.168.2.50',
+        port: 1319,
+        presets: [
+          { id: 'wide',  name: 'Wide',    command: "SEND_COMMAND dvCam1,'PRESET-1'" },
+          { id: 'close', name: 'Close-up', command: "SEND_COMMAND dvCam1,'PRESET-2'" },
+          { id: 'cross', name: 'Cross',   command: "SEND_COMMAND dvCam1,'PRESET-3'" },
+        ],
+      }),
+      sort_order: 0,
+    },
+    {
+      id: 'cam-pulpit',
+      name: 'Pulpit',
+      mixer_input: 2,
+      control_type: 'amx',
+      control_config: JSON.stringify({
+        host: '192.168.2.50',
+        port: 1319,
+        presets: [
+          { id: 'wide',  name: 'Wide',    command: "SEND_COMMAND dvCam2,'PRESET-1'" },
+          { id: 'close', name: 'Close-up', command: "SEND_COMMAND dvCam2,'PRESET-2'" },
+        ],
+      }),
+      sort_order: 1,
+    },
+    {
+      id: 'cam-overview',
+      name: 'Overview',
+      mixer_input: 3,
+      control_type: 'none',
+      control_config: JSON.stringify({}),
+      sort_order: 2,
+    },
+  ];
+
+  const insert = db.prepare(`
+    INSERT INTO prod_cameras (id, name, mixer_input, control_type, control_config, sort_order)
+    VALUES (@id, @name, @mixer_input, @control_type, @control_config, @sort_order)
+  `);
+  const insertAll = db.transaction((rows) => rows.forEach(r => insert.run(r)));
+  insertAll(cameras);
+}

--- a/packages/production-control/src/registry.js
+++ b/packages/production-control/src/registry.js
@@ -6,6 +6,7 @@
 
 import * as amxAdapter from './adapters/camera/amx.js';
 import * as noneAdapter from './adapters/camera/none.js';
+import * as rolandAdapter from './adapters/mixer/roland.js';
 
 // ---------------------------------------------------------------------------
 // Adapter maps
@@ -17,7 +18,8 @@ const CAMERA_ADAPTERS = {
 };
 
 const MIXER_ADAPTERS = {
-  // Phase 2+: roland, atem, obs
+  roland: rolandAdapter,
+  // Phase 6+: atem, obs
 };
 
 /**
@@ -52,9 +54,9 @@ export class DeviceRegistry {
    */
   constructor(db) {
     this._db = db;
-    /** @type {Map<string, object>} cameraId → connection handle */
+    /** @type {Map<string, { adapter: object, handle: object }>} cameraId → entry */
     this._cameraConnections = new Map();
-    /** @type {Map<string, object>} mixerId → connection handle */
+    /** @type {Map<string, { adapter: object, handle: object }>} mixerId → entry */
     this._mixerConnections = new Map();
   }
 
@@ -84,15 +86,19 @@ export class DeviceRegistry {
   /** Gracefully disconnect all devices. */
   async stop() {
     const cameraDisconnects = [...this._cameraConnections.entries()].map(async ([id, { adapter, handle }]) => {
-      try { await adapter.disconnect(handle); } catch (e) { /* ignore */ }
+      try { await adapter.disconnect(handle); } catch { /* ignore */ }
       this._cameraConnections.delete(id);
     });
     const mixerDisconnects = [...this._mixerConnections.entries()].map(async ([id, { adapter, handle }]) => {
-      try { await adapter.disconnect(handle); } catch (e) { /* ignore */ }
+      try { await adapter.disconnect(handle); } catch { /* ignore */ }
       this._mixerConnections.delete(id);
     });
     await Promise.all([...cameraDisconnects, ...mixerDisconnects]);
   }
+
+  // ---------------------------------------------------------------------------
+  // Camera operations
+  // ---------------------------------------------------------------------------
 
   /**
    * Trigger a preset for a camera by id.
@@ -113,7 +119,7 @@ export class DeviceRegistry {
   async reloadCamera(cameraId) {
     const existing = this._cameraConnections.get(cameraId);
     if (existing) {
-      try { await existing.adapter.disconnect(existing.handle); } catch (e) { /* ignore */ }
+      try { await existing.adapter.disconnect(existing.handle); } catch { /* ignore */ }
       this._cameraConnections.delete(cameraId);
     }
     const camera = this._loadCamera(cameraId);
@@ -127,8 +133,71 @@ export class DeviceRegistry {
   async removeCamera(cameraId) {
     const existing = this._cameraConnections.get(cameraId);
     if (existing) {
-      try { await existing.adapter.disconnect(existing.handle); } catch (e) { /* ignore */ }
+      try { await existing.adapter.disconnect(existing.handle); } catch { /* ignore */ }
       this._cameraConnections.delete(cameraId);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Mixer operations
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Switch the program source on a mixer.
+   * @param {string} mixerId
+   * @param {number} inputNumber  1-based input number
+   */
+  async switchSource(mixerId, inputNumber) {
+    const mixer = this._loadMixer(mixerId);
+    const entry = this._mixerConnections.get(mixerId);
+    if (!entry) throw new Error(`No connection for mixer '${mixer.name}'`);
+    await entry.adapter.switchSource(entry.handle, inputNumber);
+  }
+
+  /**
+   * Return the active program source for a mixer, or null if unknown.
+   * @param {string} mixerId
+   * @returns {number|null}
+   */
+  getActiveSource(mixerId) {
+    const entry = this._mixerConnections.get(mixerId);
+    if (!entry) return null;
+    return entry.adapter.getActiveSource(entry.handle);
+  }
+
+  /**
+   * Return whether a mixer TCP connection is currently established.
+   * @param {string} mixerId
+   * @returns {boolean}
+   */
+  isMixerConnected(mixerId) {
+    const entry = this._mixerConnections.get(mixerId);
+    return entry?.handle?.connected === true;
+  }
+
+  /**
+   * Reload a single mixer's connection (e.g. after config update).
+   * @param {string} mixerId
+   */
+  async reloadMixer(mixerId) {
+    const existing = this._mixerConnections.get(mixerId);
+    if (existing) {
+      try { await existing.adapter.disconnect(existing.handle); } catch { /* ignore */ }
+      this._mixerConnections.delete(mixerId);
+    }
+    const mixer = this._loadMixer(mixerId);
+    await this._connectMixer(mixer);
+  }
+
+  /**
+   * Remove a mixer connection (e.g. after deletion).
+   * @param {string} mixerId
+   */
+  async removeMixer(mixerId) {
+    const existing = this._mixerConnections.get(mixerId);
+    if (existing) {
+      try { await existing.adapter.disconnect(existing.handle); } catch { /* ignore */ }
+      this._mixerConnections.delete(mixerId);
     }
   }
 
@@ -160,6 +229,12 @@ export class DeviceRegistry {
     const row = this._db.prepare('SELECT * FROM prod_cameras WHERE id = ?').get(cameraId);
     if (!row) throw new Error(`Camera not found: ${cameraId}`);
     return parseCamera(row);
+  }
+
+  _loadMixer(mixerId) {
+    const row = this._db.prepare('SELECT * FROM prod_mixers WHERE id = ?').get(mixerId);
+    if (!row) throw new Error(`Mixer not found: ${mixerId}`);
+    return parseMixer(row);
   }
 }
 

--- a/packages/production-control/src/registry.js
+++ b/packages/production-control/src/registry.js
@@ -1,0 +1,189 @@
+/**
+ * Device registry.
+ * Loads cameras and mixers from the database, manages live adapter connections,
+ * and provides adapter resolution by device type.
+ */
+
+import * as amxAdapter from './adapters/camera/amx.js';
+import * as noneAdapter from './adapters/camera/none.js';
+
+// ---------------------------------------------------------------------------
+// Adapter maps
+// ---------------------------------------------------------------------------
+
+const CAMERA_ADAPTERS = {
+  amx:  amxAdapter,
+  none: noneAdapter,
+};
+
+const MIXER_ADAPTERS = {
+  // Phase 2+: roland, atem, obs
+};
+
+/**
+ * Get the camera adapter module for a given camera row.
+ * @param {{ controlType: string }} camera
+ * @returns {object} adapter with connect/disconnect/callPreset
+ */
+export function getCameraAdapter(camera) {
+  const adapter = CAMERA_ADAPTERS[camera.controlType];
+  if (!adapter) throw new Error(`unknown camera controlType: '${camera.controlType}'`);
+  return adapter;
+}
+
+/**
+ * Get the mixer adapter module for a given mixer row.
+ * @param {{ type: string }} mixer
+ * @returns {object} adapter with connect/disconnect/switchSource/getActiveSource
+ */
+export function getMixerAdapter(mixer) {
+  const adapter = MIXER_ADAPTERS[mixer.type];
+  if (!adapter) throw new Error(`unknown mixer type: '${mixer.type}'`);
+  return adapter;
+}
+
+// ---------------------------------------------------------------------------
+// Registry class
+// ---------------------------------------------------------------------------
+
+export class DeviceRegistry {
+  /**
+   * @param {import('better-sqlite3').Database} db
+   */
+  constructor(db) {
+    this._db = db;
+    /** @type {Map<string, object>} cameraId → connection handle */
+    this._cameraConnections = new Map();
+    /** @type {Map<string, object>} mixerId → connection handle */
+    this._mixerConnections = new Map();
+  }
+
+  /**
+   * Load all cameras and mixers from DB and open adapter connections.
+   * Logs warnings for unreachable devices but does not throw.
+   */
+  async start() {
+    const cameras = this._db
+      .prepare('SELECT * FROM prod_cameras ORDER BY sort_order, created_at')
+      .all()
+      .map(parseCamera);
+
+    const mixers = this._db
+      .prepare('SELECT * FROM prod_mixers ORDER BY created_at')
+      .all()
+      .map(parseMixer);
+
+    await Promise.all([
+      ...cameras.map(cam => this._connectCamera(cam)),
+      ...mixers.map(mix => this._connectMixer(mix)),
+    ]);
+
+    console.info(`[production-control] Registry started — ${cameras.length} camera(s), ${mixers.length} mixer(s)`);
+  }
+
+  /** Gracefully disconnect all devices. */
+  async stop() {
+    const cameraDisconnects = [...this._cameraConnections.entries()].map(async ([id, { adapter, handle }]) => {
+      try { await adapter.disconnect(handle); } catch (e) { /* ignore */ }
+      this._cameraConnections.delete(id);
+    });
+    const mixerDisconnects = [...this._mixerConnections.entries()].map(async ([id, { adapter, handle }]) => {
+      try { await adapter.disconnect(handle); } catch (e) { /* ignore */ }
+      this._mixerConnections.delete(id);
+    });
+    await Promise.all([...cameraDisconnects, ...mixerDisconnects]);
+  }
+
+  /**
+   * Trigger a preset for a camera by id.
+   * @param {string} cameraId
+   * @param {string} presetId
+   */
+  async callPreset(cameraId, presetId) {
+    const camera = this._loadCamera(cameraId);
+    const entry = this._cameraConnections.get(cameraId);
+    if (!entry) throw new Error(`No connection for camera '${camera.name}'`);
+    await entry.adapter.callPreset(entry.handle, camera, presetId);
+  }
+
+  /**
+   * Reload a single camera's connection (e.g. after config update).
+   * @param {string} cameraId
+   */
+  async reloadCamera(cameraId) {
+    const existing = this._cameraConnections.get(cameraId);
+    if (existing) {
+      try { await existing.adapter.disconnect(existing.handle); } catch (e) { /* ignore */ }
+      this._cameraConnections.delete(cameraId);
+    }
+    const camera = this._loadCamera(cameraId);
+    await this._connectCamera(camera);
+  }
+
+  /**
+   * Remove a camera connection (e.g. after deletion).
+   * @param {string} cameraId
+   */
+  async removeCamera(cameraId) {
+    const existing = this._cameraConnections.get(cameraId);
+    if (existing) {
+      try { await existing.adapter.disconnect(existing.handle); } catch (e) { /* ignore */ }
+      this._cameraConnections.delete(cameraId);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------------
+
+  async _connectCamera(camera) {
+    const adapter = getCameraAdapter(camera);
+    try {
+      const handle = await adapter.connect(camera.controlConfig);
+      this._cameraConnections.set(camera.id, { adapter, handle });
+    } catch (err) {
+      console.warn(`[production-control] Could not connect camera '${camera.name}': ${err.message}`);
+    }
+  }
+
+  async _connectMixer(mixer) {
+    try {
+      const adapter = getMixerAdapter(mixer);
+      const handle = await adapter.connect(mixer.connectionConfig);
+      this._mixerConnections.set(mixer.id, { adapter, handle });
+    } catch (err) {
+      console.warn(`[production-control] Could not connect mixer '${mixer.name}': ${err.message}`);
+    }
+  }
+
+  _loadCamera(cameraId) {
+    const row = this._db.prepare('SELECT * FROM prod_cameras WHERE id = ?').get(cameraId);
+    if (!row) throw new Error(`Camera not found: ${cameraId}`);
+    return parseCamera(row);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Row parsers — SQLite stores JSON as TEXT; parse on read
+// ---------------------------------------------------------------------------
+
+export function parseCamera(row) {
+  return {
+    ...row,
+    mixerInput: row.mixer_input,
+    controlType: row.control_type,
+    controlConfig: JSON.parse(row.control_config || '{}'),
+    bridgeInstanceId: row.bridge_instance_id,
+    sortOrder: row.sort_order,
+    createdAt: row.created_at,
+  };
+}
+
+export function parseMixer(row) {
+  return {
+    ...row,
+    connectionConfig: JSON.parse(row.connection_config || '{}'),
+    bridgeInstanceId: row.bridge_instance_id,
+    createdAt: row.created_at,
+  };
+}

--- a/packages/production-control/src/registry.js
+++ b/packages/production-control/src/registry.js
@@ -7,6 +7,7 @@
 import * as amxAdapter from './adapters/camera/amx.js';
 import * as noneAdapter from './adapters/camera/none.js';
 import * as rolandAdapter from './adapters/mixer/roland.js';
+import * as amxMixerAdapter from './adapters/mixer/amx.js';
 
 // ---------------------------------------------------------------------------
 // Adapter maps
@@ -19,6 +20,7 @@ const CAMERA_ADAPTERS = {
 
 const MIXER_ADAPTERS = {
   roland: rolandAdapter,
+  amx:    amxMixerAdapter,
   // Phase 6+: atem, obs
 };
 
@@ -151,7 +153,8 @@ export class DeviceRegistry {
     const mixer = this._loadMixer(mixerId);
     const entry = this._mixerConnections.get(mixerId);
     if (!entry) throw new Error(`No connection for mixer '${mixer.name}'`);
-    await entry.adapter.switchSource(entry.handle, inputNumber);
+    // Pass mixer so adapters that need connectionConfig (e.g. AMX) can look up commands
+    await entry.adapter.switchSource(entry.handle, inputNumber, mixer);
   }
 
   /**

--- a/packages/production-control/src/routes/bridge.js
+++ b/packages/production-control/src/routes/bridge.js
@@ -1,0 +1,132 @@
+import { Router } from 'express';
+import { randomBytes, randomUUID } from 'node:crypto';
+
+/**
+ * @param {import('better-sqlite3').Database} db
+ * @param {import('../bridge-manager.js').BridgeManager} bridgeManager
+ * @param {string} [publicUrl]  Backend's public URL, used when generating .env files
+ */
+export function createBridgeRouter(db, bridgeManager, publicUrl = '') {
+
+  const router = Router();
+
+  // ── SSE stream: bridge agent connects here ────────────────────────────────
+
+  // GET /production/bridge/commands?token=xxx
+  router.get('/commands', (req, res) => {
+    const token = req.query.token;
+    const instance = bridgeManager.authenticate(token);
+    if (!instance) {
+      return res.status(401).json({ error: 'Invalid bridge token' });
+    }
+    bridgeManager.connect(instance.id, res);
+    // connect() takes over the response — do not call res.json() after this
+  });
+
+  // POST /production/bridge/status — bridge posts heartbeats and command results
+  router.post('/status', (req, res) => {
+    const token = req.headers['x-bridge-token'] ?? req.body?.token;
+    const instance = bridgeManager.authenticate(token);
+    if (!instance) {
+      return res.status(401).json({ error: 'Invalid bridge token' });
+    }
+    bridgeManager.receiveStatus(instance.id, req.body ?? {});
+    res.json({ ok: true });
+  });
+
+  // ── Bridge instance CRUD ──────────────────────────────────────────────────
+
+  // GET /production/bridge/instances — list all bridge instances
+  router.get('/instances', (_req, res) => {
+    const rows = db.prepare('SELECT * FROM prod_bridge_instances ORDER BY created_at').all();
+    res.json(rows.map(r => ({
+      id:        r.id,
+      name:      r.name,
+      status:    bridgeManager.isConnected(r.id) ? 'connected' : 'disconnected',
+      lastSeen:  r.last_seen,
+      createdAt: r.created_at,
+      // token is never returned in list
+    })));
+  });
+
+  // POST /production/bridge/instances — create a bridge instance
+  // Returns { id, name, envContent } where envContent is the pre-filled .env
+  router.post('/instances', (req, res) => {
+    const { name } = req.body;
+    if (!name || typeof name !== 'string') {
+      return res.status(400).json({ error: 'name is required' });
+    }
+    const id    = randomUUID();
+    const token = randomBytes(32).toString('hex');
+    db.prepare(`
+      INSERT INTO prod_bridge_instances (id, name, token)
+      VALUES (?, ?, ?)
+    `).run(id, name.trim(), token);
+
+    const envContent = buildEnvContent(token, publicUrl);
+    res.status(201).json({ id, name: name.trim(), envContent });
+  });
+
+  // DELETE /production/bridge/instances/:id — delete a bridge instance
+  router.delete('/instances/:id', (req, res) => {
+    const { id } = req.params;
+    const existing = db.prepare('SELECT * FROM prod_bridge_instances WHERE id = ?').get(id);
+    if (!existing) return res.status(404).json({ error: 'Bridge instance not found' });
+
+    // Count cameras and mixers assigned to this bridge
+    const camCount = db.prepare(
+      'SELECT COUNT(*) AS n FROM prod_cameras WHERE bridge_instance_id = ?'
+    ).get(id).n;
+    const mixCount = db.prepare(
+      'SELECT COUNT(*) AS n FROM prod_mixers WHERE bridge_instance_id = ?'
+    ).get(id).n;
+
+    if (!req.query.force && (camCount > 0 || mixCount > 0)) {
+      return res.status(409).json({
+        error: 'Bridge has assigned devices',
+        cameras: camCount,
+        mixers: mixCount,
+        hint: 'Add ?force=1 to null out assignments and delete anyway',
+      });
+    }
+
+    // Null out assignments
+    db.prepare('UPDATE prod_cameras SET bridge_instance_id = NULL WHERE bridge_instance_id = ?').run(id);
+    db.prepare('UPDATE prod_mixers  SET bridge_instance_id = NULL WHERE bridge_instance_id = ?').run(id);
+    db.prepare('DELETE FROM prod_bridge_instances WHERE id = ?').run(id);
+
+    bridgeManager.disconnect(id);
+    res.status(204).end();
+  });
+
+  // GET /production/bridge/instances/:id/env — re-download the .env file
+  router.get('/instances/:id/env', (req, res) => {
+    const row = db.prepare('SELECT * FROM prod_bridge_instances WHERE id = ?').get(req.params.id);
+    if (!row) return res.status(404).json({ error: 'Bridge instance not found' });
+
+    const content = buildEnvContent(row.token, publicUrl);
+    res.set({
+      'Content-Type':        'text/plain',
+      'Content-Disposition': `attachment; filename="lcyt-bridge-${row.name.replace(/\s+/g, '-')}.env"`,
+    });
+    res.send(content);
+  });
+
+  return router;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildEnvContent(token, publicUrl) {
+  const backendUrl = publicUrl || 'https://api.lcyt.fi';
+  return [
+    '# lcyt-bridge configuration',
+    '# Place this file next to lcyt-bridge.exe and start the app.',
+    '# Keep this file private — it contains your bridge authentication token.',
+    '',
+    `BACKEND_URL=${backendUrl}`,
+    `BRIDGE_TOKEN=${token}`,
+  ].join('\n') + '\n';
+}

--- a/packages/production-control/src/routes/cameras.js
+++ b/packages/production-control/src/routes/cameras.js
@@ -1,0 +1,98 @@
+import { Router } from 'express';
+import { randomUUID } from 'node:crypto';
+import { parseCamera } from '../registry.js';
+
+export function createCamerasRouter(db, registry) {
+  const router = Router();
+
+  // GET /production/cameras — list all cameras
+  router.get('/', (_req, res) => {
+    const rows = db
+      .prepare('SELECT * FROM prod_cameras ORDER BY sort_order, created_at')
+      .all()
+      .map(parseCamera);
+    res.json(rows);
+  });
+
+  // GET /production/cameras/:id — single camera
+  router.get('/:id', (req, res) => {
+    const row = db.prepare('SELECT * FROM prod_cameras WHERE id = ?').get(req.params.id);
+    if (!row) return res.status(404).json({ error: 'Camera not found' });
+    res.json(parseCamera(row));
+  });
+
+  // POST /production/cameras — create camera
+  router.post('/', (req, res) => {
+    const { name, mixerInput, controlType = 'none', controlConfig = {}, sortOrder = 0 } = req.body;
+    if (!name || typeof name !== 'string') {
+      return res.status(400).json({ error: 'name is required' });
+    }
+    const id = randomUUID();
+    db.prepare(`
+      INSERT INTO prod_cameras (id, name, mixer_input, control_type, control_config, sort_order)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `).run(id, name, mixerInput ?? null, controlType, JSON.stringify(controlConfig), sortOrder);
+
+    const camera = parseCamera(db.prepare('SELECT * FROM prod_cameras WHERE id = ?').get(id));
+    // Asynchronously open adapter connection for the new camera
+    registry.reloadCamera(id).catch(err =>
+      console.warn(`[production-control] reloadCamera after create: ${err.message}`)
+    );
+    res.status(201).json(camera);
+  });
+
+  // PUT /production/cameras/:id — update camera
+  router.put('/:id', (req, res) => {
+    const { id } = req.params;
+    const existing = db.prepare('SELECT * FROM prod_cameras WHERE id = ?').get(id);
+    if (!existing) return res.status(404).json({ error: 'Camera not found' });
+
+    const {
+      name       = existing.name,
+      mixerInput = existing.mixer_input,
+      controlType = existing.control_type,
+      controlConfig = JSON.parse(existing.control_config),
+      sortOrder  = existing.sort_order,
+    } = req.body;
+
+    db.prepare(`
+      UPDATE prod_cameras
+      SET name = ?, mixer_input = ?, control_type = ?, control_config = ?, sort_order = ?
+      WHERE id = ?
+    `).run(name, mixerInput ?? null, controlType, JSON.stringify(controlConfig), sortOrder, id);
+
+    const camera = parseCamera(db.prepare('SELECT * FROM prod_cameras WHERE id = ?').get(id));
+    registry.reloadCamera(id).catch(err =>
+      console.warn(`[production-control] reloadCamera after update: ${err.message}`)
+    );
+    res.json(camera);
+  });
+
+  // DELETE /production/cameras/:id — delete camera
+  router.delete('/:id', (req, res) => {
+    const { id } = req.params;
+    const existing = db.prepare('SELECT * FROM prod_cameras WHERE id = ?').get(id);
+    if (!existing) return res.status(404).json({ error: 'Camera not found' });
+
+    db.prepare('DELETE FROM prod_cameras WHERE id = ?').run(id);
+    registry.removeCamera(id).catch(() => {});
+    res.status(204).end();
+  });
+
+  // POST /production/cameras/:id/preset/:presetId — trigger preset
+  router.post('/:id/preset/:presetId', async (req, res) => {
+    const { id, presetId } = req.params;
+    const existing = db.prepare('SELECT * FROM prod_cameras WHERE id = ?').get(id);
+    if (!existing) return res.status(404).json({ error: 'Camera not found' });
+
+    try {
+      await registry.callPreset(id, presetId);
+      res.json({ ok: true, cameraId: id, presetId });
+    } catch (err) {
+      const status = err.message.includes('not connected') ? 503 : 400;
+      res.status(status).json({ error: err.message });
+    }
+  });
+
+  return router;
+}

--- a/packages/production-control/src/routes/cameras.js
+++ b/packages/production-control/src/routes/cameras.js
@@ -1,8 +1,9 @@
 import { Router } from 'express';
 import { randomUUID } from 'node:crypto';
 import { parseCamera } from '../registry.js';
+import { getSwitchCommand as amxGetCommand } from '../adapters/mixer/amx.js';
 
-export function createCamerasRouter(db, registry) {
+export function createCamerasRouter(db, registry, bridgeManager = null) {
   const router = Router();
 
   // GET /production/cameras — list all cameras
@@ -23,18 +24,20 @@ export function createCamerasRouter(db, registry) {
 
   // POST /production/cameras — create camera
   router.post('/', (req, res) => {
-    const { name, mixerInput, controlType = 'none', controlConfig = {}, sortOrder = 0 } = req.body;
+    const {
+      name, mixerInput, controlType = 'none', controlConfig = {},
+      sortOrder = 0, bridgeInstanceId = null,
+    } = req.body;
     if (!name || typeof name !== 'string') {
       return res.status(400).json({ error: 'name is required' });
     }
     const id = randomUUID();
     db.prepare(`
-      INSERT INTO prod_cameras (id, name, mixer_input, control_type, control_config, sort_order)
-      VALUES (?, ?, ?, ?, ?, ?)
-    `).run(id, name, mixerInput ?? null, controlType, JSON.stringify(controlConfig), sortOrder);
+      INSERT INTO prod_cameras (id, name, mixer_input, control_type, control_config, bridge_instance_id, sort_order)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run(id, name, mixerInput ?? null, controlType, JSON.stringify(controlConfig), bridgeInstanceId, sortOrder);
 
     const camera = parseCamera(db.prepare('SELECT * FROM prod_cameras WHERE id = ?').get(id));
-    // Asynchronously open adapter connection for the new camera
     registry.reloadCamera(id).catch(err =>
       console.warn(`[production-control] reloadCamera after create: ${err.message}`)
     );
@@ -48,18 +51,21 @@ export function createCamerasRouter(db, registry) {
     if (!existing) return res.status(404).json({ error: 'Camera not found' });
 
     const {
-      name       = existing.name,
-      mixerInput = existing.mixer_input,
-      controlType = existing.control_type,
-      controlConfig = JSON.parse(existing.control_config),
-      sortOrder  = existing.sort_order,
+      name             = existing.name,
+      mixerInput       = existing.mixer_input,
+      controlType      = existing.control_type,
+      controlConfig    = JSON.parse(existing.control_config),
+      sortOrder        = existing.sort_order,
+      bridgeInstanceId = existing.bridge_instance_id,
     } = req.body;
 
     db.prepare(`
       UPDATE prod_cameras
-      SET name = ?, mixer_input = ?, control_type = ?, control_config = ?, sort_order = ?
+      SET name = ?, mixer_input = ?, control_type = ?, control_config = ?,
+          bridge_instance_id = ?, sort_order = ?
       WHERE id = ?
-    `).run(name, mixerInput ?? null, controlType, JSON.stringify(controlConfig), sortOrder, id);
+    `).run(name, mixerInput ?? null, controlType, JSON.stringify(controlConfig),
+           bridgeInstanceId ?? null, sortOrder, id);
 
     const camera = parseCamera(db.prepare('SELECT * FROM prod_cameras WHERE id = ?').get(id));
     registry.reloadCamera(id).catch(err =>
@@ -82,14 +88,35 @@ export function createCamerasRouter(db, registry) {
   // POST /production/cameras/:id/preset/:presetId — trigger preset
   router.post('/:id/preset/:presetId', async (req, res) => {
     const { id, presetId } = req.params;
-    const existing = db.prepare('SELECT * FROM prod_cameras WHERE id = ?').get(id);
-    if (!existing) return res.status(404).json({ error: 'Camera not found' });
+    const row = db.prepare('SELECT * FROM prod_cameras WHERE id = ?').get(id);
+    if (!row) return res.status(404).json({ error: 'Camera not found' });
 
     try {
-      await registry.callPreset(id, presetId);
+      const camera = parseCamera(row);
+
+      // Bridge routing: if camera is assigned to a bridge, relay via SSE
+      if (camera.bridgeInstanceId && bridgeManager) {
+        if (!bridgeManager.isConnected(camera.bridgeInstanceId)) {
+          return res.status(503).json({ error: 'Bridge is not connected' });
+        }
+        const presets = camera.controlConfig?.presets ?? [];
+        const preset  = presets.find(p => p.id === presetId);
+        if (!preset) {
+          return res.status(400).json({ error: `Unknown preset '${presetId}'` });
+        }
+        await bridgeManager.sendCommand(camera.bridgeInstanceId, {
+          host:    camera.controlConfig.host,
+          port:    camera.controlConfig.port,
+          payload: preset.command + '\r\n',
+        });
+      } else {
+        // Direct TCP via registry
+        await registry.callPreset(id, presetId);
+      }
+
       res.json({ ok: true, cameraId: id, presetId });
     } catch (err) {
-      const status = err.message.includes('not connected') ? 503 : 400;
+      const status = err.message.includes('not connected') || err.message.includes('timed out') ? 503 : 400;
       res.status(status).json({ error: err.message });
     }
   });

--- a/packages/production-control/src/routes/mixers.js
+++ b/packages/production-control/src/routes/mixers.js
@@ -2,10 +2,12 @@ import { Router } from 'express';
 import { createConnection } from 'node:net';
 import { randomUUID } from 'node:crypto';
 import { parseMixer } from '../registry.js';
+import { getSwitchCommand as rolandGetSwitchCommand } from '../adapters/mixer/roland.js';
+import { getSwitchCommand as amxGetSwitchCommand } from '../adapters/mixer/amx.js';
 
-const MIXER_TYPES = ['roland'];
+const MIXER_TYPES = ['roland', 'amx'];
 
-export function createMixersRouter(db, registry) {
+export function createMixersRouter(db, registry, bridgeManager = null) {
   const router = Router();
 
   // GET /production/mixers — list all mixers with connection status
@@ -38,7 +40,7 @@ export function createMixersRouter(db, registry) {
 
   // POST /production/mixers — create mixer
   router.post('/', (req, res) => {
-    const { name, type, connectionConfig = {} } = req.body;
+    const { name, type, connectionConfig = {}, bridgeInstanceId = null } = req.body;
     if (!name || typeof name !== 'string') {
       return res.status(400).json({ error: 'name is required' });
     }
@@ -47,9 +49,9 @@ export function createMixersRouter(db, registry) {
     }
     const id = randomUUID();
     db.prepare(`
-      INSERT INTO prod_mixers (id, name, type, connection_config)
-      VALUES (?, ?, ?, ?)
-    `).run(id, name, type, JSON.stringify(connectionConfig));
+      INSERT INTO prod_mixers (id, name, type, connection_config, bridge_instance_id)
+      VALUES (?, ?, ?, ?, ?)
+    `).run(id, name, type, JSON.stringify(connectionConfig), bridgeInstanceId);
 
     const mixer = parseMixer(db.prepare('SELECT * FROM prod_mixers WHERE id = ?').get(id));
     registry.reloadMixer(id).catch(err =>
@@ -68,6 +70,7 @@ export function createMixersRouter(db, registry) {
       name             = existing.name,
       type             = existing.type,
       connectionConfig = JSON.parse(existing.connection_config),
+      bridgeInstanceId = existing.bridge_instance_id,
     } = req.body;
 
     if (type && !MIXER_TYPES.includes(type)) {
@@ -75,8 +78,9 @@ export function createMixersRouter(db, registry) {
     }
 
     db.prepare(`
-      UPDATE prod_mixers SET name = ?, type = ?, connection_config = ? WHERE id = ?
-    `).run(name, type, JSON.stringify(connectionConfig), id);
+      UPDATE prod_mixers SET name = ?, type = ?, connection_config = ?, bridge_instance_id = ?
+      WHERE id = ?
+    `).run(name, type, JSON.stringify(connectionConfig), bridgeInstanceId ?? null, id);
 
     const mixer = parseMixer(db.prepare('SELECT * FROM prod_mixers WHERE id = ?').get(id));
     registry.reloadMixer(id).catch(err =>
@@ -103,14 +107,31 @@ export function createMixersRouter(db, registry) {
     if (!Number.isInteger(input) || input < 1) {
       return res.status(400).json({ error: 'inputNumber must be a positive integer' });
     }
-    const existing = db.prepare('SELECT * FROM prod_mixers WHERE id = ?').get(id);
-    if (!existing) return res.status(404).json({ error: 'Mixer not found' });
+    const row = db.prepare('SELECT * FROM prod_mixers WHERE id = ?').get(id);
+    if (!row) return res.status(404).json({ error: 'Mixer not found' });
 
     try {
-      await registry.switchSource(id, input);
+      const mixer = parseMixer(row);
+
+      // Bridge routing: if mixer is assigned to a bridge, relay via SSE
+      if (mixer.bridgeInstanceId && bridgeManager) {
+        if (!bridgeManager.isConnected(mixer.bridgeInstanceId)) {
+          return res.status(503).json({ error: 'Bridge is not connected' });
+        }
+        const payload = buildSwitchPayload(mixer, input);
+        await bridgeManager.sendCommand(mixer.bridgeInstanceId, {
+          host:    mixer.connectionConfig.host,
+          port:    mixer.connectionConfig.port,
+          payload,
+        });
+      } else {
+        // Direct TCP via registry
+        await registry.switchSource(id, input);
+      }
+
       res.json({ ok: true, mixerId: id, activeSource: input });
     } catch (err) {
-      const status = err.message.includes('not connected') ? 503 : 400;
+      const status = err.message.includes('not connected') || err.message.includes('timed out') ? 503 : 400;
       res.status(status).json({ error: err.message });
     }
   });
@@ -133,7 +154,8 @@ export function createMixersRouter(db, registry) {
     const row = db.prepare('SELECT * FROM prod_mixers WHERE id = ?').get(req.params.id);
     if (!row) return res.status(404).json({ error: 'Mixer not found' });
 
-    const { host, port = 8023 } = JSON.parse(row.connection_config || '{}');
+    const { host, port = row.type === 'amx' ? 1319 : 8023 } =
+      JSON.parse(row.connection_config || '{}');
     if (!host) return res.status(400).json({ ok: false, error: 'connectionConfig.host is not set' });
 
     const TIMEOUT_MS = 4_000;
@@ -151,4 +173,19 @@ export function createMixersRouter(db, registry) {
   });
 
   return router;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build the payload string to send for a mixer source switch, by type. */
+function buildSwitchPayload(mixer, inputNumber) {
+  if (mixer.type === 'roland') {
+    return rolandGetSwitchCommand(mixer.connectionConfig, inputNumber);
+  }
+  if (mixer.type === 'amx') {
+    return amxGetSwitchCommand(mixer.connectionConfig, inputNumber);
+  }
+  throw new Error(`No bridge payload builder for mixer type '${mixer.type}'`);
 }

--- a/packages/production-control/src/routes/mixers.js
+++ b/packages/production-control/src/routes/mixers.js
@@ -1,0 +1,154 @@
+import { Router } from 'express';
+import { createConnection } from 'node:net';
+import { randomUUID } from 'node:crypto';
+import { parseMixer } from '../registry.js';
+
+const MIXER_TYPES = ['roland'];
+
+export function createMixersRouter(db, registry) {
+  const router = Router();
+
+  // GET /production/mixers — list all mixers with connection status
+  router.get('/', (_req, res) => {
+    const rows = db
+      .prepare('SELECT * FROM prod_mixers ORDER BY created_at')
+      .all()
+      .map(row => {
+        const mixer = parseMixer(row);
+        return {
+          ...mixer,
+          connected: registry.isMixerConnected(mixer.id),
+          activeSource: registry.getActiveSource(mixer.id),
+        };
+      });
+    res.json(rows);
+  });
+
+  // GET /production/mixers/:id — single mixer
+  router.get('/:id', (req, res) => {
+    const row = db.prepare('SELECT * FROM prod_mixers WHERE id = ?').get(req.params.id);
+    if (!row) return res.status(404).json({ error: 'Mixer not found' });
+    const mixer = parseMixer(row);
+    res.json({
+      ...mixer,
+      connected: registry.isMixerConnected(mixer.id),
+      activeSource: registry.getActiveSource(mixer.id),
+    });
+  });
+
+  // POST /production/mixers — create mixer
+  router.post('/', (req, res) => {
+    const { name, type, connectionConfig = {} } = req.body;
+    if (!name || typeof name !== 'string') {
+      return res.status(400).json({ error: 'name is required' });
+    }
+    if (!type || !MIXER_TYPES.includes(type)) {
+      return res.status(400).json({ error: `type must be one of: ${MIXER_TYPES.join(', ')}` });
+    }
+    const id = randomUUID();
+    db.prepare(`
+      INSERT INTO prod_mixers (id, name, type, connection_config)
+      VALUES (?, ?, ?, ?)
+    `).run(id, name, type, JSON.stringify(connectionConfig));
+
+    const mixer = parseMixer(db.prepare('SELECT * FROM prod_mixers WHERE id = ?').get(id));
+    registry.reloadMixer(id).catch(err =>
+      console.warn(`[production-control] reloadMixer after create: ${err.message}`)
+    );
+    res.status(201).json({ ...mixer, connected: false, activeSource: null });
+  });
+
+  // PUT /production/mixers/:id — update mixer
+  router.put('/:id', (req, res) => {
+    const { id } = req.params;
+    const existing = db.prepare('SELECT * FROM prod_mixers WHERE id = ?').get(id);
+    if (!existing) return res.status(404).json({ error: 'Mixer not found' });
+
+    const {
+      name             = existing.name,
+      type             = existing.type,
+      connectionConfig = JSON.parse(existing.connection_config),
+    } = req.body;
+
+    if (type && !MIXER_TYPES.includes(type)) {
+      return res.status(400).json({ error: `type must be one of: ${MIXER_TYPES.join(', ')}` });
+    }
+
+    db.prepare(`
+      UPDATE prod_mixers SET name = ?, type = ?, connection_config = ? WHERE id = ?
+    `).run(name, type, JSON.stringify(connectionConfig), id);
+
+    const mixer = parseMixer(db.prepare('SELECT * FROM prod_mixers WHERE id = ?').get(id));
+    registry.reloadMixer(id).catch(err =>
+      console.warn(`[production-control] reloadMixer after update: ${err.message}`)
+    );
+    res.json({ ...mixer, connected: registry.isMixerConnected(id), activeSource: registry.getActiveSource(id) });
+  });
+
+  // DELETE /production/mixers/:id — delete mixer
+  router.delete('/:id', (req, res) => {
+    const { id } = req.params;
+    const existing = db.prepare('SELECT * FROM prod_mixers WHERE id = ?').get(id);
+    if (!existing) return res.status(404).json({ error: 'Mixer not found' });
+
+    db.prepare('DELETE FROM prod_mixers WHERE id = ?').run(id);
+    registry.removeMixer(id).catch(() => {});
+    res.status(204).end();
+  });
+
+  // POST /production/mixers/:id/switch/:inputNumber — switch program source
+  router.post('/:id/switch/:inputNumber', async (req, res) => {
+    const { id, inputNumber } = req.params;
+    const input = Number(inputNumber);
+    if (!Number.isInteger(input) || input < 1) {
+      return res.status(400).json({ error: 'inputNumber must be a positive integer' });
+    }
+    const existing = db.prepare('SELECT * FROM prod_mixers WHERE id = ?').get(id);
+    if (!existing) return res.status(404).json({ error: 'Mixer not found' });
+
+    try {
+      await registry.switchSource(id, input);
+      res.json({ ok: true, mixerId: id, activeSource: input });
+    } catch (err) {
+      const status = err.message.includes('not connected') ? 503 : 400;
+      res.status(status).json({ error: err.message });
+    }
+  });
+
+  // GET /production/mixers/:id/active — current active input
+  router.get('/:id/active', (req, res) => {
+    const { id } = req.params;
+    const existing = db.prepare('SELECT * FROM prod_mixers WHERE id = ?').get(id);
+    if (!existing) return res.status(404).json({ error: 'Mixer not found' });
+
+    res.json({
+      mixerId: id,
+      activeSource: registry.getActiveSource(id),
+      connected: registry.isMixerConnected(id),
+    });
+  });
+
+  // POST /production/mixers/:id/test — test TCP reachability (no persistent connection)
+  router.post('/:id/test', async (req, res) => {
+    const row = db.prepare('SELECT * FROM prod_mixers WHERE id = ?').get(req.params.id);
+    if (!row) return res.status(404).json({ error: 'Mixer not found' });
+
+    const { host, port = 8023 } = JSON.parse(row.connection_config || '{}');
+    if (!host) return res.status(400).json({ ok: false, error: 'connectionConfig.host is not set' });
+
+    const TIMEOUT_MS = 4_000;
+    const result = await new Promise((resolve) => {
+      const socket = createConnection({ host, port: Number(port) }, () => {
+        socket.destroy();
+        resolve({ ok: true });
+      });
+      socket.setTimeout(TIMEOUT_MS);
+      socket.on('timeout', () => { socket.destroy(); resolve({ ok: false, error: 'Connection timed out' }); });
+      socket.on('error', (err) => resolve({ ok: false, error: err.message }));
+    });
+
+    res.status(result.ok ? 200 : 502).json({ ...result, host, port });
+  });
+
+  return router;
+}

--- a/packages/production-control/test/adapters.test.js
+++ b/packages/production-control/test/adapters.test.js
@@ -1,0 +1,151 @@
+import { test, describe, mock } from 'node:test';
+import assert from 'node:assert/strict';
+
+// ---------------------------------------------------------------------------
+// AMX adapter — unit tests (no live TCP; net.createConnection is mocked)
+// ---------------------------------------------------------------------------
+
+describe('AMX adapter', () => {
+  /**
+   * Build a fake AMX handle that simulates a connected socket without real TCP.
+   */
+  function makeHandle(connected = true) {
+    const written = [];
+    const socket = {
+      write(data, _enc, cb) { written.push(data); if (cb) cb(null); },
+      setKeepAlive() {},
+      destroy() {},
+      on() {},
+      once() {},
+    };
+    return { socket, connected, host: '127.0.0.1', port: 1319, destroyed: false, written };
+  }
+
+  function makeCamera(presets = []) {
+    return {
+      name: 'Test Cam',
+      controlConfig: {
+        host: '127.0.0.1',
+        port: 1319,
+        presets,
+      },
+    };
+  }
+
+  test('callPreset sends command verbatim over TCP', async (t) => {
+    // Import the module under test
+    const { callPreset } = await import('../src/adapters/camera/amx.js');
+    const handle = makeHandle(true);
+    const camera = makeCamera([
+      { id: 'wide', name: 'Wide', command: "SEND_COMMAND dvCam,'PRESET-1'" },
+    ]);
+
+    await callPreset(handle, camera, 'wide');
+
+    assert.equal(handle.written.length, 1);
+    assert.equal(handle.written[0], "SEND_COMMAND dvCam,'PRESET-1'\r\n");
+  });
+
+  test('callPreset throws for unknown presetId', async () => {
+    const { callPreset } = await import('../src/adapters/camera/amx.js');
+    const handle = makeHandle(true);
+    const camera = makeCamera([{ id: 'wide', name: 'Wide', command: 'CMD' }]);
+
+    await assert.rejects(
+      () => callPreset(handle, camera, 'missing'),
+      /unknown preset 'missing'/
+    );
+  });
+
+  test('callPreset throws when not connected', async () => {
+    const { callPreset } = await import('../src/adapters/camera/amx.js');
+    const handle = makeHandle(false);
+    const camera = makeCamera([{ id: 'wide', name: 'Wide', command: 'CMD' }]);
+
+    await assert.rejects(
+      () => callPreset(handle, camera, 'wide'),
+      /not connected/
+    );
+  });
+
+  test('callPreset passes command string unchanged (no transformation)', async () => {
+    const { callPreset } = await import('../src/adapters/camera/amx.js');
+    const rawCommand = "SEND_COMMAND dvCam,\"POSITION 123,456,789\"";
+    const handle = makeHandle(true);
+    const camera = makeCamera([{ id: 'p1', name: 'P1', command: rawCommand }]);
+
+    await callPreset(handle, camera, 'p1');
+
+    // The payload sent must be exactly rawCommand + CRLF, no alteration
+    assert.equal(handle.written[0], rawCommand + '\r\n');
+  });
+
+  test('callPreset works with empty presets array gives clear error', async () => {
+    const { callPreset } = await import('../src/adapters/camera/amx.js');
+    const handle = makeHandle(true);
+    const camera = makeCamera([]);
+
+    await assert.rejects(
+      () => callPreset(handle, camera, 'wide'),
+      /unknown preset 'wide'/
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// `none` adapter — unit tests
+// ---------------------------------------------------------------------------
+
+describe('none adapter', () => {
+  test('connect returns a handle with connected=true', async () => {
+    const { connect } = await import('../src/adapters/camera/none.js');
+    const handle = await connect({});
+    assert.equal(handle.connected, true);
+    assert.equal(handle.type, 'none');
+  });
+
+  test('disconnect does not throw', async () => {
+    const { connect, disconnect } = await import('../src/adapters/camera/none.js');
+    const handle = await connect({});
+    await assert.doesNotReject(() => disconnect(handle));
+  });
+
+  test('callPreset throws with a descriptive error', async () => {
+    const { connect, callPreset } = await import('../src/adapters/camera/none.js');
+    const handle = await connect({});
+    const camera = { name: 'Overview', controlConfig: {} };
+    await assert.rejects(
+      () => callPreset(handle, camera, 'wide'),
+      /no camera control/
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Registry — adapter resolution tests
+// ---------------------------------------------------------------------------
+
+describe('registry getCameraAdapter', () => {
+  test('returns amx adapter for controlType amx', async () => {
+    const { getCameraAdapter } = await import('../src/registry.js');
+    const camera = { controlType: 'amx' };
+    const adapter = getCameraAdapter(camera);
+    assert.ok(typeof adapter.callPreset === 'function');
+    assert.ok(typeof adapter.connect === 'function');
+  });
+
+  test('returns none adapter for controlType none', async () => {
+    const { getCameraAdapter } = await import('../src/registry.js');
+    const camera = { controlType: 'none' };
+    const adapter = getCameraAdapter(camera);
+    assert.ok(typeof adapter.callPreset === 'function');
+  });
+
+  test('throws for unknown controlType', async () => {
+    const { getCameraAdapter } = await import('../src/registry.js');
+    assert.throws(
+      () => getCameraAdapter({ controlType: 'unknown-type' }),
+      /unknown camera controlType/
+    );
+  });
+});

--- a/packages/production-control/test/roland.test.js
+++ b/packages/production-control/test/roland.test.js
@@ -1,0 +1,161 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+// ---------------------------------------------------------------------------
+// Roland adapter unit tests — no live TCP; exercise state via injected handles
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a fake Roland handle with a mock socket.
+ */
+function makeHandle({ connected = true, activeSource = null } = {}) {
+  const written = [];
+  const socket = {
+    write(data, _enc, cb) { written.push(data); if (cb) cb(null); },
+    destroy() {},
+    setEncoding() {},
+    setTimeout() {},
+    on() {},
+    once() {},
+    setKeepAlive() {},
+  };
+  return {
+    _socket: socket,
+    connected,
+    destroyed: false,
+    host: '127.0.0.1',
+    port: 8023,
+    _activeSource: activeSource,
+    _lineBuffer: '',
+    _reconnectTimer: null,
+    written,
+  };
+}
+
+describe('Roland adapter — switchSource', () => {
+  test('switchSource sends a JSON command to the socket', async () => {
+    const { switchSource } = await import('../src/adapters/mixer/roland.js');
+    const handle = makeHandle({ connected: true });
+
+    await switchSource(handle, 2);
+
+    assert.equal(handle.written.length, 1);
+    const parsed = JSON.parse(handle.written[0].trimEnd());
+    assert.equal(parsed.method, 'set');
+    assert.equal(parsed.params?.name, 'program');
+    // input number matches what we passed
+    assert.equal(parsed.params?.inputBus?.number, 2);
+  });
+
+  test('switchSource updates _activeSource optimistically', async () => {
+    const { switchSource } = await import('../src/adapters/mixer/roland.js');
+    const handle = makeHandle({ connected: true, activeSource: 1 });
+
+    await switchSource(handle, 3);
+
+    assert.equal(handle._activeSource, 3);
+  });
+
+  test('switchSource throws when not connected', async () => {
+    const { switchSource } = await import('../src/adapters/mixer/roland.js');
+    const handle = makeHandle({ connected: false });
+
+    await assert.rejects(
+      () => switchSource(handle, 1),
+      /not connected/
+    );
+  });
+
+  test('switchSource throws when socket is null', async () => {
+    const { switchSource } = await import('../src/adapters/mixer/roland.js');
+    const handle = makeHandle({ connected: true });
+    handle._socket = null;
+
+    await assert.rejects(
+      () => switchSource(handle, 1),
+      /not connected/
+    );
+  });
+});
+
+describe('Roland adapter — getActiveSource', () => {
+  test('returns null when no source known', async () => {
+    const { getActiveSource } = await import('../src/adapters/mixer/roland.js');
+    const handle = makeHandle({ activeSource: null });
+    assert.equal(getActiveSource(handle), null);
+  });
+
+  test('returns the stored active source', async () => {
+    const { getActiveSource } = await import('../src/adapters/mixer/roland.js');
+    const handle = makeHandle({ activeSource: 4 });
+    assert.equal(getActiveSource(handle), 4);
+  });
+});
+
+describe('Roland adapter — disconnect', () => {
+  test('sets destroyed=true and connected=false', async () => {
+    const { disconnect } = await import('../src/adapters/mixer/roland.js');
+    const handle = makeHandle({ connected: true });
+
+    await disconnect(handle);
+
+    assert.equal(handle.destroyed, true);
+    assert.equal(handle.connected, false);
+    assert.equal(handle._socket, null);
+  });
+});
+
+describe('Roland adapter — command format', () => {
+  test('switchSource to input 1 generates valid JSON with number=1', async () => {
+    const { switchSource } = await import('../src/adapters/mixer/roland.js');
+    const handle = makeHandle({ connected: true });
+
+    await switchSource(handle, 1);
+
+    const msg = JSON.parse(handle.written[0].trimEnd());
+    assert.equal(msg.params.inputBus.number, 1);
+  });
+
+  test('each switchSource call includes a message id', async () => {
+    const { switchSource } = await import('../src/adapters/mixer/roland.js');
+    const handle = makeHandle({ connected: true });
+
+    await switchSource(handle, 1);
+
+    const msg = JSON.parse(handle.written[0].trimEnd());
+    assert.ok(typeof msg.id === 'number', 'message must have numeric id');
+  });
+
+  test('command is newline-terminated', async () => {
+    const { switchSource } = await import('../src/adapters/mixer/roland.js');
+    const handle = makeHandle({ connected: true });
+
+    await switchSource(handle, 2);
+
+    assert.ok(handle.written[0].endsWith('\r\n') || handle.written[0].endsWith('\n'),
+      'command must end with newline');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Registry — getMixerAdapter resolution
+// ---------------------------------------------------------------------------
+
+describe('registry getMixerAdapter', () => {
+  test('returns roland adapter for type roland', async () => {
+    const { getMixerAdapter } = await import('../src/registry.js');
+    const adapter = getMixerAdapter({ type: 'roland' });
+    assert.ok(typeof adapter.switchSource === 'function');
+    assert.ok(typeof adapter.getActiveSource === 'function');
+    assert.ok(typeof adapter.connect === 'function');
+    assert.ok(typeof adapter.disconnect === 'function');
+  });
+
+  test('throws for unknown mixer type', async () => {
+    const { getMixerAdapter } = await import('../src/registry.js');
+    assert.throws(
+      () => getMixerAdapter({ type: 'unknown-mixer' }),
+      /unknown mixer type/
+    );
+  });
+});

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -165,6 +165,33 @@ echo "    Built → $REPO_DIR/packages/lcyt-site/dist"
 echo "    Build log: $SITE_BUILD_LOG"
 
 # ---------------------------------------------------------------------------
+# Step 2d: Build lcyt-bridge executables (served from the backend for download)
+# ---------------------------------------------------------------------------
+
+echo "==> Installing lcyt-bridge dependencies (includes pkg for exe bundling)"
+BRIDGE_INSTALL_LOG="$REPO_DIR/lcyt-bridge-npm-install.log"
+rm -f "$BRIDGE_INSTALL_LOG"
+npm ci \
+  --prefix "$REPO_DIR" \
+  --workspace packages/lcyt-bridge \
+  --include=dev 2>&1 | tee "$BRIDGE_INSTALL_LOG"
+echo "    Install log: $BRIDGE_INSTALL_LOG"
+tail -n 10 "$BRIDGE_INSTALL_LOG" || true
+
+echo "==> Building lcyt-bridge executables (win, mac, linux)"
+BRIDGE_BUILD_LOG="$REPO_DIR/lcyt-bridge-build.log"
+rm -f "$BRIDGE_BUILD_LOG"
+(
+  cd "$REPO_DIR/packages/lcyt-bridge"
+  npm run build:win 2>&1
+  npm run build:mac 2>&1
+  npm run build:linux 2>&1
+) | tee "$BRIDGE_BUILD_LOG" || \
+  echo "Warning: lcyt-bridge build failed (non-fatal) — bridge executables will not be updated."
+echo "    Built → $REPO_DIR/packages/lcyt-bridge/dist"
+echo "    Build log: $BRIDGE_BUILD_LOG"
+
+# ---------------------------------------------------------------------------
 # Step 3: Start / restart the site container via Docker Compose
 # ---------------------------------------------------------------------------
 
@@ -193,4 +220,5 @@ echo "  Main site: in packages/lcyt-site/dist, served by host nginx; see nginx s
 echo "  Backend:   http://localhost:3000/health"
 echo "  MCP SSE:   http://localhost:3001/sse"
 echo "  Web UI:    in lcyt-web/dist, served by host nginx; see nginx symlink in this script"
+echo "  Bridge:    executables in packages/lcyt-bridge/dist/ (win/mac/linux)"
 echo ""

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -191,6 +191,13 @@ rm -f "$BRIDGE_BUILD_LOG"
 echo "    Built → $REPO_DIR/packages/lcyt-bridge/dist"
 echo "    Build log: $BRIDGE_BUILD_LOG"
 
+# Keep the nginx-served symlink up to date so /bridge-downloads/ serves
+# the freshly built executables without any backend involvement.
+if [[ -d /var/www/html ]]; then
+  ln -sfn "$REPO_DIR/packages/lcyt-bridge/dist" /var/www/html/lcyt-bridge
+  echo "==> Symlinked /var/www/html/lcyt-bridge → $REPO_DIR/packages/lcyt-bridge/dist"
+fi
+
 # ---------------------------------------------------------------------------
 # Step 3: Start / restart the site container via Docker Compose
 # ---------------------------------------------------------------------------
@@ -220,5 +227,5 @@ echo "  Main site: in packages/lcyt-site/dist, served by host nginx; see nginx s
 echo "  Backend:   http://localhost:3000/health"
 echo "  MCP SSE:   http://localhost:3001/sse"
 echo "  Web UI:    in lcyt-web/dist, served by host nginx; see nginx symlink in this script"
-echo "  Bridge:    executables in packages/lcyt-bridge/dist/ (win/mac/linux)"
+echo "  Bridge:    executables at /bridge-downloads/ (nginx) — win/mac/linux"
 echo ""

--- a/scripts/nginx-app.conf.sample
+++ b/scripts/nginx-app.conf.sample
@@ -10,6 +10,7 @@
 #
 # Symlink setup (run once after first deploy):
 #   ln -sfn ~/lcyt/packages/lcyt-web/dist /var/www/html/lcyt-web
+#   ln -sfn ~/lcyt/packages/lcyt-bridge/dist /var/www/html/lcyt-bridge
 #
 # Then point `root` below at /var/www/html/lcyt-web (or the dist path directly).
 
@@ -29,6 +30,16 @@ server {
     location /assets/ {
         expires 1y;
         add_header Cache-Control "public, immutable";
+    }
+
+    # lcyt-bridge executables — served as direct file downloads.
+    # Symlink: ln -sfn ~/lcyt/packages/lcyt-bridge/dist /var/www/html/lcyt-bridge
+    # Files: lcyt-bridge.exe (Windows), lcyt-bridge-mac (macOS), lcyt-bridge-linux (Linux)
+    location /bridge-downloads/ {
+        alias /var/www/html/lcyt-bridge/;
+        default_type application/octet-stream;
+        add_header Content-Disposition "attachment";
+        add_header Cache-Control "no-cache";
     }
 
     # ssl_certificate / ssl_certificate_key — managed by certbot or similar.


### PR DESCRIPTION
Adds a new `packages/production-control` workspace package implementing
the production control layer described in docs/plan_prod.md.

Phase 1 deliverables:
- Package scaffold: ESM package registered in root workspaces
- DB migrations: `prod_bridge_instances`, `prod_cameras`, `prod_mixers` tables
  with additive/idempotent migration pattern (dev seed data included)
- AMX adapter (`src/adapters/camera/amx.js`): TCP connection to AMX NetLinx
  master, verbatim command dispatch, keepalive/reconnect on drop
- None adapter (`src/adapters/camera/none.js`): no-op stub for mixer-only cameras
- Device registry (`src/registry.js`): loads devices from DB, manages adapter
  connections, exposes getCameraAdapter/getMixerAdapter resolution
- REST API (`/production/cameras`): full CRUD + POST preset trigger via Express router
- lcyt-backend integration: initProductionControl() wired into server.js startup
- Configuration UI: `/production/cameras` — camera list, add/edit form with
  control-type selector, AMX host/port fields, preset command editor
- Operator UI: `/production` — camera grid with preset buttons, pending/ok/error
  feedback states, responsive tablet layout
- 11 unit tests (all passing): AMX preset dispatch, command passthrough,
  error cases, none adapter no-op behaviour, registry adapter resolution

https://claude.ai/code/session_01CM5f2tfvqgyR7NbcSt4obP