### PR TITLE
fix: add production-control workspace to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,17 +6,20 @@ COPY package.json package-lock.json ./
 COPY packages/lcyt/package.json packages/lcyt/
 COPY packages/lcyt-backend/package.json packages/lcyt-backend/
 COPY packages/lcyt-mcp-sse/package.json packages/lcyt-mcp-sse/
+COPY packages/production-control/package.json packages/production-control/
 
 # Install workspace dependencies.
 RUN npm ci \
   --workspace=packages/lcyt \
   --workspace=packages/lcyt-backend \
-  --workspace=packages/lcyt-mcp-sse
+  --workspace=packages/lcyt-mcp-sse \
+  --workspace=packages/production-control
 
 # Copy source
 COPY packages/lcyt/ packages/lcyt/
 COPY packages/lcyt-backend/ packages/lcyt-backend/
 COPY packages/lcyt-mcp-sse/src/ packages/lcyt-mcp-sse/src/
+COPY packages/production-control/ packages/production-control/
 
 FROM node:20-slim
 WORKDIR /app


### PR DESCRIPTION
The lcyt-backend package depends on production-control, but the Docker
build stage was not copying its package.json or source, causing npm ci
to fail to resolve the workspace symlink and resulting in
ERR_MODULE_NOT_FOUND at runtime.

https://claude.ai/code/session_011Vsf3N7PdYPWQWDBAcGh7W