### PR TITLE
add user management

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3828,6 +3828,12 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+      "license": "MIT"
+    },
     "node_modules/better-sqlite3": {
       "version": "11.10.0",
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
@@ -9928,6 +9934,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "bcryptjs": "^2.4.3",
         "better-sqlite3": "^11.0",
         "busboy": "^1.6",
         "express": "^4.21",

--- a/packages/lcyt-backend/bin/lcyt-backend-admin
+++ b/packages/lcyt-backend/bin/lcyt-backend-admin
@@ -1,5 +1,10 @@
 #!/usr/bin/env node
-import { initDb, getAllKeys, getKey, createKey, revokeKey, deleteKey, renewKey, updateKey, cleanRevokedKeys } from '../src/db.js';
+import bcrypt from 'bcryptjs';
+import {
+  initDb,
+  getAllKeys, getKey, createKey, revokeKey, deleteKey, renewKey, updateKey, cleanRevokedKeys,
+  createUser, getUserByEmail, getUserById, updateUserPassword, getKeysByUserId,
+} from '../src/db.js';
 
 // ---------------------------------------------------------------------------
 // Argument parsing helpers
@@ -54,6 +59,7 @@ function printKeyTable(keys) {
     padEnd('OWNER', 16),
     padEnd('ACTIVE', 8),
     padEnd('EXPIRES', 14),
+    padEnd('USER', 6),
     'CREATED'
   ].join(' ');
 
@@ -66,6 +72,7 @@ function printKeyTable(keys) {
       padEnd(k.owner, 16),
       padEnd(active, 8),
       padEnd(formatDate(k.expires_at), 14),
+      padEnd(k.user_id ?? '—', 6),
       formatDate(k.created_at)
     ].join(' ');
     console.log('  ' + row);
@@ -80,6 +87,7 @@ function printKey(k) {
   console.log(`key:             ${k.key}`);
   console.log(`owner:           ${k.owner}`);
   console.log(`email:           ${k.email || '—'}`);
+  console.log(`user id:         ${k.user_id ?? '—'}`);
   console.log(`active:          ${k.active ? 'yes' : 'REVOKED'}`);
   console.log(`expires:         ${formatDate(k.expires_at)}`);
   console.log(`daily limit:     ${k.daily_limit ?? 'unlimited'}`);
@@ -94,8 +102,41 @@ function printKey(k) {
   console.log(`created:         ${formatDate(k.created_at)}`);
 }
 
+function printUserTable(users) {
+  const header = [
+    padEnd('ID', 6),
+    padEnd('EMAIL', 32),
+    padEnd('NAME', 20),
+    padEnd('ACTIVE', 8),
+    'CREATED'
+  ].join(' ');
+  console.log('  ' + header);
+  for (const u of users) {
+    const row = [
+      padEnd(u.id, 6),
+      padEnd(u.email, 32),
+      padEnd(u.name || '—', 20),
+      padEnd(u.active ? 'yes' : 'INACTIVE', 8),
+      formatDate(u.created_at)
+    ].join(' ');
+    console.log('  ' + row);
+  }
+}
+
+function printUser(u) {
+  if (!u) {
+    console.error('User not found.');
+    process.exit(1);
+  }
+  console.log(`id:              ${u.id}`);
+  console.log(`email:           ${u.email}`);
+  console.log(`name:            ${u.name || '—'}`);
+  console.log(`active:          ${u.active ? 'yes' : 'INACTIVE'}`);
+  console.log(`created:         ${formatDate(u.created_at)}`);
+}
+
 // ---------------------------------------------------------------------------
-// Commands
+// Key commands
 // ---------------------------------------------------------------------------
 
 function cmdList(db) {
@@ -113,6 +154,24 @@ function cmdAdd(db, flags) {
     console.error('Error: --owner is required');
     process.exit(1);
   }
+
+  // Resolve --user-email to a user_id if provided
+  let userId = undefined;
+  if (flags['user-email']) {
+    const user = getUserByEmail(db, flags['user-email']);
+    if (!user) {
+      console.error(`Error: no user found with email '${flags['user-email']}'`);
+      process.exit(1);
+    }
+    userId = user.id;
+  } else if (flags['user-id']) {
+    userId = Number(flags['user-id']);
+    if (!getUserById(db, userId)) {
+      console.error(`Error: no user found with id ${userId}`);
+      process.exit(1);
+    }
+  }
+
   const created = createKey(db, {
     key: key || undefined,
     owner,
@@ -126,6 +185,7 @@ function cmdAdd(db, flags) {
     hls_enabled: flags['hls'] === true || flags['hls'] === 'true',
     cea708_delay_ms: flags['cea708-delay'] !== undefined ? Number(flags['cea708-delay']) : undefined,
     embed_cors: flags['embed-cors'] || undefined,
+    user_id: userId ?? null,
   });
   console.log('Created API key:');
   printKey(created);
@@ -239,15 +299,124 @@ function cmdClean(db, flags) {
   }
 }
 
+// ---------------------------------------------------------------------------
+// User commands
+// ---------------------------------------------------------------------------
+
+function resolveUser(db, ref) {
+  if (!ref) {
+    console.error('Error: user email or id required');
+    process.exit(1);
+  }
+  const user = /^\d+$/.test(ref)
+    ? getUserById(db, Number(ref))
+    : getUserByEmail(db, ref);
+  if (!user) {
+    console.error(`User not found: ${ref}`);
+    process.exit(1);
+  }
+  return user;
+}
+
+function cmdUsersList(db) {
+  const users = db.prepare('SELECT * FROM users ORDER BY id').all();
+  if (users.length === 0) {
+    console.log('No users found.');
+    return;
+  }
+  printUserTable(users);
+}
+
+function cmdUsersInfo(db, positional) {
+  const user = resolveUser(db, positional[2]);
+  printUser(user);
+  const keys = getKeysByUserId(db, user.id);
+  if (keys.length === 0) {
+    console.log('  (no API keys)');
+  } else {
+    console.log(`\nAPI keys (${keys.length}):`);
+    printKeyTable(keys);
+  }
+}
+
+async function cmdUsersAdd(db, flags) {
+  const { email, name } = flags;
+  const password = flags.password;
+  if (!email) {
+    console.error('Error: --email is required');
+    process.exit(1);
+  }
+  if (!password || password.length < 8) {
+    console.error('Error: --password is required and must be at least 8 characters');
+    process.exit(1);
+  }
+  if (getUserByEmail(db, email)) {
+    console.error(`Error: a user with email '${email}' already exists`);
+    process.exit(1);
+  }
+  const passwordHash = await bcrypt.hash(password, 10);
+  const user = createUser(db, { email, passwordHash, name: name || null });
+  console.log('Created user:');
+  printUser(getUserById(db, user.id));
+}
+
+async function cmdUsersSetPassword(db, positional, flags) {
+  const user = resolveUser(db, positional[2]);
+  const password = flags.password;
+  if (!password || password.length < 8) {
+    console.error('Error: --password is required and must be at least 8 characters');
+    process.exit(1);
+  }
+  const hash = await bcrypt.hash(password, 10);
+  updateUserPassword(db, user.id, hash);
+  console.log(`Password updated for user ${user.id} (${user.email})`);
+}
+
+function cmdUsersDeactivate(db, positional) {
+  const user = resolveUser(db, positional[2]);
+  db.prepare('UPDATE users SET active = 0 WHERE id = ?').run(user.id);
+  console.log(`Deactivated user ${user.id} (${user.email})`);
+}
+
+function cmdUsersActivate(db, positional) {
+  const user = resolveUser(db, positional[2]);
+  db.prepare('UPDATE users SET active = 1 WHERE id = ?').run(user.id);
+  console.log(`Activated user ${user.id} (${user.email})`);
+}
+
+function cmdUsersDelete(db, positional) {
+  const user = resolveUser(db, positional[2]);
+  const keyCount = db.prepare('SELECT COUNT(*) as n FROM api_keys WHERE user_id = ? AND active = 1').get(user.id)?.n ?? 0;
+  if (keyCount > 0) {
+    console.error(`Error: user has ${keyCount} active key(s). Revoke them first, or use --force.`);
+    process.exit(1);
+  }
+  db.prepare('UPDATE api_keys SET user_id = NULL WHERE user_id = ?').run(user.id);
+  db.prepare('DELETE FROM users WHERE id = ?').run(user.id);
+  console.log(`Deleted user ${user.id} (${user.email}). ${keyCount === 0 ? '' : `Their keys have been unlinked.`}`);
+}
+
+function cmdUsersDeleteForce(db, positional) {
+  const user = resolveUser(db, positional[2]);
+  db.prepare('UPDATE api_keys SET user_id = NULL WHERE user_id = ?').run(user.id);
+  db.prepare('DELETE FROM users WHERE id = ?').run(user.id);
+  console.log(`Deleted user ${user.id} (${user.email}) and unlinked their keys.`);
+}
+
+// ---------------------------------------------------------------------------
+// Usage
+// ---------------------------------------------------------------------------
+
 function usage() {
   console.log(`Usage: lcyt-backend-admin <command> [options]
 
-Commands:
+Key commands:
   list                              List all API keys
   add --owner <name> [--key <key>] [--email <email>] [--expires <date>]
       [--daily-limit <n>] [--lifetime-limit <n>] [--file-saving] [--relay]
       [--radio] [--hls] [--cea708-delay <ms>] [--embed-cors <origin>]
-                                    Create a new API key
+      [--user-email <email>] [--user-id <id>]
+                                    Create a new API key (optionally linked to a user)
   update <key> [--owner <name>] [--expires <date>]
       [--daily-limit <n|none>] [--lifetime-limit <n|none>]
       [--file-saving [true|false]] [--relay [true|false]]
@@ -259,6 +428,18 @@ Commands:
   renew <key> --expires <date>      Extend key expiration
   info <key>                        Show details for a key
   clean [--days 30] [--dry-run]     Purge revoked keys older than N days
+
+User commands:
+  users list                        List all user accounts
+  users info <email|id>             Show user details and their API keys
+  users add --email <email> --password <password> [--name <name>]
+                                    Create a new user account
+  users set-password <email|id> --password <password>
+                                    Reset a user's password
+  users deactivate <email|id>       Disable a user account (login blocked)
+  users activate <email|id>         Re-enable a disabled user account
+  users delete <email|id>           Delete a user (fails if they have active keys)
+  users delete <email|id> --force   Delete a user and unlink their keys
 
 Options:
   --db <path>    Path to the SQLite database (default: ./lcyt-backend.db or DB_PATH env var)
@@ -283,35 +464,67 @@ const db = initDb(dbPath);
 
 const command = positional[0];
 
-switch (command) {
-  case 'list':
-    cmdList(db);
-    break;
-  case 'add':
-    cmdAdd(db, flags);
-    break;
-  case 'update':
-    cmdUpdate(db, positional, flags);
-    break;
-  case 'revoke':
-    cmdRevoke(db, positional);
-    break;
-  case 'delete':
-    cmdDelete(db, positional);
-    break;
-  case 'renew':
-    cmdRenew(db, positional, flags);
-    break;
-  case 'info':
-    cmdInfo(db, positional);
-    break;
-  case 'clean':
-    cmdClean(db, flags);
-    break;
-  default:
-    console.error(`Unknown command: ${command}`);
-    usage();
-    process.exit(1);
+if (command === 'users') {
+  const sub = positional[1];
+  switch (sub) {
+    case 'list':
+      cmdUsersList(db);
+      break;
+    case 'info':
+      cmdUsersInfo(db, positional);
+      break;
+    case 'add':
+      await cmdUsersAdd(db, flags);
+      break;
+    case 'set-password':
+      await cmdUsersSetPassword(db, positional, flags);
+      break;
+    case 'deactivate':
+      cmdUsersDeactivate(db, positional);
+      break;
+    case 'activate':
+      cmdUsersActivate(db, positional);
+      break;
+    case 'delete':
+      if (flags.force) cmdUsersDeleteForce(db, positional);
+      else cmdUsersDelete(db, positional);
+      break;
+    default:
+      console.error(`Unknown users subcommand: ${sub || '(none)'}`);
+      usage();
+      process.exit(1);
+  }
+} else {
+  switch (command) {
+    case 'list':
+      cmdList(db);
+      break;
+    case 'add':
+      await cmdAdd(db, flags);
+      break;
+    case 'update':
+      cmdUpdate(db, positional, flags);
+      break;
+    case 'revoke':
+      cmdRevoke(db, positional);
+      break;
+    case 'delete':
+      cmdDelete(db, positional);
+      break;
+    case 'renew':
+      cmdRenew(db, positional, flags);
+      break;
+    case 'info':
+      cmdInfo(db, positional);
+      break;
+    case 'clean':
+      cmdClean(db, flags);
+      break;
+    default:
+      console.error(`Unknown command: ${command}`);
+      usage();
+      process.exit(1);
+  }
 }
 
 db.close();

--- a/packages/lcyt-backend/package.json
+++ b/packages/lcyt-backend/package.json
@@ -17,6 +17,7 @@
     "express": "^4.21",
     "express-rate-limit": "^8.2.1",
     "jsonwebtoken": "^9.0",
+    "bcryptjs": "^2.4.3",
     "lcyt": "*",
     "lcyt-dsk": "*",
     "lcyt-production": "*"

--- a/packages/lcyt-backend/src/db/index.js
+++ b/packages/lcyt-backend/src/db/index.js
@@ -16,6 +16,17 @@ export function initDb(dbPath) {
   const db = new Database(resolvedPath);
 
   db.exec(`
+    CREATE TABLE IF NOT EXISTS users (
+      id            INTEGER PRIMARY KEY AUTOINCREMENT,
+      email         TEXT    NOT NULL UNIQUE,
+      password_hash TEXT    NOT NULL,
+      name          TEXT,
+      created_at    TEXT    NOT NULL DEFAULT (datetime('now')),
+      active        INTEGER NOT NULL DEFAULT 1
+    )
+  `);
+
+  db.exec(`
     CREATE TABLE IF NOT EXISTS api_keys (
       id             INTEGER PRIMARY KEY AUTOINCREMENT,
       key            TEXT    NOT NULL UNIQUE,
@@ -60,6 +71,7 @@ export function initDb(dbPath) {
   // CORS origin for embeddable player.js and HLS endpoints. Default '*' (allow all).
   // Set to a specific origin e.g. 'https://example.com' to restrict access.
   if (!existingCols.has('embed_cors'))        db.exec("ALTER TABLE api_keys ADD COLUMN embed_cors TEXT NOT NULL DEFAULT '*'");
+  if (!existingCols.has('user_id'))           db.exec('ALTER TABLE api_keys ADD COLUMN user_id INTEGER REFERENCES users(id)');
 
   // ── rtmp_relays: one incoming stream fans out to up to 4 target URLs ──────────
   // slot (1-4): one row per target; UNIQUE on (api_key, slot)
@@ -296,6 +308,7 @@ export function initDb(dbPath) {
 
 // Re-export all domain modules
 export { currentDateHour } from './helpers.js';
+export * from './users.js';
 export * from './keys.js';
 export * from './sessions.js';
 export * from './sequences.js';

--- a/packages/lcyt-backend/src/db/keys.js
+++ b/packages/lcyt-backend/src/db/keys.js
@@ -150,13 +150,13 @@ export function getKeyByEmail(db, email) {
 /**
  * Create a new API key.
  * @param {import('better-sqlite3').Database} db
- * @param {{ key?: string, owner: string, email?: string, expiresAt?: string, daily_limit?: number|null, lifetime_limit?: number|null, backend_file_enabled?: boolean, relay_allowed?: boolean, radio_enabled?: boolean, hls_enabled?: boolean, cea708_delay_ms?: number, embed_cors?: string }} options
+ * @param {{ key?: string, owner: string, email?: string, expiresAt?: string, daily_limit?: number|null, lifetime_limit?: number|null, backend_file_enabled?: boolean, relay_allowed?: boolean, radio_enabled?: boolean, hls_enabled?: boolean, cea708_delay_ms?: number, embed_cors?: string, user_id?: number|null }} options
  * @returns {object} The created row
  */
-export function createKey(db, { key, owner, email, expiresAt, daily_limit, lifetime_limit, backend_file_enabled, relay_allowed, radio_enabled, hls_enabled, cea708_delay_ms, embed_cors } = {}) {
+export function createKey(db, { key, owner, email, expiresAt, daily_limit, lifetime_limit, backend_file_enabled, relay_allowed, radio_enabled, hls_enabled, cea708_delay_ms, embed_cors, user_id } = {}) {
   const resolvedKey = key || randomUUID();
   db.prepare(
-    'INSERT INTO api_keys (key, owner, email, expires_at, daily_limit, lifetime_limit, backend_file_enabled, relay_allowed, radio_enabled, hls_enabled, cea708_delay_ms, embed_cors) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+    'INSERT INTO api_keys (key, owner, email, expires_at, daily_limit, lifetime_limit, backend_file_enabled, relay_allowed, radio_enabled, hls_enabled, cea708_delay_ms, embed_cors, user_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
   ).run(
     resolvedKey,
     owner,
@@ -170,6 +170,7 @@ export function createKey(db, { key, owner, email, expiresAt, daily_limit, lifet
     (hls_enabled ?? false) ? 1 : 0,
     cea708_delay_ms ?? 0,
     embed_cors ?? '*',
+    user_id ?? null,
   );
   return getKey(db, resolvedKey);
 }

--- a/packages/lcyt-backend/src/db/users.js
+++ b/packages/lcyt-backend/src/db/users.js
@@ -1,0 +1,64 @@
+/**
+ * User CRUD operations for the `users` table.
+ * Used when USE_USER_LOGINS=1 (default).
+ */
+
+/**
+ * Create a new user account.
+ * @param {import('better-sqlite3').Database} db
+ * @param {{ email: string, passwordHash: string, name?: string }} opts
+ * @returns {{ id: number, email: string, name: string|null }}
+ */
+export function createUser(db, { email, passwordHash, name = null }) {
+  const stmt = db.prepare(
+    'INSERT INTO users (email, password_hash, name) VALUES (?, ?, ?)'
+  );
+  const result = stmt.run(email.toLowerCase().trim(), passwordHash, name || null);
+  return { id: result.lastInsertRowid, email: email.toLowerCase().trim(), name: name || null };
+}
+
+/**
+ * Fetch a user by email (includes password_hash for verification).
+ * @param {import('better-sqlite3').Database} db
+ * @param {string} email
+ * @returns {object|undefined}
+ */
+export function getUserByEmail(db, email) {
+  return db.prepare('SELECT * FROM users WHERE email = ? AND active = 1').get(
+    email.toLowerCase().trim()
+  );
+}
+
+/**
+ * Fetch a user by ID (excludes password_hash).
+ * @param {import('better-sqlite3').Database} db
+ * @param {number} id
+ * @returns {{ id: number, email: string, name: string|null, created_at: string, active: number }|undefined}
+ */
+export function getUserById(db, id) {
+  return db.prepare(
+    'SELECT id, email, name, created_at, active FROM users WHERE id = ?'
+  ).get(id);
+}
+
+/**
+ * Update a user's password hash.
+ * @param {import('better-sqlite3').Database} db
+ * @param {number} id
+ * @param {string} passwordHash
+ */
+export function updateUserPassword(db, id, passwordHash) {
+  db.prepare('UPDATE users SET password_hash = ? WHERE id = ?').run(passwordHash, id);
+}
+
+/**
+ * Get all API keys belonging to a user.
+ * @param {import('better-sqlite3').Database} db
+ * @param {number} userId
+ * @returns {object[]}
+ */
+export function getKeysByUserId(db, userId) {
+  return db.prepare(
+    'SELECT * FROM api_keys WHERE user_id = ? ORDER BY created_at DESC'
+  ).all(userId);
+}

--- a/packages/lcyt-backend/src/middleware/user-auth.js
+++ b/packages/lcyt-backend/src/middleware/user-auth.js
@@ -1,0 +1,28 @@
+import jwt from 'jsonwebtoken';
+
+/**
+ * Middleware factory for verifying user-level JWT tokens.
+ * User tokens have payload `{ type: 'user', userId, email }`.
+ * Distinct from session tokens which have `{ sessionId, apiKey }`.
+ *
+ * @param {string} jwtSecret
+ * @returns {import('express').RequestHandler}
+ */
+export function createUserAuthMiddleware(jwtSecret) {
+  return (req, res, next) => {
+    const header = req.headers.authorization;
+    if (!header?.startsWith('Bearer ')) {
+      return res.status(401).json({ error: 'Missing or invalid Authorization header' });
+    }
+    try {
+      const payload = jwt.verify(header.slice(7), jwtSecret);
+      if (payload.type !== 'user') {
+        return res.status(401).json({ error: 'Invalid token type' });
+      }
+      req.user = { userId: payload.userId, email: payload.email };
+      next();
+    } catch {
+      res.status(401).json({ error: 'Invalid or expired token' });
+    }
+  };
+}

--- a/packages/lcyt-backend/src/routes/auth.js
+++ b/packages/lcyt-backend/src/routes/auth.js
@@ -1,0 +1,119 @@
+import { Router } from 'express';
+import jwt from 'jsonwebtoken';
+import bcrypt from 'bcryptjs';
+import { createUser, getUserByEmail, getUserById, updateUserPassword } from '../db/users.js';
+import { createUserAuthMiddleware } from '../middleware/user-auth.js';
+
+const BCRYPT_ROUNDS = 12;
+const USER_TOKEN_TTL_DAYS = 30;
+
+function issueUserToken(jwtSecret, { userId, email }) {
+  return jwt.sign(
+    { type: 'user', userId, email },
+    jwtSecret,
+    { expiresIn: `${USER_TOKEN_TTL_DAYS}d` }
+  );
+}
+
+/**
+ * Creates the /auth router for user registration and login.
+ *
+ * @param {import('better-sqlite3').Database} db
+ * @param {string} jwtSecret
+ * @param {{ loginEnabled: boolean }} opts
+ * @returns {import('express').Router}
+ */
+export function createAuthRouter(db, jwtSecret, { loginEnabled }) {
+  const router = Router();
+  const userAuth = createUserAuthMiddleware(jwtSecret);
+
+  // All routes return 503 if logins are disabled
+  router.use((req, res, next) => {
+    if (!loginEnabled) {
+      return res.status(503).json({ error: 'User logins are disabled on this server' });
+    }
+    next();
+  });
+
+  // POST /auth/register
+  router.post('/register', async (req, res) => {
+    const { email, password, name } = req.body || {};
+    if (!email || typeof email !== 'string') {
+      return res.status(400).json({ error: 'email is required' });
+    }
+    if (!password || typeof password !== 'string' || password.length < 8) {
+      return res.status(400).json({ error: 'password must be at least 8 characters' });
+    }
+    // Check for existing account
+    const existing = getUserByEmail(db, email);
+    if (existing) {
+      return res.status(409).json({ error: 'An account with this email already exists' });
+    }
+    try {
+      const passwordHash = await bcrypt.hash(password, BCRYPT_ROUNDS);
+      const user = createUser(db, { email, passwordHash, name: name || null });
+      const token = issueUserToken(jwtSecret, { userId: user.id, email: user.email });
+      res.status(201).json({ token, userId: user.id, email: user.email, name: user.name });
+    } catch (err) {
+      console.error('[auth] register error:', err.message);
+      res.status(500).json({ error: 'Registration failed' });
+    }
+  });
+
+  // POST /auth/login
+  router.post('/login', async (req, res) => {
+    const { email, password } = req.body || {};
+    if (!email || !password) {
+      return res.status(400).json({ error: 'email and password are required' });
+    }
+    const user = getUserByEmail(db, email);
+    if (!user) {
+      return res.status(401).json({ error: 'Invalid email or password' });
+    }
+    try {
+      const match = await bcrypt.compare(password, user.password_hash);
+      if (!match) {
+        return res.status(401).json({ error: 'Invalid email or password' });
+      }
+      const token = issueUserToken(jwtSecret, { userId: user.id, email: user.email });
+      res.json({ token, userId: user.id, email: user.email, name: user.name });
+    } catch (err) {
+      console.error('[auth] login error:', err.message);
+      res.status(500).json({ error: 'Login failed' });
+    }
+  });
+
+  // GET /auth/me — requires user token
+  router.get('/me', userAuth, (req, res) => {
+    const user = getUserById(db, req.user.userId);
+    if (!user) return res.status(404).json({ error: 'User not found' });
+    res.json({ userId: user.id, email: user.email, name: user.name, createdAt: user.created_at });
+  });
+
+  // POST /auth/change-password — requires user token
+  router.post('/change-password', userAuth, async (req, res) => {
+    const { currentPassword, newPassword } = req.body || {};
+    if (!currentPassword || !newPassword) {
+      return res.status(400).json({ error: 'currentPassword and newPassword are required' });
+    }
+    if (newPassword.length < 8) {
+      return res.status(400).json({ error: 'newPassword must be at least 8 characters' });
+    }
+    const user = getUserByEmail(db, req.user.email);
+    if (!user) return res.status(404).json({ error: 'User not found' });
+    try {
+      const match = await bcrypt.compare(currentPassword, user.password_hash);
+      if (!match) {
+        return res.status(401).json({ error: 'Current password is incorrect' });
+      }
+      const newHash = await bcrypt.hash(newPassword, BCRYPT_ROUNDS);
+      updateUserPassword(db, user.id, newHash);
+      res.json({ ok: true });
+    } catch (err) {
+      console.error('[auth] change-password error:', err.message);
+      res.status(500).json({ error: 'Password change failed' });
+    }
+  });
+
+  return router;
+}

--- a/packages/lcyt-backend/src/routes/keys.js
+++ b/packages/lcyt-backend/src/routes/keys.js
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { join, resolve, basename } from 'node:path';
 import { existsSync, unlinkSync } from 'node:fs';
-import { getAllKeys, getKey, getKeyByEmail, createKey, revokeKey, deleteKey, updateKey, formatKey, deleteAllImages } from '../db.js';
+import { getAllKeys, getKey, getKeyByEmail, createKey, revokeKey, deleteKey, updateKey, formatKey, deleteAllImages, getKeysByUserId } from '../db.js';
 import { adminMiddleware } from '../middleware/admin.js';
 
 const GRAPHICS_BASE_DIR = resolve(process.env.GRAPHICS_DIR || '/data/images');
@@ -18,16 +18,23 @@ const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
  *   PATCH  /keys/:key    — Update owner, expiration, or limits
  *   DELETE /keys/:key    — Revoke (soft-delete) or permanently delete
  *
+ * User routes (when loginEnabled=true, require Bearer user token):
+ *   GET    /keys         — List own API keys (projects)
+ *   POST   /keys         — Create a new project key for the authenticated user
+ *   PATCH  /keys/:key    — Rename own project (owner field only)
+ *   DELETE /keys/:key    — Revoke own project key
+ *
  * Public route (requires FREE_APIKEY_ACTIVE=1):
  *   POST   /keys?freetier — Self-service free-tier key sign-up (name + email required)
  *
  * @param {import('better-sqlite3').Database} db
+ * @param {{ loginEnabled?: boolean, jwtSecret?: string }} [opts]
  * @returns {Router}
  */
-export function createKeysRouter(db) {
+export function createKeysRouter(db, { loginEnabled = false, jwtSecret = null } = {}) {
   const router = Router();
 
-  // POST /keys — Create API key (admin) OR free-tier sign-up (?freetier)
+  // POST /keys — Create API key (admin) OR user project OR free-tier sign-up (?freetier)
   router.post('/', (req, res) => {
     // ── free-tier path ────────────────────────────────────────────────────────
     if ('freetier' in req.query) {
@@ -66,6 +73,12 @@ export function createKeysRouter(db) {
       return res.status(201).json(formatKey(newKey));
     }
 
+    // ── user path (loginEnabled + Bearer token, no X-Admin-Key) ──────────────
+    const hasAdminKey = !!req.headers['x-admin-key'];
+    if (loginEnabled && !hasAdminKey) {
+      return _userCreateKey(db, jwtSecret, req, res);
+    }
+
     // ── admin path ────────────────────────────────────────────────────────────
     return adminMiddleware(req, res, () => {
       const { owner, key, expires, daily_limit, lifetime_limit } = req.body || {};
@@ -85,13 +98,19 @@ export function createKeysRouter(db) {
     });
   });
 
-  // GET /keys — List all API keys (admin)
-  router.get('/', adminMiddleware, (req, res) => {
-    const keys = getAllKeys(db);
-    return res.status(200).json({ keys: keys.map(formatKey) });
+  // GET /keys — List API keys (admin or user-scoped)
+  router.get('/', (req, res) => {
+    const hasAdminKey = !!req.headers['x-admin-key'];
+    if (loginEnabled && !hasAdminKey) {
+      return _userListKeys(db, jwtSecret, req, res);
+    }
+    return adminMiddleware(req, res, () => {
+      const keys = getAllKeys(db);
+      return res.status(200).json({ keys: keys.map(formatKey) });
+    });
   });
 
-  // GET /keys/:key — Get details for a specific key (admin)
+  // GET /keys/:key — Get details for a specific key (admin only)
   router.get('/:key', adminMiddleware, (req, res) => {
     const row = getKey(db, req.params.key);
     if (!row) {
@@ -100,59 +119,132 @@ export function createKeysRouter(db) {
     return res.status(200).json(formatKey(row));
   });
 
-  // PATCH /keys/:key — Update owner, expiration, or limits (admin)
-  router.patch('/:key', adminMiddleware, (req, res) => {
-    const existing = getKey(db, req.params.key);
-    if (!existing) {
-      return res.status(404).json({ error: 'API key not found' });
+  // PATCH /keys/:key — Update key (admin or user for own keys)
+  router.patch('/:key', (req, res) => {
+    const hasAdminKey = !!req.headers['x-admin-key'];
+    if (loginEnabled && !hasAdminKey) {
+      return _userUpdateKey(db, jwtSecret, req, res);
     }
+    return adminMiddleware(req, res, () => {
+      const existing = getKey(db, req.params.key);
+      if (!existing) {
+        return res.status(404).json({ error: 'API key not found' });
+      }
 
-    const body = req.body || {};
-    const updates = {};
-    if (body.owner !== undefined) updates.owner = body.owner;
-    if ('expires' in body) updates.expiresAt = body.expires || null;
-    if ('daily_limit' in body) updates.daily_limit = body.daily_limit ?? null;
-    if ('lifetime_limit' in body) updates.lifetime_limit = body.lifetime_limit ?? null;
-    if ('backend_file_enabled' in body) updates.backend_file_enabled = !!body.backend_file_enabled;
-    if ('relay_allowed' in body) updates.relay_allowed = !!body.relay_allowed;
-    if ('radio_enabled' in body) updates.radio_enabled = !!body.radio_enabled;
-    if ('hls_enabled' in body) updates.hls_enabled = !!body.hls_enabled;
-    if ('cea708_delay_ms' in body) updates.cea708_delay_ms = body.cea708_delay_ms;
-    if ('graphics_enabled' in body) updates.graphics_enabled = !!body.graphics_enabled;
-    if ('embed_cors' in body) updates.embed_cors = body.embed_cors ?? '*';
+      const body = req.body || {};
+      const updates = {};
+      if (body.owner !== undefined) updates.owner = body.owner;
+      if ('expires' in body) updates.expiresAt = body.expires || null;
+      if ('daily_limit' in body) updates.daily_limit = body.daily_limit ?? null;
+      if ('lifetime_limit' in body) updates.lifetime_limit = body.lifetime_limit ?? null;
+      if ('backend_file_enabled' in body) updates.backend_file_enabled = !!body.backend_file_enabled;
+      if ('relay_allowed' in body) updates.relay_allowed = !!body.relay_allowed;
+      if ('radio_enabled' in body) updates.radio_enabled = !!body.radio_enabled;
+      if ('hls_enabled' in body) updates.hls_enabled = !!body.hls_enabled;
+      if ('cea708_delay_ms' in body) updates.cea708_delay_ms = body.cea708_delay_ms;
+      if ('graphics_enabled' in body) updates.graphics_enabled = !!body.graphics_enabled;
+      if ('embed_cors' in body) updates.embed_cors = body.embed_cors ?? '*';
 
-    updateKey(db, req.params.key, updates);
+      updateKey(db, req.params.key, updates);
 
-    const updated = getKey(db, req.params.key);
-    return res.status(200).json(formatKey(updated));
+      const updated = getKey(db, req.params.key);
+      return res.status(200).json(formatKey(updated));
+    });
   });
 
-  // DELETE /keys/:key — Revoke or permanently delete (admin)
-  router.delete('/:key', adminMiddleware, (req, res) => {
-    const existing = getKey(db, req.params.key);
-    if (!existing) {
-      return res.status(404).json({ error: 'API key not found' });
+  // DELETE /keys/:key — Revoke or permanently delete (admin or user for own keys)
+  router.delete('/:key', (req, res) => {
+    const hasAdminKey = !!req.headers['x-admin-key'];
+    if (loginEnabled && !hasAdminKey) {
+      return _userDeleteKey(db, jwtSecret, req, res);
     }
-
-    if (req.query.permanent === 'true') {
-      // Delete all images from disk before removing DB rows
-      const imageRows = deleteAllImages(db, req.params.key);
-      for (const row of imageRows) {
-        try {
-          const safe = row.api_key.replace(/[^a-zA-Z0-9-]/g, '_').slice(0, 40);
-          const filepath = join(GRAPHICS_BASE_DIR, safe, basename(row.filename));
-          if (existsSync(filepath)) unlinkSync(filepath);
-        } catch (e) {
-          console.warn('[keys] Could not delete image file on key deletion:', e.message);
-        }
+    return adminMiddleware(req, res, () => {
+      const existing = getKey(db, req.params.key);
+      if (!existing) {
+        return res.status(404).json({ error: 'API key not found' });
       }
-      deleteKey(db, req.params.key);
-      return res.status(200).json({ key: req.params.key, deleted: true });
-    } else {
-      revokeKey(db, req.params.key);
-      return res.status(200).json({ key: req.params.key, revoked: true });
-    }
+
+      if (req.query.permanent === 'true') {
+        const imageRows = deleteAllImages(db, req.params.key);
+        for (const row of imageRows) {
+          try {
+            const safe = row.api_key.replace(/[^a-zA-Z0-9-]/g, '_').slice(0, 40);
+            const filepath = join(GRAPHICS_BASE_DIR, safe, basename(row.filename));
+            if (existsSync(filepath)) unlinkSync(filepath);
+          } catch (e) {
+            console.warn('[keys] Could not delete image file on key deletion:', e.message);
+          }
+        }
+        deleteKey(db, req.params.key);
+        return res.status(200).json({ key: req.params.key, deleted: true });
+      } else {
+        revokeKey(db, req.params.key);
+        return res.status(200).json({ key: req.params.key, revoked: true });
+      }
+    });
   });
 
   return router;
+}
+
+// ── User-scoped handlers ──────────────────────────────────────────────────────
+
+import jwt from 'jsonwebtoken';
+
+function _verifyUserToken(jwtSecret, req) {
+  const header = req.headers.authorization;
+  if (!header?.startsWith('Bearer ')) return null;
+  try {
+    const payload = jwt.verify(header.slice(7), jwtSecret);
+    if (payload.type !== 'user') return null;
+    return { userId: payload.userId, email: payload.email };
+  } catch {
+    return null;
+  }
+}
+
+function _userListKeys(db, jwtSecret, req, res) {
+  const user = _verifyUserToken(jwtSecret, req);
+  if (!user) return res.status(401).json({ error: 'Authentication required' });
+  const keys = getKeysByUserId(db, user.userId);
+  return res.status(200).json({ keys: keys.map(formatKey) });
+}
+
+function _userCreateKey(db, jwtSecret, req, res) {
+  const user = _verifyUserToken(jwtSecret, req);
+  if (!user) return res.status(401).json({ error: 'Authentication required' });
+  const { name } = req.body || {};
+  if (!name || typeof name !== 'string' || !name.trim()) {
+    return res.status(400).json({ error: 'name is required' });
+  }
+  const newKey = createKey(db, {
+    owner: name.trim(),
+    user_id: user.userId,
+  });
+  return res.status(201).json(formatKey(newKey));
+}
+
+function _userUpdateKey(db, jwtSecret, req, res) {
+  const user = _verifyUserToken(jwtSecret, req);
+  if (!user) return res.status(401).json({ error: 'Authentication required' });
+  const existing = getKey(db, req.params.key);
+  if (!existing) return res.status(404).json({ error: 'API key not found' });
+  if (existing.user_id !== user.userId) return res.status(403).json({ error: 'Forbidden' });
+  const { name } = req.body || {};
+  if (!name || typeof name !== 'string' || !name.trim()) {
+    return res.status(400).json({ error: 'name is required' });
+  }
+  updateKey(db, req.params.key, { owner: name.trim() });
+  const updated = getKey(db, req.params.key);
+  return res.status(200).json(formatKey(updated));
+}
+
+function _userDeleteKey(db, jwtSecret, req, res) {
+  const user = _verifyUserToken(jwtSecret, req);
+  if (!user) return res.status(401).json({ error: 'Authentication required' });
+  const existing = getKey(db, req.params.key);
+  if (!existing) return res.status(404).json({ error: 'API key not found' });
+  if (existing.user_id !== user.userId) return res.status(403).json({ error: 'Forbidden' });
+  revokeKey(db, req.params.key);
+  return res.status(200).json({ key: req.params.key, revoked: true });
 }

--- a/packages/lcyt-backend/src/server.js
+++ b/packages/lcyt-backend/src/server.js
@@ -13,6 +13,7 @@ import { createCaptionsRouter } from './routes/captions.js';
 import { createEventsRouter } from './routes/events.js';
 import { createSyncRouter } from './routes/sync.js';
 import { createKeysRouter } from './routes/keys.js';
+import { createAuthRouter } from './routes/auth.js';
 import { createStatsRouter } from './routes/stats.js';
 import { createMicRouter } from './routes/mic.js';
 import { createUsageRouter } from './routes/usage.js';
@@ -88,6 +89,13 @@ if (process.env.FREE_APIKEY_ACTIVE !== '1') {
   console.info('ℹ FREE_APIKEY_ACTIVE is not set — POST /keys?freetier is disabled.');
 } else {
   console.info('✓ Free-tier API key endpoint enabled at POST /keys?freetier');
+}
+
+const loginEnabled = process.env.USE_USER_LOGINS !== '0';
+if (loginEnabled) {
+  console.info('✓ User logins enabled. Set USE_USER_LOGINS=0 to disable.');
+} else {
+  console.info('ℹ User logins disabled (USE_USER_LOGINS=0).');
 }
 
 if (process.env.GRAPHICS_ENABLED === '1') {
@@ -315,6 +323,7 @@ app.get('/health', (req, res) => {
     ok: true,
     uptime: Math.floor(process.uptime()),
     activeSessions: store.size(),
+    loginEnabled,
     ...(process.env.RTMP_RELAY_ACTIVE === '1' ? {
       rtmpIngest: {
         host: process.env.RTMP_HOST || 'rtmp.lcyt.fi',
@@ -350,7 +359,8 @@ app.use('/live', createLiveRouter(db, store, jwtSecret));
 app.use('/captions', createCaptionsRouter(store, auth, db, relayManager, _dskCaptionProcessor));
 app.use('/events', createEventsRouter(store, jwtSecret));
 app.use('/sync', createSyncRouter(store, auth));
-app.use('/keys', createKeysRouter(db));
+app.use('/auth', createAuthRouter(db, jwtSecret, { loginEnabled }));
+app.use('/keys', createKeysRouter(db, { loginEnabled, jwtSecret }));
 app.use('/stats', createStatsRouter(db, auth, store));
 app.use('/mic', createMicRouter(store, auth));
 app.use('/usage', createUsageRouter(db));

--- a/packages/lcyt-web/src/components/LoginPage.jsx
+++ b/packages/lcyt-web/src/components/LoginPage.jsx
@@ -1,0 +1,118 @@
+import { useState } from 'react';
+import { useUserAuth } from '../hooks/useUserAuth';
+
+function getBackendUrl() {
+  // Read from URL param or localStorage
+  const params = new URLSearchParams(window.location.search);
+  const urlParam = params.get('server');
+  if (urlParam) return urlParam;
+  try {
+    const cfg = JSON.parse(localStorage.getItem('lcyt-config') || '{}');
+    return cfg.backendUrl || '';
+  } catch {
+    return '';
+  }
+}
+
+export function LoginPage() {
+  const { login } = useUserAuth();
+  const [backendUrl, setBackendUrl] = useState(getBackendUrl);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    if (!backendUrl.trim() || !email.trim() || !password) return;
+    setError(null);
+    setLoading(true);
+    try {
+      await login(backendUrl.trim(), email.trim(), password);
+      window.location.href = '/projects';
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div style={{
+      minHeight: '100vh',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      background: 'var(--color-bg)',
+      padding: 24,
+    }}>
+      <div style={{ width: '100%', maxWidth: 400 }}>
+        <h1 style={{ fontSize: 22, fontWeight: 600, marginBottom: 24, color: 'var(--color-text)' }}>
+          Sign in
+        </h1>
+        <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <div className="settings-field">
+            <label className="settings-field__label">Server URL</label>
+            <input
+              className="settings-field__input"
+              type="url"
+              value={backendUrl}
+              onChange={e => setBackendUrl(e.target.value)}
+              placeholder="https://api.lcyt.fi"
+              required
+              autoComplete="url"
+            />
+          </div>
+          <div className="settings-field">
+            <label className="settings-field__label">Email</label>
+            <input
+              className="settings-field__input"
+              type="email"
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+              placeholder="you@example.com"
+              required
+              autoComplete="email"
+              autoFocus
+            />
+          </div>
+          <div className="settings-field">
+            <label className="settings-field__label">Password</label>
+            <input
+              className="settings-field__input"
+              type="password"
+              value={password}
+              onChange={e => setPassword(e.target.value)}
+              placeholder="••••••••"
+              required
+              autoComplete="current-password"
+            />
+          </div>
+          {error && (
+            <div style={{ color: 'var(--color-error)', fontSize: 13 }}>{error}</div>
+          )}
+          <button
+            className="btn btn--primary"
+            type="submit"
+            disabled={loading}
+            style={{ marginTop: 4 }}
+          >
+            {loading ? 'Signing in…' : 'Sign in'}
+          </button>
+        </form>
+        <p style={{ marginTop: 20, fontSize: 13, color: 'var(--color-text-muted)', textAlign: 'center' }}>
+          Don&rsquo;t have an account?{' '}
+          <a
+            href={`/register${backendUrl ? `?server=${encodeURIComponent(backendUrl)}` : ''}`}
+            style={{ color: 'var(--color-accent)' }}
+          >
+            Register
+          </a>
+        </p>
+        <p style={{ marginTop: 8, fontSize: 13, color: 'var(--color-text-muted)', textAlign: 'center' }}>
+          <a href="/" style={{ color: 'var(--color-text-muted)' }}>Back to app</a>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/packages/lcyt-web/src/components/ProjectsPage.jsx
+++ b/packages/lcyt-web/src/components/ProjectsPage.jsx
@@ -1,0 +1,336 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useUserAuth } from '../hooks/useUserAuth';
+
+function copyToClipboard(text) {
+  navigator.clipboard?.writeText(text).catch(() => {});
+}
+
+function maskKey(key) {
+  if (!key || key.length < 8) return key;
+  return key.slice(0, 8) + '••••••••••••••••••••••••••••';
+}
+
+function ProjectCard({ project, onUse, onRename, onDelete }) {
+  const [showKey, setShowKey] = useState(false);
+  const [renaming, setRenaming] = useState(false);
+  const [newName, setNewName] = useState(project.owner);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+
+  async function handleRename(e) {
+    e.preventDefault();
+    if (!newName.trim()) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await onRename(project.key, newName.trim());
+      setRenaming(false);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div style={{
+      border: '1px solid var(--color-border)',
+      borderRadius: 8,
+      padding: '16px 20px',
+      background: 'var(--color-surface)',
+      display: 'flex',
+      flexDirection: 'column',
+      gap: 10,
+    }}>
+      {renaming ? (
+        <form onSubmit={handleRename} style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+          <input
+            className="settings-field__input"
+            value={newName}
+            onChange={e => setNewName(e.target.value)}
+            autoFocus
+            style={{ flex: 1 }}
+          />
+          <button className="btn btn--primary btn--sm" type="submit" disabled={saving}>
+            {saving ? '…' : 'Save'}
+          </button>
+          <button className="btn btn--ghost btn--sm" type="button" onClick={() => { setRenaming(false); setNewName(project.owner); }}>
+            Cancel
+          </button>
+        </form>
+      ) : (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ fontWeight: 600, fontSize: 15, flex: 1, color: 'var(--color-text)' }}>
+            {project.owner}
+          </span>
+          <button className="btn btn--ghost btn--sm" onClick={() => setRenaming(true)} title="Rename">
+            Rename
+          </button>
+        </div>
+      )}
+      {error && <div style={{ color: 'var(--color-error)', fontSize: 12 }}>{error}</div>}
+
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <code style={{
+          fontSize: 12,
+          fontFamily: 'monospace',
+          color: 'var(--color-text-muted)',
+          flex: 1,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}>
+          {showKey ? project.key : maskKey(project.key)}
+        </code>
+        <button
+          className="btn btn--ghost btn--sm"
+          onClick={() => setShowKey(v => !v)}
+          title={showKey ? 'Hide key' : 'Show key'}
+        >
+          {showKey ? 'Hide' : 'Show'}
+        </button>
+        <button
+          className="btn btn--ghost btn--sm"
+          onClick={() => copyToClipboard(project.key)}
+          title="Copy API key"
+        >
+          Copy
+        </button>
+      </div>
+
+      <div style={{ fontSize: 12, color: 'var(--color-text-muted)' }}>
+        Created {new Date(project.createdAt).toLocaleDateString()}
+        {project.expires && ` · Expires ${new Date(project.expires).toLocaleDateString()}`}
+      </div>
+
+      <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
+        <button
+          className="btn btn--primary btn--sm"
+          onClick={() => onUse(project)}
+          style={{ flex: 1 }}
+        >
+          Use this project
+        </button>
+        <button
+          className="btn btn--ghost btn--sm"
+          onClick={() => onDelete(project.key)}
+          style={{ color: 'var(--color-error)' }}
+        >
+          Delete
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function CreateProjectForm({ onCreated, onCancel, backendUrl, token }) {
+  const [name, setName] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+
+  async function handleCreate(e) {
+    e.preventDefault();
+    if (!name.trim()) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const r = await fetch(`${backendUrl}/keys`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ name: name.trim() }),
+      });
+      const data = await r.json();
+      if (!r.ok) throw new Error(data.error || `HTTP ${r.status}`);
+      onCreated(data);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleCreate} style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div className="settings-field">
+        <label className="settings-field__label">Project name</label>
+        <input
+          className="settings-field__input"
+          value={name}
+          onChange={e => setName(e.target.value)}
+          placeholder="e.g. Sunday service"
+          autoFocus
+        />
+      </div>
+      {error && <div style={{ color: 'var(--color-error)', fontSize: 13 }}>{error}</div>}
+      <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+        <button className="btn btn--ghost" type="button" onClick={onCancel}>Cancel</button>
+        <button className="btn btn--primary" type="submit" disabled={saving}>
+          {saving ? 'Creating…' : 'Create project'}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+export function ProjectsPage() {
+  const { user, token, backendUrl, loading: authLoading, logout } = useUserAuth();
+  const [projects, setProjects] = useState([]);
+  const [loadingProjects, setLoadingProjects] = useState(false);
+  const [error, setError] = useState(null);
+  const [creating, setCreating] = useState(false);
+
+  // Redirect to login if not authenticated
+  useEffect(() => {
+    if (!authLoading && !user) {
+      window.location.href = '/login';
+    }
+  }, [authLoading, user]);
+
+  const fetchProjects = useCallback(async () => {
+    if (!token || !backendUrl) return;
+    setLoadingProjects(true);
+    setError(null);
+    try {
+      const r = await fetch(`${backendUrl}/keys`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = await r.json();
+      if (!r.ok) throw new Error(data.error || `HTTP ${r.status}`);
+      setProjects(data.keys || []);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoadingProjects(false);
+    }
+  }, [token, backendUrl]);
+
+  useEffect(() => {
+    fetchProjects();
+  }, [fetchProjects]);
+
+  function handleUseProject(project) {
+    try {
+      const existing = JSON.parse(localStorage.getItem('lcyt-config') || '{}');
+      localStorage.setItem('lcyt-config', JSON.stringify({
+        ...existing,
+        backendUrl,
+        apiKey: project.key,
+      }));
+    } catch {
+      localStorage.setItem('lcyt-config', JSON.stringify({ backendUrl, apiKey: project.key }));
+    }
+    window.location.href = '/';
+  }
+
+  async function handleRename(key, newName) {
+    const r = await fetch(`${backendUrl}/keys/${encodeURIComponent(key)}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ name: newName }),
+    });
+    const data = await r.json();
+    if (!r.ok) throw new Error(data.error || `HTTP ${r.status}`);
+    setProjects(prev => prev.map(p => p.key === key ? { ...p, owner: data.owner } : p));
+  }
+
+  async function handleDelete(key) {
+    if (!confirm('Delete this project? The API key will be revoked.')) return;
+    const r = await fetch(`${backendUrl}/keys/${encodeURIComponent(key)}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!r.ok) {
+      const data = await r.json().catch(() => ({}));
+      alert(data.error || `HTTP ${r.status}`);
+      return;
+    }
+    setProjects(prev => prev.filter(p => p.key !== key));
+  }
+
+  if (authLoading) {
+    return (
+      <div style={{ minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'var(--color-bg)' }}>
+        <span style={{ color: 'var(--color-text-muted)' }}>Loading…</span>
+      </div>
+    );
+  }
+
+  if (!user) return null; // redirecting
+
+  return (
+    <div style={{
+      minHeight: '100vh',
+      background: 'var(--color-bg)',
+      padding: '32px 24px',
+      maxWidth: 600,
+      margin: '0 auto',
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
+        <h1 style={{ fontSize: 22, fontWeight: 600, color: 'var(--color-text)' }}>Projects</h1>
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+          <span style={{ fontSize: 13, color: 'var(--color-text-muted)' }}>{user.email}</span>
+          <button className="btn btn--ghost btn--sm" onClick={logout}>Sign out</button>
+        </div>
+      </div>
+      <p style={{ fontSize: 13, color: 'var(--color-text-muted)', marginBottom: 24 }}>
+        Each project has its own API key. Select a project to use it in the app.
+      </p>
+
+      {error && (
+        <div style={{ color: 'var(--color-error)', fontSize: 13, marginBottom: 16 }}>{error}</div>
+      )}
+
+      {creating ? (
+        <div style={{ border: '1px solid var(--color-border)', borderRadius: 8, padding: '16px 20px', background: 'var(--color-surface)', marginBottom: 16 }}>
+          <CreateProjectForm
+            backendUrl={backendUrl}
+            token={token}
+            onCreated={newKey => {
+              setProjects(prev => [newKey, ...prev]);
+              setCreating(false);
+            }}
+            onCancel={() => setCreating(false)}
+          />
+        </div>
+      ) : (
+        <button
+          className="btn btn--primary"
+          onClick={() => setCreating(true)}
+          style={{ marginBottom: 16 }}
+        >
+          + New project
+        </button>
+      )}
+
+      {loadingProjects ? (
+        <div style={{ color: 'var(--color-text-muted)', fontSize: 13 }}>Loading projects…</div>
+      ) : projects.length === 0 ? (
+        <div style={{ color: 'var(--color-text-muted)', fontSize: 13 }}>
+          No projects yet. Create one to get started.
+        </div>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+          {projects.map(p => (
+            <ProjectCard
+              key={p.key}
+              project={p}
+              onUse={handleUseProject}
+              onRename={handleRename}
+              onDelete={handleDelete}
+            />
+          ))}
+        </div>
+      )}
+
+      <p style={{ marginTop: 32, fontSize: 13, color: 'var(--color-text-muted)' }}>
+        <a href="/" style={{ color: 'var(--color-text-muted)' }}>← Back to app</a>
+      </p>
+    </div>
+  );
+}

--- a/packages/lcyt-web/src/components/RegisterPage.jsx
+++ b/packages/lcyt-web/src/components/RegisterPage.jsx
@@ -1,0 +1,151 @@
+import { useState } from 'react';
+import { useUserAuth } from '../hooks/useUserAuth';
+
+function getBackendUrl() {
+  const params = new URLSearchParams(window.location.search);
+  const urlParam = params.get('server');
+  if (urlParam) return urlParam;
+  try {
+    const cfg = JSON.parse(localStorage.getItem('lcyt-config') || '{}');
+    return cfg.backendUrl || '';
+  } catch {
+    return '';
+  }
+}
+
+export function RegisterPage() {
+  const { register } = useUserAuth();
+  const [backendUrl, setBackendUrl] = useState(getBackendUrl);
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    if (!backendUrl.trim() || !email.trim() || !password) return;
+    if (password !== confirm) {
+      setError('Passwords do not match');
+      return;
+    }
+    if (password.length < 8) {
+      setError('Password must be at least 8 characters');
+      return;
+    }
+    setError(null);
+    setLoading(true);
+    try {
+      await register(backendUrl.trim(), email.trim(), password, name.trim() || undefined);
+      window.location.href = '/projects';
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div style={{
+      minHeight: '100vh',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      background: 'var(--color-bg)',
+      padding: 24,
+    }}>
+      <div style={{ width: '100%', maxWidth: 400 }}>
+        <h1 style={{ fontSize: 22, fontWeight: 600, marginBottom: 24, color: 'var(--color-text)' }}>
+          Create account
+        </h1>
+        <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <div className="settings-field">
+            <label className="settings-field__label">Server URL</label>
+            <input
+              className="settings-field__input"
+              type="url"
+              value={backendUrl}
+              onChange={e => setBackendUrl(e.target.value)}
+              placeholder="https://api.lcyt.fi"
+              required
+              autoComplete="url"
+            />
+          </div>
+          <div className="settings-field">
+            <label className="settings-field__label">Name (optional)</label>
+            <input
+              className="settings-field__input"
+              type="text"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              placeholder="Your name"
+              autoComplete="name"
+              autoFocus
+            />
+          </div>
+          <div className="settings-field">
+            <label className="settings-field__label">Email</label>
+            <input
+              className="settings-field__input"
+              type="email"
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+              placeholder="you@example.com"
+              required
+              autoComplete="email"
+            />
+          </div>
+          <div className="settings-field">
+            <label className="settings-field__label">Password</label>
+            <input
+              className="settings-field__input"
+              type="password"
+              value={password}
+              onChange={e => setPassword(e.target.value)}
+              placeholder="At least 8 characters"
+              required
+              autoComplete="new-password"
+              minLength={8}
+            />
+          </div>
+          <div className="settings-field">
+            <label className="settings-field__label">Confirm password</label>
+            <input
+              className="settings-field__input"
+              type="password"
+              value={confirm}
+              onChange={e => setConfirm(e.target.value)}
+              placeholder="Repeat password"
+              required
+              autoComplete="new-password"
+            />
+          </div>
+          {error && (
+            <div style={{ color: 'var(--color-error)', fontSize: 13 }}>{error}</div>
+          )}
+          <button
+            className="btn btn--primary"
+            type="submit"
+            disabled={loading}
+            style={{ marginTop: 4 }}
+          >
+            {loading ? 'Creating account…' : 'Create account'}
+          </button>
+        </form>
+        <p style={{ marginTop: 20, fontSize: 13, color: 'var(--color-text-muted)', textAlign: 'center' }}>
+          Already have an account?{' '}
+          <a
+            href={`/login${backendUrl ? `?server=${encodeURIComponent(backendUrl)}` : ''}`}
+            style={{ color: 'var(--color-accent)' }}
+          >
+            Sign in
+          </a>
+        </p>
+        <p style={{ marginTop: 8, fontSize: 13, color: 'var(--color-text-muted)', textAlign: 'center' }}>
+          <a href="/" style={{ color: 'var(--color-text-muted)' }}>Back to app</a>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/packages/lcyt-web/src/components/SettingsModal.jsx
+++ b/packages/lcyt-web/src/components/SettingsModal.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
+import { useUserAuth } from '../hooks/useUserAuth';
 import { useSessionContext } from '../contexts/SessionContext';
 import { useLang } from '../contexts/LangContext';
 import { FilesModal } from './FilesModal';
@@ -227,6 +228,7 @@ export function SettingsModal({ isOpen, onClose, inline }) {
   const session = useSessionContext();
   const { showToast } = useToastContext();
   const { lang, setLang, t, LOCALE_CODES } = useLang();
+  const { user: loggedInUser, logout: userLogout } = useUserAuth();
 
   const [activeTab, setActiveTab] = useState('basic');
   const [advancedMode, setAdvancedModeState] = useState(getAdvancedMode);
@@ -466,6 +468,35 @@ export function SettingsModal({ isOpen, onClose, inline }) {
           {/* ── Basic ── */}
           {activeTab === 'basic' && (
             <div className="settings-panel settings-panel--active">
+
+              {loggedInUser && (
+                <div className="settings-field" style={{ background: 'var(--color-surface)', borderRadius: 6, padding: '10px 12px' }}>
+                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
+                    <span style={{ fontSize: 13, color: 'var(--color-text-muted)' }}>
+                      Signed in as <strong style={{ color: 'var(--color-text)' }}>{loggedInUser.email}</strong>
+                    </span>
+                    <div style={{ display: 'flex', gap: 6 }}>
+                      <a href="/projects" className="btn btn--ghost btn--sm" style={{ textDecoration: 'none' }}>
+                        Projects
+                      </a>
+                      <button
+                        className="btn btn--ghost btn--sm"
+                        onClick={userLogout}
+                        style={{ color: 'var(--color-text-muted)' }}
+                      >
+                        Sign out
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {!loggedInUser && (
+                <div className="settings-field" style={{ fontSize: 13, color: 'var(--color-text-muted)' }}>
+                  <a href="/login" style={{ color: 'var(--color-accent)' }}>Sign in</a>
+                  {' '}to manage your projects, or enter credentials manually below.
+                </div>
+              )}
 
               <div className="settings-field">
                 <label className="settings-field__label">{t('settings.connection.backendUrl')}</label>

--- a/packages/lcyt-web/src/hooks/useUserAuth.js
+++ b/packages/lcyt-web/src/hooks/useUserAuth.js
@@ -1,0 +1,119 @@
+import { useState, useEffect, useCallback } from 'react';
+
+const STORAGE_KEY = 'lcyt-user';
+
+function loadStored() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function saveStored(data) {
+  if (data) {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  } else {
+    localStorage.removeItem(STORAGE_KEY);
+  }
+}
+
+/**
+ * Hook for managing user-level authentication (email + password login).
+ * Separate from the caption session (API key + JWT).
+ *
+ * Persists { token, backendUrl } to localStorage under 'lcyt-user'.
+ */
+export function useUserAuth() {
+  const [user, setUser] = useState(null);     // { userId, email, name }
+  const [token, setToken] = useState(null);   // user JWT string
+  const [backendUrl, setBackendUrl] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  // On mount: verify stored token against /auth/me
+  useEffect(() => {
+    const stored = loadStored();
+    if (!stored?.token || !stored?.backendUrl) {
+      setLoading(false);
+      return;
+    }
+    const base = stored.backendUrl.replace(/\/$/, '');
+    fetch(`${base}/auth/me`, {
+      headers: { Authorization: `Bearer ${stored.token}` },
+    })
+      .then(r => r.ok ? r.json() : null)
+      .then(data => {
+        if (data?.userId) {
+          setToken(stored.token);
+          setBackendUrl(stored.backendUrl);
+          setUser({ userId: data.userId, email: data.email, name: data.name });
+        } else {
+          saveStored(null);
+        }
+      })
+      .catch(() => {
+        // Network error — keep stored creds, will retry on next action
+        setToken(stored.token);
+        setBackendUrl(stored.backendUrl);
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  const login = useCallback(async (url, email, password) => {
+    const base = url.replace(/\/$/, '');
+    const res = await fetch(`${base}/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || 'Login failed');
+    saveStored({ token: data.token, backendUrl: base });
+    setToken(data.token);
+    setBackendUrl(base);
+    setUser({ userId: data.userId, email: data.email, name: data.name });
+    return data;
+  }, []);
+
+  const register = useCallback(async (url, email, password, name) => {
+    const base = url.replace(/\/$/, '');
+    const res = await fetch(`${base}/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password, name }),
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || 'Registration failed');
+    saveStored({ token: data.token, backendUrl: base });
+    setToken(data.token);
+    setBackendUrl(base);
+    setUser({ userId: data.userId, email: data.email, name: data.name });
+    return data;
+  }, []);
+
+  const logout = useCallback(() => {
+    saveStored(null);
+    setToken(null);
+    setBackendUrl(null);
+    setUser(null);
+  }, []);
+
+  const changePassword = useCallback(async (currentPassword, newPassword) => {
+    if (!token || !backendUrl) throw new Error('Not logged in');
+    const res = await fetch(`${backendUrl}/auth/change-password`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ currentPassword, newPassword }),
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || 'Password change failed');
+    return data;
+  }, [token, backendUrl]);
+
+  return { user, token, backendUrl, loading, login, register, logout, changePassword };
+}

--- a/packages/lcyt-web/src/main.jsx
+++ b/packages/lcyt-web/src/main.jsx
@@ -19,6 +19,9 @@ import { ProductionCamerasPage } from './components/ProductionCamerasPage';
 import { ProductionMixersPage } from './components/ProductionMixersPage';
 import { ProductionBridgesPage } from './components/ProductionBridgesPage';
 import { ProductionOperatorPage } from './components/ProductionOperatorPage';
+import { LoginPage } from './components/LoginPage';
+import { RegisterPage } from './components/RegisterPage';
+import { ProjectsPage } from './components/ProjectsPage';
 
 const path = window.location.pathname;
 
@@ -41,6 +44,9 @@ function getPage() {
   if (path.startsWith('/production/mixers'))        return <ProductionMixersPage />;
   if (path.startsWith('/production/bridges'))       return <ProductionBridgesPage />;
   if (path.startsWith('/production'))               return <ProductionOperatorPage />;
+  if (path.startsWith('/login'))                    return <LoginPage />;
+  if (path.startsWith('/register'))                 return <RegisterPage />;
+  if (path.startsWith('/projects'))                 return <ProjectsPage />;
   return <App />;
 }
 


### PR DESCRIPTION
feat(admin-cli): add user management commands + user_id in key output

- New `users` subcommand group:
  - users list                    — table of all user accounts
  - users info <email|id>         — user details + their API keys
  - users add --email --password [--name]  — create user (bcrypt hash)
  - users set-password <email|id> --password  — reset password
  - users deactivate / activate   — enable/disable login
  - users delete [--force]        — delete user; --force unlinks keys
- Key commands updated:
  - list — adds USER column showing user_id
  - info — shows user id field
  - add  — accepts --user-email and --user-id to link key to a user

https://claude.ai/code/session_01A2wjBDasSVhTNx49sU9ut3