### PR TITLE
feat(dsk-editor): Phase 6 — standard editor features

### DIFF
--- a/docs/plan_dsk.md
+++ b/docs/plan_dsk.md
@@ -1,0 +1,319 @@
+# Plan: DSK Graphics Editor — Phase 2 (Editable Shapes)
+
+---
+id: plan/dsk
+---
+
+> Target branch: `claude/add-editable-shapes-yxAXO`
+
+---
+
+## Phase 1 — Status: Complete
+
+Phase 1 shipped the full DSK template editor pipeline:
+
+| Component | File | Status |
+|---|---|---|
+| Visual editor UI | `packages/lcyt-web/src/components/DskEditorPage.jsx` | ✓ Done |
+| Broadcast control panel | `packages/lcyt-web/src/components/DskControlPage.jsx` | ✓ Done |
+| Green-screen overlay display | `packages/lcyt-web/src/components/DskPage.jsx` | ✓ Done |
+| Playwright renderer + ffmpeg RTMP output | `packages/plugins/lcyt-dsk/src/renderer.js` | ✓ Done |
+| Template CRUD API | `packages/plugins/lcyt-dsk/src/routes/dsk-templates.js` | ✓ Done |
+| DB helpers | `packages/plugins/lcyt-dsk/src/db/dsk-templates.js` | ✓ Done |
+| Editor auth middleware | `packages/plugins/lcyt-dsk/src/middleware/editor-auth.js` | ✓ Done |
+
+**Phase 1 capabilities:**
+- Create/edit/delete named templates stored as JSON on the backend
+- Preset templates: Lower Third, Corner Bug, Full-screen Title
+- Layers: `rect`, `text`, `image` with CSS style overrides
+- Reorder layers (z-index), delete, add
+- Click a layer in the 960×540 scaled preview to select it
+- Property editor panel: form inputs for x, y, width, height, and type-specific style fields
+- Save to backend; Playwright renders to HTML → ffmpeg → RTMP
+- `DskControlPage`: activate templates and inject live text data
+
+---
+
+## Phase 2 — Editable Shapes
+
+### Goal
+
+Replace the forms-only workflow with direct manipulation on the preview canvas:
+users can drag to move layers and drag resize handles to resize them, without
+needing to type numbers into the property panel. The panel remains available
+for precise numeric editing.
+
+### User-visible changes
+
+1. **Drag to move**: grab any layer and drag it; x/y update in real time.
+2. **Resize handles**: 8 handles appear around the selected layer (4 corners + 4 edge midpoints); dragging any handle resizes (and for top/left handles, also repositions) the layer.
+3. **Keyboard nudge**: arrow keys move the selected layer by 1 px; Shift+arrow by 10 px.
+4. **Cursor feedback**: `move` cursor when hovering a layer, `resize` cursors on handles.
+5. **No-op on deselect**: clicking the canvas background deselects the layer.
+
+### Scale contract
+
+The preview renders a 1920×1080 canvas scaled to 50% (960×540 display area).
+All pointer events must divide coordinates by 0.5 before storing them in the
+template JSON, and the preview must multiply stored coordinates by 0.5 when
+positioning elements.
+
+---
+
+## Implementation Plan
+
+### 1. `TemplatePreview` — add drag-move and resize-handle support
+
+**File:** `packages/lcyt-web/src/components/DskEditorPage.jsx`
+
+#### 1a. New props
+
+```js
+function TemplatePreview({ template, selectedLayerId, onSelectLayer, onMoveLayer, onResizeLayer })
+```
+
+- `onMoveLayer(id, { x, y })` — called during and after drag; updates layer position
+- `onResizeLayer(id, { x, y, width, height })` — called during and after handle drag
+
+#### 1b. Drag-to-move
+
+Replace the plain `onClick` on each layer element with full pointer-event handling:
+
+```
+onPointerDown(e) {
+  if layer is not selected → select it and return (first click selects only)
+  capture pointer
+  record startPointer = { x: e.clientX, y: e.clientY }
+  record startPos    = { x: layer.x, y: layer.y }
+  set dragging = true
+}
+
+onPointerMove(e) {
+  if !dragging return
+  const dx = (e.clientX - startPointer.x) / SCALE   // SCALE = 0.5
+  const dy = (e.clientY - startPointer.y) / SCALE
+  onMoveLayer(id, {
+    x: Math.round(startPos.x + dx),
+    y: Math.round(startPos.y + dy),
+  })
+}
+
+onPointerUp(e) {
+  release pointer
+  dragging = false
+}
+```
+
+Use `useRef` for drag state (not `useState`) to avoid re-renders mid-drag. The final
+position is committed to React state via `onMoveLayer`, which calls the parent's
+`updateLayer`.
+
+#### 1c. Resize handles
+
+Render 8 handle `<div>` elements as children of the selected-layer wrapper.
+Each handle is a small square (8×8 px at display scale) absolutely positioned
+at one of these anchor points relative to the layer:
+
+| Handle ID | CSS position | Cursor |
+|---|---|---|
+| `nw` | top-left | `nw-resize` |
+| `n` | top-center | `n-resize` |
+| `ne` | top-right | `ne-resize` |
+| `e` | center-right | `e-resize` |
+| `se` | bottom-right | `se-resize` |
+| `s` | bottom-center | `s-resize` |
+| `sw` | bottom-left | `sw-resize` |
+| `w` | center-left | `w-resize` |
+
+Each handle has its own `onPointerDown` handler that records:
+- `handle` — which of the 8 anchors
+- `startPointer` — pointer coords at mousedown
+- `startRect` — `{ x, y, width, height }` at mousedown
+
+On `onPointerMove` (attached to the outer canvas container, not the handle itself,
+to avoid losing the pointer if the mouse moves fast):
+
+```
+delta = { dx: (e.clientX - startPointer.x) / SCALE,
+          dy: (e.clientY - startPointer.y) / SCALE }
+
+Compute new { x, y, width, height } based on handle:
+  "e"  → width  += dx
+  "w"  → x += dx, width -= dx
+  "s"  → height += dy
+  "n"  → y += dy, height -= dy
+  "se" → width += dx, height += dy
+  "sw" → x += dx, width -= dx, height += dy
+  "ne" → width += dx, y += dy, height -= dy
+  "nw" → x += dx, width -= dx, y += dy, height -= dy
+
+Clamp: width = Math.max(4, Math.round(width))
+       height = Math.max(4, Math.round(height))
+       x = Math.round(x), y = Math.round(y)
+
+onResizeLayer(id, { x, y, width, height })
+```
+
+The outer canvas container (the 960×540 `<div>`) receives `onPointerMove` and
+`onPointerUp` so the drag continues even if the pointer leaves the layer element.
+
+#### 1d. Keyboard nudge
+
+Attach `onKeyDown` to the preview container (make it `tabIndex={0}` and
+`outline: none`):
+
+```
+if (!selectedLayerId) return
+const step = e.shiftKey ? 10 : 1
+switch (e.key) {
+  case 'ArrowLeft':  onMoveLayer(id, { x: layer.x - step, y: layer.y }); break
+  case 'ArrowRight': onMoveLayer(id, { x: layer.x + step, y: layer.y }); break
+  case 'ArrowUp':    onMoveLayer(id, { x: layer.x, y: layer.y - step }); break
+  case 'ArrowDown':  onMoveLayer(id, { x: layer.x, y: layer.y + step }); break
+}
+e.preventDefault()
+```
+
+#### 1e. Deselect on canvas click
+
+The outer 960×540 container already calls `onClick={() => setSelectedLayerId(null)}`
+via the existing `onSelectLayer` prop — no change needed.
+
+---
+
+### 2. `DskEditorPage` — wire new callbacks
+
+In `DskEditorPage`, add two new handlers and pass them to `TemplatePreview`:
+
+```js
+function moveLayer(id, { x, y }) {
+  setTemplate(t => ({
+    ...t,
+    layers: t.layers.map(l =>
+      l.id === id ? { ...l, x, y } : l
+    ),
+  }));
+  isDirty.current = true;
+}
+
+function resizeLayer(id, { x, y, width, height }) {
+  setTemplate(t => ({
+    ...t,
+    layers: t.layers.map(l =>
+      l.id === id ? { ...l, x, y, width, height } : l
+    ),
+  }));
+  isDirty.current = true;
+}
+```
+
+Pass to preview:
+
+```jsx
+<TemplatePreview
+  template={template}
+  selectedLayerId={selectedLayerId}
+  onSelectLayer={id => setSelectedLayerId(id === selectedLayerId ? null : id)}
+  onMoveLayer={moveLayer}
+  onResizeLayer={resizeLayer}
+/>
+```
+
+The `LayerPropertyEditor` already calls `onChange` (which calls `updateLayer`) on
+each keystroke — no change needed there. The two sources of truth (canvas drag and
+form inputs) both flow through `setTemplate`, so they stay in sync automatically.
+
+---
+
+### 3. Pointer event coordination — drag vs click
+
+A plain click on a non-selected layer must only select it (not start a drag).
+Use a `hasMoved` ref to distinguish:
+
+```
+onPointerDown: hasMoved = false; dragging = true
+onPointerMove: if distance > 3px: hasMoved = true; ... update position
+onPointerUp: if !hasMoved: onSelectLayer(id)  // treat as click
+             dragging = false
+```
+
+This prevents accidental position changes when the user intends just to select.
+
+---
+
+### 4. Handle rendering details
+
+Handles are rendered **outside** the `transform: scale(0.5)` container, or they
+must be sized at `8/0.5 = 16 px` in template coordinates to appear as 8 px in the
+scaled preview.
+
+**Recommended approach**: render handles inside the scaled container at 16×16 px
+(template space), which shows as 8×8 px at 50% scale, centred on the handle anchor.
+Position them using CSS `transform: translate(-50%, -50%)` relative to the anchor
+corner/edge.
+
+Each handle `<div>` style:
+
+```js
+{
+  position: 'absolute',
+  width: 16,
+  height: 16,
+  background: '#4af',
+  border: '2px solid #fff',
+  borderRadius: 2,
+  cursor: `${handle}-resize`,
+  zIndex: 9999,
+  // Anchor positioning computed from layer dimensions + handle id
+}
+```
+
+Handle anchor coordinates (in template px, relative to layer origin):
+
+| Handle | left | top |
+|---|---|---|
+| `nw` | 0 | 0 |
+| `n` | width/2 | 0 |
+| `ne` | width | 0 |
+| `e` | width | height/2 |
+| `se` | width | height |
+| `s` | width/2 | height |
+| `sw` | 0 | height |
+| `w` | 0 | height/2 |
+
+```js
+style={{
+  left: anchorX,
+  top:  anchorY,
+  transform: 'translate(-50%, -50%)',
+}}
+```
+
+---
+
+### 5. No backend changes required
+
+Phase 2 is purely a UI change. The template JSON schema (`x`, `y`, `width`,
+`height`) is unchanged; the property editor, save/load, Playwright renderer, and
+all API routes are unaffected.
+
+---
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `packages/lcyt-web/src/components/DskEditorPage.jsx` | Add drag-move, resize handles, keyboard nudge; wire `onMoveLayer` / `onResizeLayer` callbacks |
+
+No other files need to change.
+
+---
+
+## Scope explicitly excluded from Phase 2
+
+- Snap to grid / snap to other layers (Phase 3)
+- Multi-selection and group move (Phase 3)
+- Undo/redo (Phase 3)
+- New shape types (`ellipse`, `line`, `polygon`) (Phase 3)
+- Rotation handle (Phase 3)
+- Image upload drag-and-drop into canvas (separate feature)

--- a/packages/lcyt-web/src/components/DskEditorPage.jsx
+++ b/packages/lcyt-web/src/components/DskEditorPage.jsx
@@ -7,7 +7,52 @@ import { useCallback, useEffect, useRef, useState } from 'react';
  *
  * Allows designing lower-third, bug, and full-screen graphic templates stored
  * as JSON on the backend. Preview mirrors the Playwright renderer output.
+ *
+ * Phase 2: direct manipulation — drag to move layers, 8-point resize handles,
+ * keyboard nudge (arrow keys, Shift+arrow for ×10 step).
  */
+
+// ── Scale ────────────────────────────────────────────────────────────────────
+
+// Preview renders the 1920×1080 canvas at 50% (960×540 display area).
+// Pointer delta in screen space must be divided by SCALE to get template px.
+const SCALE = 0.5;
+
+// ── Resize handles ───────────────────────────────────────────────────────────
+
+const HANDLE_LIST = ['nw', 'n', 'ne', 'e', 'se', 's', 'sw', 'w'];
+const HANDLE_CURSORS = {
+  nw: 'nw-resize', n: 'n-resize',  ne: 'ne-resize',
+  e:  'e-resize',  se: 'se-resize', s:  's-resize',
+  sw: 'sw-resize', w:  'w-resize',
+};
+
+/** Anchor point of a handle in template coordinates (relative to canvas origin). */
+function handleAnchor(handle, layer) {
+  const x = Number(layer.x) || 0;
+  const y = Number(layer.y) || 0;
+  const w = Number(layer.width)  || 0;
+  const h = Number(layer.height) || 0;
+  return {
+    left: handle.includes('e') ? x + w : handle.includes('w') ? x : x + w / 2,
+    top:  handle.includes('s') ? y + h : handle.includes('n') ? y : y + h / 2,
+  };
+}
+
+/** Compute updated { x, y, width, height } after dragging a resize handle by (dx, dy) template px. */
+function applyResize(handle, startRect, dx, dy) {
+  let { x, y, width, height } = startRect;
+  if (handle.includes('e')) width  = width  + dx;
+  if (handle.includes('w')) { x += dx; width  = width  - dx; }
+  if (handle.includes('s')) height = height + dy;
+  if (handle.includes('n')) { y += dy; height = height - dy; }
+  return {
+    x:      Math.round(x),
+    y:      Math.round(y),
+    width:  Math.max(4, Math.round(width)),
+    height: Math.max(4, Math.round(height)),
+  };
+}
 
 // ── Preset templates ────────────────────────────────────────────────────────
 
@@ -94,22 +139,152 @@ const EMPTY_TEMPLATE = {
 /**
  * Renders template JSON layers as React JSX in a scaled container.
  * Mirrors the logic in packages/plugins/lcyt-dsk/src/renderer.js renderTemplateToHtml().
+ *
+ * Phase 2: supports drag-to-move, resize handles, and keyboard nudge.
+ *
+ * Props:
+ *   template         — template JSON object
+ *   selectedLayerId  — id of the currently selected layer (or null)
+ *   onSelectLayer(id) — called when user clicks a layer (parent toggles selection)
+ *   onMoveLayer(id, { x, y }) — called during and after drag-move
+ *   onResizeLayer(id, { x, y, width, height }) — called during and after resize-drag
  */
-function TemplatePreview({ template, selectedLayerId, onSelectLayer }) {
+function TemplatePreview({ template, selectedLayerId, onSelectLayer, onMoveLayer, onResizeLayer }) {
   const t = template || EMPTY_TEMPLATE;
   const layers = Array.isArray(t.layers) ? t.layers : [];
 
+  const containerRef = useRef(null);
+  // dragRef.current: null | { type: 'move'|'resize'|'background', layerId?, handle?,
+  //                            startPointer, startRect?, hasMoved }
+  const dragRef = useRef(null);
+
+  // ── Drag initiation ───────────────────────────────────────────────────────
+
+  function startLayerDrag(e, layerId) {
+    e.stopPropagation();
+    const layer = layers.find(l => l.id === layerId);
+    if (!layer) return;
+    dragRef.current = {
+      type: 'move',
+      layerId,
+      startPointer: { x: e.clientX, y: e.clientY },
+      startRect: {
+        x:      Number(layer.x)      || 0,
+        y:      Number(layer.y)      || 0,
+        width:  Number(layer.width)  || 0,
+        height: Number(layer.height) || 0,
+      },
+      hasMoved: false,
+    };
+    // Capture pointer on the container so pointermove fires there even when
+    // the cursor leaves the layer element during a fast drag.
+    containerRef.current?.setPointerCapture(e.pointerId);
+  }
+
+  function startHandleDrag(e, layerId, handle) {
+    e.stopPropagation();
+    const layer = layers.find(l => l.id === layerId);
+    if (!layer) return;
+    dragRef.current = {
+      type: 'resize',
+      layerId,
+      handle,
+      startPointer: { x: e.clientX, y: e.clientY },
+      startRect: {
+        x:      Number(layer.x)      || 0,
+        y:      Number(layer.y)      || 0,
+        width:  Number(layer.width)  || 0,
+        height: Number(layer.height) || 0,
+      },
+      hasMoved: false,
+    };
+    containerRef.current?.setPointerCapture(e.pointerId);
+  }
+
+  // ── Container pointer handlers ────────────────────────────────────────────
+
+  function onContainerPointerDown(e) {
+    // Fires only for background clicks — layer/handle events call stopPropagation.
+    dragRef.current = { type: 'background' };
+  }
+
+  function onContainerPointerMove(e) {
+    const drag = dragRef.current;
+    if (!drag || drag.type === 'background') return;
+
+    const dx = (e.clientX - drag.startPointer.x) / SCALE;
+    const dy = (e.clientY - drag.startPointer.y) / SCALE;
+
+    // Debounce: require > 3 screen px before marking as a real drag.
+    if (!drag.hasMoved &&
+        (Math.abs(e.clientX - drag.startPointer.x) > 3 ||
+         Math.abs(e.clientY - drag.startPointer.y) > 3)) {
+      drag.hasMoved = true;
+    }
+    if (!drag.hasMoved) return;
+
+    if (drag.type === 'move') {
+      onMoveLayer(drag.layerId, {
+        x: Math.round(drag.startRect.x + dx),
+        y: Math.round(drag.startRect.y + dy),
+      });
+    } else if (drag.type === 'resize') {
+      onResizeLayer(drag.layerId, applyResize(drag.handle, drag.startRect, dx, dy));
+    }
+  }
+
+  function onContainerPointerUp(e) {
+    const drag = dragRef.current;
+    dragRef.current = null;
+    if (!drag) return;
+
+    if (drag.type === 'background') {
+      // Click on empty canvas area → deselect.
+      onSelectLayer(null);
+    } else if (!drag.hasMoved) {
+      // Pointer went down and up without moving → treat as a select/deselect click.
+      onSelectLayer(drag.layerId);
+    }
+  }
+
+  // ── Keyboard nudge ────────────────────────────────────────────────────────
+
+  function onContainerKeyDown(e) {
+    if (!selectedLayerId) return;
+    const layer = layers.find(l => l.id === selectedLayerId);
+    if (!layer) return;
+    const step = e.shiftKey ? 10 : 1;
+    const x = Number(layer.x) || 0;
+    const y = Number(layer.y) || 0;
+    if (e.key === 'ArrowLeft')  { onMoveLayer(selectedLayerId, { x: x - step, y }); e.preventDefault(); }
+    if (e.key === 'ArrowRight') { onMoveLayer(selectedLayerId, { x: x + step, y }); e.preventDefault(); }
+    if (e.key === 'ArrowUp')    { onMoveLayer(selectedLayerId, { x, y: y - step }); e.preventDefault(); }
+    if (e.key === 'ArrowDown')  { onMoveLayer(selectedLayerId, { x, y: y + step }); e.preventDefault(); }
+  }
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
   return (
-    <div style={{
-      width: 960,
-      height: 540,
-      position: 'relative',
-      overflow: 'hidden',
-      flexShrink: 0,
-      border: '2px solid #444',
-      borderRadius: 4,
-      cursor: 'default',
-    }}>
+    <div
+      ref={containerRef}
+      tabIndex={0}
+      style={{
+        width: 960,
+        height: 540,
+        position: 'relative',
+        overflow: 'hidden',
+        flexShrink: 0,
+        border: '2px solid #444',
+        borderRadius: 4,
+        cursor: 'default',
+        outline: 'none',
+        touchAction: 'none',
+      }}
+      onPointerDown={onContainerPointerDown}
+      onPointerMove={onContainerPointerMove}
+      onPointerUp={onContainerPointerUp}
+      onKeyDown={onContainerKeyDown}
+    >
       {/* Canvas at 1920×1080 scaled to 50% */}
       <div style={{
         width: 1920,
@@ -124,24 +299,24 @@ function TemplatePreview({ template, selectedLayerId, onSelectLayer }) {
           ? 'repeating-conic-gradient(#2a2a2a 0% 25%, #1a1a1a 0% 50%) 0 0 / 40px 40px'
           : undefined,
       }}>
-        {layers.map((layer) => {
+        {layers.flatMap((layer) => {
           const isSelected = layer.id === selectedLayerId;
           const base = {
             position: 'absolute',
             left: Number(layer.x) || 0,
             top: Number(layer.y) || 0,
-            ...(layer.width != null ? { width: Number(layer.width) } : {}),
+            ...(layer.width  != null ? { width:  Number(layer.width)  } : {}),
             ...(layer.height != null ? { height: Number(layer.height) } : {}),
             outline: isSelected ? '3px solid #4af' : undefined,
-            cursor: 'pointer',
+            cursor: 'move',
             boxSizing: 'border-box',
+            userSelect: 'none',
           };
 
-          // Apply style object (CSS property names as-is from template JSON)
+          // Convert kebab-case CSS keys to camelCase for React
           const styleProps = {};
           if (layer.style) {
             for (const [k, v] of Object.entries(layer.style)) {
-              // Convert kebab-case to camelCase for React
               const camel = k.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
               styleProps[camel] = v;
             }
@@ -149,31 +324,61 @@ function TemplatePreview({ template, selectedLayerId, onSelectLayer }) {
 
           const merged = { ...base, ...styleProps };
 
-          const handleClick = (e) => {
-            e.stopPropagation();
-            onSelectLayer(layer.id);
-          };
-
+          let layerEl;
           if (layer.type === 'text') {
-            return (
-              <div key={layer.id} style={merged} onClick={handleClick}>
+            layerEl = (
+              <div key={layer.id} style={merged}
+                   onPointerDown={e => startLayerDrag(e, layer.id)}>
                 {layer.text || ''}
               </div>
             );
           } else if (layer.type === 'rect') {
-            return <div key={layer.id} style={merged} onClick={handleClick} />;
+            layerEl = (
+              <div key={layer.id} style={merged}
+                   onPointerDown={e => startLayerDrag(e, layer.id)} />
+            );
           } else if (layer.type === 'image') {
+            layerEl = (
+              <img key={layer.id} src={layer.src || ''} alt=""
+                   draggable={false}
+                   style={merged}
+                   onPointerDown={e => startLayerDrag(e, layer.id)} />
+            );
+          } else {
+            return [];
+          }
+
+          if (!isSelected) return [layerEl];
+
+          // Render 8 resize handles for the selected layer.
+          // Handles are in template px (1920×1080 space) — they scale to 8×8 px
+          // at 50% preview scale (16px template = 8px display).
+          const handles = HANDLE_LIST.map(handle => {
+            const { left, top } = handleAnchor(handle, layer);
             return (
-              <img
-                key={layer.id}
-                src={layer.src || ''}
-                alt=""
-                style={merged}
-                onClick={handleClick}
+              <div
+                key={`${layer.id}-${handle}`}
+                style={{
+                  position: 'absolute',
+                  left,
+                  top,
+                  width: 16,
+                  height: 16,
+                  background: '#4af',
+                  border: '2px solid #fff',
+                  borderRadius: 2,
+                  cursor: HANDLE_CURSORS[handle],
+                  zIndex: 9999,
+                  transform: 'translate(-50%, -50%)',
+                  boxSizing: 'border-box',
+                  touchAction: 'none',
+                }}
+                onPointerDown={e => startHandleDrag(e, layer.id, handle)}
               />
             );
-          }
-          return null;
+          });
+
+          return [layerEl, ...handles];
         })}
       </div>
     </div>
@@ -564,6 +769,24 @@ export function DskEditorPage() {
     isDirty.current = true;
   }
 
+  // ── Direct manipulation callbacks (Phase 2) ───────────────────────────────
+
+  function moveLayerPosition(id, { x, y }) {
+    setTemplate(t => ({
+      ...t,
+      layers: t.layers.map(l => l.id === id ? { ...l, x, y } : l),
+    }));
+    isDirty.current = true;
+  }
+
+  function resizeLayerRect(id, { x, y, width, height }) {
+    setTemplate(t => ({
+      ...t,
+      layers: t.layers.map(l => l.id === id ? { ...l, x, y, width, height } : l),
+    }));
+    isDirty.current = true;
+  }
+
   // ── Derived ──────────────────────────────────────────────────────────────
 
   const selectedLayer = template.layers?.find(l => l.id === selectedLayerId) || null;
@@ -680,6 +903,8 @@ export function DskEditorPage() {
               template={template}
               selectedLayerId={selectedLayerId}
               onSelectLayer={id => setSelectedLayerId(id === selectedLayerId ? null : id)}
+              onMoveLayer={moveLayerPosition}
+              onResizeLayer={resizeLayerRect}
             />
 
             {/* Layer list */}

--- a/packages/lcyt-web/src/components/DskEditorPage.jsx
+++ b/packages/lcyt-web/src/components/DskEditorPage.jsx
@@ -161,6 +161,7 @@ const EMPTY_TEMPLATE = {
 // ── Render a single layer element ─────────────────────────────────────────────
 
 function renderLayerElement(layer, isSelected, isInSelection, onPointerDown) {
+  if (layer.visible === false) return null;
   const base = {
     position: 'absolute',
     left:  Number(layer.x) || 0,
@@ -223,7 +224,7 @@ function renderLayerElement(layer, isSelected, isInSelection, onPointerDown) {
  */
 function TemplatePreview({
   template, selectedIds, primaryId,
-  onSelect, onDragStart, onMoveSelected, onResizeLayer, snapGrid,
+  onSelect, onDragStart, onMoveSelected, onResizeLayer, snapGrid, showSafeArea,
 }) {
   const t = template || EMPTY_TEMPLATE;
   const layers = Array.isArray(t.layers) ? t.layers : [];
@@ -425,6 +426,15 @@ function TemplatePreview({
           return [el, ...handles];
         })}
       </div>
+      {/* Safe area guides — rendered at display (960×540) coords, outside the scaled inner div */}
+      {showSafeArea && (<>
+        <div style={{ position:'absolute', left:'5%', top:'5%', right:'5%', bottom:'5%',
+                      border:'1px dashed rgba(255,255,0,0.6)', pointerEvents:'none', zIndex:10000,
+                      boxSizing:'border-box' }} title="90% title-safe" />
+        <div style={{ position:'absolute', left:'10%', top:'10%', right:'10%', bottom:'10%',
+                      border:'1px dashed rgba(255,140,0,0.5)', pointerEvents:'none', zIndex:10000,
+                      boxSizing:'border-box' }} title="80% action-safe" />
+      </>)}
     </div>
   );
 }
@@ -569,23 +579,30 @@ const COMMON_FIELDS = [
 
 const STYLE_FIELDS_RECT = [
   { key: 'background',   label: 'Background',   type: 'color-text' },
-  { key: 'opacity',      label: 'Opacity',      type: 'text', placeholder: '0.9' },
   { key: 'border-radius',label: 'Border radius',type: 'text', placeholder: '8px' },
 ];
 
 const STYLE_FIELDS_ELLIPSE = [
   { key: 'background', label: 'Background', type: 'color-text' },
-  { key: 'opacity',    label: 'Opacity',    type: 'text', placeholder: '0.9' },
 ];
 
 const STYLE_FIELDS_TEXT = [
   { key: 'font-family',  label: 'Font family',   type: 'text',   placeholder: 'Arial, sans-serif' },
   { key: 'font-size',    label: 'Font size',      type: 'text',   placeholder: '48px' },
-  { key: 'font-weight',  label: 'Font weight',    type: 'text',   placeholder: 'bold' },
+  { key: 'font-weight',  label: 'Font weight',    type: 'select', options: ['normal', 'bold', '100', '200', '300', '400', '500', '600', '700', '800', '900'] },
+  { key: 'font-style',   label: 'Italic',         type: 'select', options: ['normal', 'italic'] },
   { key: 'color',        label: 'Color',          type: 'color-text' },
   { key: 'letter-spacing', label: 'Letter spacing', type: 'text', placeholder: '2px' },
   { key: 'text-align',   label: 'Text align',     type: 'select', options: ['left', 'center', 'right'] },
   { key: 'white-space',  label: 'White space',    type: 'select', options: ['normal', 'nowrap', 'pre'] },
+  { key: 'text-shadow',       label: 'Text shadow',  type: 'text', placeholder: '1px 1px 4px #000' },
+  { key: '-webkit-text-stroke', label: 'Text stroke', type: 'text', placeholder: '1px #000' },
+];
+
+// Shared for all layer types
+const STYLE_FIELDS_BORDER = [
+  { key: 'border',     label: 'Border',  type: 'text', placeholder: '2px solid #fff' },
+  { key: 'box-shadow', label: 'Shadow',  type: 'text', placeholder: '0 2px 8px rgba(0,0,0,0.5)' },
 ];
 
 function ColorTextInput({ value, onChange }) {
@@ -601,7 +618,7 @@ function ColorTextInput({ value, onChange }) {
   );
 }
 
-function LayerPropertyEditor({ layer, selectionCount, onChange }) {
+function LayerPropertyEditor({ layer, selectionCount, aspectLock, onAspectLock, onChange }) {
   if (selectionCount > 1 && !layer) {
     return <div style={{ color: '#888', fontSize: 13, padding: '16px 0' }}>{selectionCount} layers selected.</div>;
   }
@@ -624,6 +641,24 @@ function LayerPropertyEditor({ layer, selectionCount, onChange }) {
                     : layer.type === 'ellipse' ? STYLE_FIELDS_ELLIPSE
                     : [];
 
+  const opacityVal = layer.style?.opacity !== undefined ? Number(layer.style.opacity) : 1;
+
+  function renderStyleField(f) {
+    if (f.type === 'color-text')
+      return <ColorTextInput value={layer.style?.[f.key] || ''} onChange={v => setStyle(f.key, v)} />;
+    if (f.type === 'select')
+      return (
+        <select value={layer.style?.[f.key] || ''} onChange={e => setStyle(f.key, e.target.value)} style={inputStyle}>
+          <option value="">—</option>
+          {f.options.map(o => <option key={o} value={o}>{o}</option>)}
+        </select>
+      );
+    return (
+      <input type="text" value={layer.style?.[f.key] || ''} placeholder={f.placeholder || ''}
+             onChange={e => setStyle(f.key, e.target.value)} style={inputStyle} />
+    );
+  }
+
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
       <div style={fieldRowStyle}>
@@ -640,6 +675,13 @@ function LayerPropertyEditor({ layer, selectionCount, onChange }) {
           <input type="text" value={layer.text || ''} onChange={e => setField('text', e.target.value)} style={inputStyle} />
         </div>
       )}
+      {layer.type === 'image' && (
+        <div style={fieldRowStyle}>
+          <span style={labelStyle}>Src</span>
+          <input type="text" value={layer.src || ''} onChange={e => setField('src', e.target.value)} style={inputStyle} />
+        </div>
+      )}
+
       <div style={sectionLabelStyle}>Position & Size</div>
       {COMMON_FIELDS.map(f => (
         <div key={f.key} style={fieldRowStyle}>
@@ -648,22 +690,45 @@ function LayerPropertyEditor({ layer, selectionCount, onChange }) {
                  style={{ ...inputStyle, width: 100 }} />
         </div>
       ))}
+      {layer.type === 'image' && (
+        <div style={fieldRowStyle}>
+          <span style={labelStyle}>Aspect lock</span>
+          <button onClick={onAspectLock}
+                  style={aspectLock ? btnActiveStyle : btnStyle}>
+            {aspectLock ? '🔒 On' : '🔓 Off'}
+          </button>
+        </div>
+      )}
+
+      {/* Global opacity for all types */}
+      <div style={sectionLabelStyle}>Opacity</div>
+      <div style={fieldRowStyle}>
+        <span style={labelStyle}>Opacity</span>
+        <input type="range" min="0" max="1" step="0.01" value={opacityVal}
+               onChange={e => setStyle('opacity', e.target.value)}
+               style={{ flex: 1, accentColor: '#4af' }} />
+        <span style={{ color: '#888', fontSize: 11, width: 32, textAlign: 'right', flexShrink: 0 }}>
+          {Math.round(opacityVal * 100)}%
+        </span>
+      </div>
+
       {styleFields.length > 0 && <div style={sectionLabelStyle}>Style</div>}
       {styleFields.map(f => (
         <div key={f.key} style={fieldRowStyle}>
           <span style={labelStyle}>{f.label}</span>
-          {f.type === 'color-text'
-            ? <ColorTextInput value={layer.style?.[f.key] || ''} onChange={v => setStyle(f.key, v)} />
-            : f.type === 'select'
-              ? <select value={layer.style?.[f.key] || ''} onChange={e => setStyle(f.key, e.target.value)} style={inputStyle}>
-                  <option value="">—</option>
-                  {f.options.map(o => <option key={o} value={o}>{o}</option>)}
-                </select>
-              : <input type="text" value={layer.style?.[f.key] || ''} placeholder={f.placeholder || ''}
-                       onChange={e => setStyle(f.key, e.target.value)} style={inputStyle} />
-          }
+          {renderStyleField(f)}
         </div>
       ))}
+
+      <div style={sectionLabelStyle}>Border & Shadow</div>
+      {STYLE_FIELDS_BORDER.map(f => (
+        <div key={f.key} style={fieldRowStyle}>
+          <span style={labelStyle}>{f.label}</span>
+          <input type="text" value={layer.style?.[f.key] || ''} placeholder={f.placeholder || ''}
+                 onChange={e => setStyle(f.key, e.target.value)} style={inputStyle} />
+        </div>
+      ))}
+
       <div style={sectionLabelStyle}>Animation</div>
       <AnimationEditor value={layer.animation || ''} onChange={v => setField('animation', v || undefined)} />
     </div>
@@ -711,6 +776,8 @@ export function DskEditorPage() {
   const [selectedIds, setSelectedIds] = useState(new Set()); // canvas multi-selection
   const [primaryId, setPrimaryId]     = useState(null);    // property-panel target
   const [snapGrid, setSnapGrid]       = useState(false);
+  const [showSafeArea, setShowSafeArea] = useState(false);
+  const [aspectLock, setAspectLock]   = useState(true);
   const [status, setStatus]           = useState('');
   const [loading, setLoading]         = useState(false);
 
@@ -722,8 +789,11 @@ export function DskEditorPage() {
   const [imgUploading, setImgUploading]   = useState(false);
   const [imgUploadErr, setImgUploadErr]   = useState('');
 
-  const isDirty    = useRef(false);
-  const imgInputRef = useRef(null);
+  const isDirty      = useRef(false);
+  const imgInputRef  = useRef(null);
+  const clipboardRef = useRef(null);
+  const selectedIdsRef = useRef(selectedIds);
+  useEffect(() => { selectedIdsRef.current = selectedIds; }, [selectedIds]);
   const historyRef = useRef({ past: [], future: [] });
   const templateRef = useRef(template); // mirror for use inside event listeners
   useEffect(() => { templateRef.current = template; }, [template]);
@@ -755,6 +825,27 @@ export function DskEditorPage() {
         if (!future.length) return;
         past.push(JSON.stringify(templateRef.current));
         setTemplate(JSON.parse(future.pop()));
+        isDirty.current = true;
+      }
+      if (e.key === 'c') {
+        const ids = selectedIdsRef.current;
+        if (!ids.size) return;
+        clipboardRef.current = templateRef.current.layers
+          .filter(l => ids.has(l.id))
+          .map(l => JSON.parse(JSON.stringify(l)));
+      }
+      if (e.key === 'v') {
+        e.preventDefault();
+        if (!clipboardRef.current?.length) return;
+        const tmpl = templateRef.current;
+        const pasted = clipboardRef.current.map(l => ({
+          ...l, id: newLayerId(l.type), x: (l.x || 0) + 20, y: (l.y || 0) + 20,
+        }));
+        historyRef.current.past.push(JSON.stringify(tmpl));
+        historyRef.current.future = [];
+        setTemplate(t => ({ ...t, layers: [...t.layers, ...pasted] }));
+        setSelectedIds(new Set(pasted.map(l => l.id)));
+        setPrimaryId(pasted[pasted.length - 1].id);
         isDirty.current = true;
       }
     }
@@ -964,6 +1055,50 @@ export function DskEditorPage() {
     isDirty.current = true;
   }
 
+  function toggleLayerVisibility(id) {
+    const layer = template.layers.find(l => l.id === id);
+    if (!layer) return;
+    updateLayer({ ...layer, visible: layer.visible === false ? undefined : false });
+  }
+
+  function duplicateLayer(id) {
+    pushHistory(template);
+    const src = template.layers.find(l => l.id === id);
+    if (!src) return;
+    const newId = newLayerId(src.type);
+    const copy = { ...JSON.parse(JSON.stringify(src)), id: newId, x: (src.x || 0) + 20, y: (src.y || 0) + 20 };
+    setTemplate(t => ({ ...t, layers: [...t.layers, copy] }));
+    setSelectedIds(new Set([newId]));
+    setPrimaryId(newId);
+    isDirty.current = true;
+  }
+
+  function alignLayers(axis, anchor) {
+    if (selectedIds.size < 1) return;
+    pushHistory(template);
+    const sel = template.layers.filter(l => selectedIds.has(l.id));
+    const minX = Math.min(...sel.map(l => l.x || 0));
+    const maxX = Math.max(...sel.map(l => (l.x || 0) + (l.width || 0)));
+    const minY = Math.min(...sel.map(l => l.y || 0));
+    const maxY = Math.max(...sel.map(l => (l.y || 0) + (l.height || 0)));
+    const cx = (minX + maxX) / 2, cy = (minY + maxY) / 2;
+    setTemplate(t => ({
+      ...t,
+      layers: t.layers.map(l => {
+        if (!selectedIds.has(l.id)) return l;
+        const w = l.width || 0, h = l.height || 0;
+        if (axis === 'x') {
+          const nx = anchor === 'min' ? minX : anchor === 'center' ? cx - w / 2 : maxX - w;
+          return { ...l, x: Math.round(nx) };
+        } else {
+          const ny = anchor === 'min' ? minY : anchor === 'center' ? cy - h / 2 : maxY - h;
+          return { ...l, y: Math.round(ny) };
+        }
+      }),
+    }));
+    isDirty.current = true;
+  }
+
   // ── Phase 2 direct-manipulation callbacks ────────────────────────────────
 
   /** Called by TemplatePreview when a drag begins (push undo before first move). */
@@ -984,9 +1119,19 @@ export function DskEditorPage() {
   }
 
   function handleResizeLayer(id, rect) {
+    let final = rect;
+    if (aspectLock && primaryLayer?.type === 'image' && primaryLayer.id === id) {
+      const orig = primaryLayer;
+      const ratio = (orig.width || 1) / (orig.height || 1);
+      if (rect.width !== (orig.width || 0)) {
+        final = { ...rect, height: Math.max(4, Math.round(rect.width / ratio)) };
+      } else {
+        final = { ...rect, width: Math.max(4, Math.round(rect.height * ratio)) };
+      }
+    }
     setTemplate(t => ({
       ...t,
-      layers: t.layers.map(l => l.id === id ? { ...l, ...rect } : l),
+      layers: t.layers.map(l => l.id === id ? { ...l, ...final } : l),
     }));
     isDirty.current = true;
   }
@@ -1168,6 +1313,12 @@ export function DskEditorPage() {
             ⊞ {snapGrid ? 'Grid on' : 'Grid'}
           </button>
 
+          {/* Safe area guides */}
+          <button onClick={() => setShowSafeArea(v => !v)} title="Safe area guides"
+                  style={showSafeArea ? btnActiveStyle : btnStyle}>
+            ⬜ Safe
+          </button>
+
           <span style={{ flex: 1 }} />
           {status && <span style={{ fontSize: 12, color: status.startsWith('Error') || status.startsWith('Save error') ? '#f88' : '#8d8' }}>{status}</span>}
           <button onClick={saveTemplate} disabled={loading} style={btnPrimaryStyle}>{loading ? 'Saving…' : 'Save'}</button>
@@ -1188,6 +1339,7 @@ export function DskEditorPage() {
               onMoveSelected={handleMoveSelected}
               onResizeLayer={handleResizeLayer}
               snapGrid={snapGrid}
+              showSafeArea={showSafeArea}
             />
 
             {/* Layer list header */}
@@ -1201,21 +1353,41 @@ export function DskEditorPage() {
               {canGroup   && <button onClick={groupSelected}   title="Group selected layers" style={{ ...btnStyle, fontSize: 12 }}>Group</button>}
               {canUngroup && <button onClick={ungroupSelected} title="Remove from group"     style={{ ...btnDangerStyle, fontSize: 12 }}>Ungroup</button>}
             </div>
+            {/* Alignment tools — shown when ≥2 layers selected */}
+            {selectedIds.size >= 2 && (
+              <div style={{ display: 'flex', alignItems: 'center', gap: 4, flexWrap: 'wrap' }}>
+                <span style={{ fontSize: 11, color: '#666', marginRight: 2 }}>Align:</span>
+                <button onClick={() => alignLayers('x', 'min')}    title="Align left"            style={{ ...btnStyle, padding: '2px 7px', fontSize: 12 }}>⬅L</button>
+                <button onClick={() => alignLayers('x', 'center')} title="Align center (H)"      style={{ ...btnStyle, padding: '2px 7px', fontSize: 12 }}>⬛C</button>
+                <button onClick={() => alignLayers('x', 'max')}    title="Align right"           style={{ ...btnStyle, padding: '2px 7px', fontSize: 12 }}>R➡</button>
+                <span style={{ width: 4 }} />
+                <button onClick={() => alignLayers('y', 'min')}    title="Align top"             style={{ ...btnStyle, padding: '2px 7px', fontSize: 12 }}>⬆T</button>
+                <button onClick={() => alignLayers('y', 'center')} title="Align middle (V)"      style={{ ...btnStyle, padding: '2px 7px', fontSize: 12 }}>⬛M</button>
+                <button onClick={() => alignLayers('y', 'max')}    title="Align bottom"          style={{ ...btnStyle, padding: '2px 7px', fontSize: 12 }}>B⬇</button>
+              </div>
+            )}
 
             {(template.layers || []).length === 0 && (
               <div style={{ color: '#555', fontSize: 13 }}>No layers yet.</div>
             )}
 
             {[...(template.layers || [])].reverse().map((layer) => {
-              const isInSel  = selectedIds.has(layer.id);
+              const isInSel   = selectedIds.has(layer.id);
               const isPrimary = layer.id === primaryId;
-              const gName    = layer.groupId ? groupNameById[layer.groupId] || layer.groupId : null;
+              const gName     = layer.groupId ? groupNameById[layer.groupId] || layer.groupId : null;
+              const isHidden  = layer.visible === false;
               return (
                 <div key={layer.id} style={{
                   display: 'flex', alignItems: 'center', padding: '4px 8px', marginBottom: 2,
                   background: isInSel ? '#1e3a5f' : '#1a1a1a', borderRadius: 3, cursor: 'pointer',
                   border: isPrimary ? '1px solid #4488dd' : isInSel ? '1px solid #336' : '1px solid transparent',
+                  opacity: isHidden ? 0.4 : 1,
                 }} onClick={() => selectLayerFromList(layer.id)}>
+                  <button onClick={e => { e.stopPropagation(); toggleLayerVisibility(layer.id); }}
+                          title={isHidden ? 'Show layer' : 'Hide layer'}
+                          style={{ ...btnStyle, padding: '1px 5px', fontSize: 11, marginRight: 4, flexShrink: 0 }}>
+                    {isHidden ? '○' : '●'}
+                  </button>
                   <span style={{ fontSize: 11, color: '#666', width: 44, flexShrink: 0 }}>{layer.type}</span>
                   <span style={{ flex: 1, fontSize: 13, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                     {layer.id}
@@ -1231,9 +1403,10 @@ export function DskEditorPage() {
                       {gName}
                     </span>
                   )}
-                  <button onClick={e => { e.stopPropagation(); reorderLayer(layer.id, -1); }} title="Move up" style={{ ...btnStyle, padding: '1px 5px', fontSize: 11 }}>↑</button>
-                  <button onClick={e => { e.stopPropagation(); reorderLayer(layer.id,  1); }} title="Move down" style={{ ...btnStyle, padding: '1px 5px', fontSize: 11 }}>↓</button>
-                  <button onClick={e => { e.stopPropagation(); deleteLayer(layer.id); }}    title="Delete" style={{ ...btnDangerStyle, padding: '1px 5px', fontSize: 11, marginLeft: 4 }}>✕</button>
+                  <button onClick={e => { e.stopPropagation(); reorderLayer(layer.id, -1); }}  title="Move up"   style={{ ...btnStyle, padding: '1px 5px', fontSize: 11 }}>↑</button>
+                  <button onClick={e => { e.stopPropagation(); reorderLayer(layer.id,  1); }}  title="Move down" style={{ ...btnStyle, padding: '1px 5px', fontSize: 11 }}>↓</button>
+                  <button onClick={e => { e.stopPropagation(); duplicateLayer(layer.id); }}    title="Duplicate" style={{ ...btnStyle, padding: '1px 5px', fontSize: 11 }}>⧉</button>
+                  <button onClick={e => { e.stopPropagation(); deleteLayer(layer.id); }}       title="Delete"    style={{ ...btnDangerStyle, padding: '1px 5px', fontSize: 11, marginLeft: 4 }}>✕</button>
                 </div>
               );
             })}
@@ -1303,6 +1476,8 @@ export function DskEditorPage() {
             <LayerPropertyEditor
               layer={primaryLayer}
               selectionCount={selectedIds.size}
+              aspectLock={aspectLock}
+              onAspectLock={() => setAspectLock(v => !v)}
               onChange={updateLayer}
             />
           </div>

--- a/packages/lcyt-web/src/components/DskEditorPage.jsx
+++ b/packages/lcyt-web/src/components/DskEditorPage.jsx
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
  * Phase 2: drag-to-move, 8-point resize handles, keyboard nudge.
  * Phase 3: undo/redo, multi-selection, snap to grid, snap to layer edges,
  *           ellipse shape type, shape grouping (group/ungroup).
+ * Phase 4: Media Library — image upload, browse, insert, delete (PNG/JPEG/WebP/SVG).
  */
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -580,7 +581,16 @@ export function DskEditorPage() {
   const [status, setStatus]           = useState('');
   const [loading, setLoading]         = useState(false);
 
+  // Media Library state
+  const [images, setImages]               = useState([]);
+  const [imgPending, setImgPending]       = useState(null);   // File awaiting shorthand
+  const [shorthandInput, setShorthandInput] = useState('');
+  const [imgLibOpen, setImgLibOpen]       = useState(true);
+  const [imgUploading, setImgUploading]   = useState(false);
+  const [imgUploadErr, setImgUploadErr]   = useState('');
+
   const isDirty    = useRef(false);
+  const imgInputRef = useRef(null);
   const historyRef = useRef({ past: [], future: [] });
   const templateRef = useRef(template); // mirror for use inside event listeners
   useEffect(() => { templateRef.current = template; }, [template]);
@@ -656,6 +666,17 @@ export function DskEditorPage() {
   }, [serverUrl, apiKey]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => { fetchTemplates(); }, [fetchTemplates]);
+
+  const loadImages = useCallback(async () => {
+    if (!serverUrl || !apiKey) return;
+    try {
+      const res = await fetch(`${serverUrl}/dsk/${encodeURIComponent(apiKey)}/images`);
+      const data = await res.json();
+      setImages(data.images || []);
+    } catch {}
+  }, [serverUrl, apiKey]);
+
+  useEffect(() => { loadImages(); }, [loadImages]);
 
   // ── Template lifecycle ───────────────────────────────────────────────────
 
@@ -881,6 +902,60 @@ export function DskEditorPage() {
     isDirty.current = true;
   }
 
+  // ── Media Library ────────────────────────────────────────────────────────
+
+  async function uploadImage(file, shorthand) {
+    setImgUploading(true); setImgUploadErr('');
+    try {
+      const fd = new FormData();
+      fd.append('file', file);
+      fd.append('shorthand', shorthand);
+      const res = await fetch(`${serverUrl}/images`, {
+        method: 'POST',
+        headers: { 'X-API-Key': apiKey },
+        body: fd,
+      });
+      if (!res.ok) { const txt = await res.text(); throw new Error(txt); }
+      setImgPending(null); setShorthandInput('');
+      await loadImages();
+    } catch (err) { setImgUploadErr(err.message); }
+    finally { setImgUploading(false); }
+  }
+
+  async function deleteImageById(id) {
+    try {
+      await fetch(`${serverUrl}/images/${id}`, {
+        method: 'DELETE',
+        headers: { 'X-API-Key': apiKey },
+      });
+      await loadImages();
+    } catch {}
+  }
+
+  function handleFileInputChange(e) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const base = file.name.replace(/\.[^.]+$/, '').replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 32);
+    setShorthandInput(base || 'image');
+    setImgPending(file);
+    e.target.value = '';
+  }
+
+  function useImageFromLibrary(img) {
+    const url = `${serverUrl}/images/${img.id}`;
+    if (primaryLayer?.type === 'image') {
+      updateLayer({ ...primaryLayer, src: url });
+    } else {
+      pushHistory(template);
+      const id = newLayerId('image');
+      const newLayer = { id, type: 'image', x: 0, y: 0, width: 400, height: 300, src: url };
+      setTemplate(t => ({ ...t, layers: [...(t.layers || []), newLayer] }));
+      setSelectedIds(new Set([id]));
+      setPrimaryId(id);
+      isDirty.current = true;
+    }
+  }
+
   // ── Derived ──────────────────────────────────────────────────────────────
 
   const primaryLayer    = template.layers?.find(l => l.id === primaryId) || null;
@@ -989,6 +1064,7 @@ export function DskEditorPage() {
               <button onClick={() => addLayer('ellipse')} style={{ ...btnStyle, fontSize: 12 }}>+ Ellipse</button>
               <button onClick={() => addLayer('rect')}    style={{ ...btnStyle, fontSize: 12 }}>+ Rect</button>
               <button onClick={() => addLayer('text')}    style={{ ...btnStyle, fontSize: 12 }}>+ Text</button>
+              <button onClick={() => addLayer('image')}   style={{ ...btnStyle, fontSize: 12 }}>+ Image</button>
               {canGroup   && <button onClick={groupSelected}   title="Group selected layers" style={{ ...btnStyle, fontSize: 12 }}>Group</button>}
               {canUngroup && <button onClick={ungroupSelected} title="Remove from group"     style={{ ...btnDangerStyle, fontSize: 12 }}>Ungroup</button>}
             </div>
@@ -1028,6 +1104,64 @@ export function DskEditorPage() {
                 </div>
               );
             })}
+
+            {/* ── Media Library ── */}
+            <div style={{ borderTop: '1px solid #333', marginTop: 4, paddingTop: 4 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 6 }}>
+                <span style={{ fontSize: 13, color: '#bbb', fontWeight: 'bold', flex: 1 }}>Media Library</span>
+                <button onClick={() => imgInputRef.current?.click()} style={{ ...btnStyle, fontSize: 12 }}>Upload</button>
+                <button onClick={() => setImgLibOpen(v => !v)} style={{ ...btnStyle, fontSize: 12, padding: '4px 8px' }}>
+                  {imgLibOpen ? '▲' : '▼'}
+                </button>
+                <input ref={imgInputRef} type="file"
+                       accept="image/png,image/jpeg,image/webp,image/svg+xml"
+                       style={{ display: 'none' }} onChange={handleFileInputChange} />
+              </div>
+
+              {imgLibOpen && (
+                <>
+                  {imgPending && (
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '4px 0 6px', flexWrap: 'wrap' }}>
+                      <span style={{ fontSize: 12, color: '#aaa' }}>{imgPending.name}</span>
+                      <input type="text" value={shorthandInput}
+                             onChange={e => setShorthandInput(e.target.value)}
+                             placeholder="shorthand" style={{ ...inputStyle, width: 120 }} />
+                      <button onClick={() => uploadImage(imgPending, shorthandInput)}
+                              disabled={imgUploading || !shorthandInput.trim()}
+                              style={{ ...btnPrimaryStyle, fontSize: 12 }}>
+                        {imgUploading ? '…' : 'OK'}
+                      </button>
+                      <button onClick={() => { setImgPending(null); setShorthandInput(''); setImgUploadErr(''); }}
+                              style={{ ...btnStyle, fontSize: 12 }}>Cancel</button>
+                      {imgUploadErr && <span style={{ color: '#f88', fontSize: 12 }}>{imgUploadErr}</span>}
+                    </div>
+                  )}
+
+                  {images.length === 0 && !imgPending && (
+                    <div style={{ color: '#555', fontSize: 13, paddingBottom: 4 }}>No images yet. Click Upload to add one.</div>
+                  )}
+
+                  {images.map(img => (
+                    <div key={img.id} style={{
+                      display: 'flex', alignItems: 'center', gap: 8, padding: '3px 0',
+                      borderBottom: '1px solid #1e1e1e',
+                    }}>
+                      <img src={`${serverUrl}/images/${img.id}`} alt={img.shorthand}
+                           style={{ width: 40, height: 40, objectFit: 'contain', background: '#222', borderRadius: 3, flexShrink: 0 }} />
+                      <span style={{ flex: 1, fontSize: 12, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                            title={img.shorthand}>{img.shorthand}</span>
+                      <span style={{ fontSize: 11, color: '#666', flexShrink: 0 }}>
+                        {img.mimeType?.split('/')[1]?.toUpperCase()}
+                      </span>
+                      <button onClick={() => useImageFromLibrary(img)} title="Insert into canvas"
+                              style={{ ...btnStyle, padding: '2px 6px', fontSize: 11 }}>Use</button>
+                      <button onClick={() => { if (window.confirm(`Delete image "${img.shorthand}"?`)) deleteImageById(img.id); }}
+                              title="Delete" style={{ ...btnDangerStyle, padding: '2px 6px', fontSize: 11 }}>✕</button>
+                    </div>
+                  ))}
+                </>
+              )}
+            </div>
           </div>
 
           {/* Properties panel */}

--- a/packages/lcyt-web/src/components/DskEditorPage.jsx
+++ b/packages/lcyt-web/src/components/DskEditorPage.jsx
@@ -10,6 +10,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
  * Phase 3: undo/redo, multi-selection, snap to grid, snap to layer edges,
  *           ellipse shape type, shape grouping (group/ungroup).
  * Phase 4: Media Library — image upload, browse, insert, delete (PNG/JPEG/WebP/SVG).
+ * Phase 5: Animations — preset picker, per-layer CSS animation shorthand, live preview.
  */
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -166,6 +167,7 @@ function renderLayerElement(layer, isSelected, isInSelection, onPointerDown) {
     top:   Number(layer.y) || 0,
     ...(layer.width  != null ? { width:  Number(layer.width)  } : {}),
     ...(layer.height != null ? { height: Number(layer.height) } : {}),
+    ...(layer.animation ? { animation: layer.animation } : {}),
     outline: isSelected   ? '3px solid #4af'
            : isInSelection ? '2px dashed #48c'
            : undefined,
@@ -427,6 +429,135 @@ function TemplatePreview({
   );
 }
 
+// ── Animation support ─────────────────────────────────────────────────────────
+
+// Inject LCYT keyframes into the browser document once (for the live preview).
+const LCYT_KEYFRAMES_CSS = `
+@keyframes lcyt-fadeIn       { from { opacity: 0 } to { opacity: 1 } }
+@keyframes lcyt-fadeOut      { from { opacity: 1 } to { opacity: 0 } }
+@keyframes lcyt-slideInLeft  { from { transform: translateX(-100%) } to { transform: translateX(0) } }
+@keyframes lcyt-slideInRight { from { transform: translateX(100%)  } to { transform: translateX(0) } }
+@keyframes lcyt-slideInUp    { from { transform: translateY(100%)  } to { transform: translateY(0) } }
+@keyframes lcyt-slideInDown  { from { transform: translateY(-100%) } to { transform: translateY(0) } }
+@keyframes lcyt-slideOutLeft  { from { transform: translateX(0) } to { transform: translateX(-100%) } }
+@keyframes lcyt-slideOutRight { from { transform: translateX(0) } to { transform: translateX(100%)  } }
+@keyframes lcyt-zoomIn  { from { transform: scale(0); opacity: 0 } to { transform: scale(1); opacity: 1 } }
+@keyframes lcyt-zoomOut { from { transform: scale(1); opacity: 1 } to { transform: scale(0); opacity: 0 } }
+@keyframes lcyt-pulse   { 0%, 100% { transform: scale(1) } 50% { transform: scale(1.05) } }
+@keyframes lcyt-blink   { 0%, 100% { opacity: 1 } 50% { opacity: 0 } }
+@keyframes lcyt-typewriter { from { clip-path: inset(0 100% 0 0) } to { clip-path: inset(0 0% 0 0) } }
+`;
+
+if (typeof document !== 'undefined' && !document.getElementById('lcyt-anim-keyframes')) {
+  const s = document.createElement('style');
+  s.id = 'lcyt-anim-keyframes';
+  s.textContent = LCYT_KEYFRAMES_CSS;
+  document.head.appendChild(s);
+}
+
+const ANIM_PRESETS = [
+  { value: '',                   label: 'None' },
+  { value: 'lcyt-fadeIn',        label: 'Fade In' },
+  { value: 'lcyt-fadeOut',       label: 'Fade Out' },
+  { value: 'lcyt-slideInLeft',   label: 'Slide In ←' },
+  { value: 'lcyt-slideInRight',  label: 'Slide In →' },
+  { value: 'lcyt-slideInUp',     label: 'Slide In ↑' },
+  { value: 'lcyt-slideInDown',   label: 'Slide In ↓' },
+  { value: 'lcyt-slideOutLeft',  label: 'Slide Out ←' },
+  { value: 'lcyt-slideOutRight', label: 'Slide Out →' },
+  { value: 'lcyt-zoomIn',        label: 'Zoom In' },
+  { value: 'lcyt-zoomOut',       label: 'Zoom Out' },
+  { value: 'lcyt-pulse',         label: 'Pulse' },
+  { value: 'lcyt-blink',         label: 'Blink' },
+  { value: 'lcyt-typewriter',    label: 'Typewriter' },
+];
+
+// CSS animation shorthand: name duration timing-function delay iteration-count direction fill-mode
+function parseAnimation(anim) {
+  if (!anim || !anim.trim()) {
+    return { preset: '', duration: '1', easing: 'ease', delay: '0', iterations: '1', direction: 'normal', fillMode: 'forwards' };
+  }
+  const parts = anim.trim().split(/\s+/);
+  return {
+    preset:     parts[0] || '',
+    duration:   (parts[1] || '1s').replace(/s$/, ''),
+    easing:     parts[2] || 'ease',
+    delay:      (parts[3] || '0s').replace(/s$/, ''),
+    iterations: parts[4] || '1',
+    direction:  parts[5] || 'normal',
+    fillMode:   parts[6] || 'forwards',
+  };
+}
+
+function buildAnimation({ preset, duration, easing, delay, iterations, direction, fillMode }) {
+  if (!preset) return '';
+  return `${preset} ${duration}s ${easing} ${delay}s ${iterations} ${direction} ${fillMode}`;
+}
+
+function AnimationEditor({ value, onChange }) {
+  const p = parseAnimation(value);
+  function upd(field, val) { onChange(buildAnimation({ ...p, [field]: val })); }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+      <div style={fieldRowStyle}>
+        <span style={labelStyle}>Preset</span>
+        <select value={p.preset} onChange={e => upd('preset', e.target.value)} style={inputStyle}>
+          {ANIM_PRESETS.map(a => <option key={a.value} value={a.value}>{a.label}</option>)}
+        </select>
+      </div>
+      {p.preset && (<>
+        <div style={fieldRowStyle}>
+          <span style={labelStyle}>Duration</span>
+          <input type="number" min="0" step="0.1" value={p.duration}
+                 onChange={e => upd('duration', e.target.value)}
+                 style={{ ...inputStyle, width: 70 }} />
+          <span style={{ color: '#666', fontSize: 12, flexShrink: 0 }}>s</span>
+        </div>
+        <div style={fieldRowStyle}>
+          <span style={labelStyle}>Delay</span>
+          <input type="number" min="0" step="0.1" value={p.delay}
+                 onChange={e => upd('delay', e.target.value)}
+                 style={{ ...inputStyle, width: 70 }} />
+          <span style={{ color: '#666', fontSize: 12, flexShrink: 0 }}>s</span>
+        </div>
+        <div style={fieldRowStyle}>
+          <span style={labelStyle}>Easing</span>
+          <select value={p.easing} onChange={e => upd('easing', e.target.value)} style={inputStyle}>
+            {['ease', 'linear', 'ease-in', 'ease-out', 'ease-in-out'].map(v =>
+              <option key={v} value={v}>{v}</option>)}
+          </select>
+        </div>
+        <div style={fieldRowStyle}>
+          <span style={labelStyle}>Iterations</span>
+          <select value={p.iterations} onChange={e => upd('iterations', e.target.value)} style={inputStyle}>
+            {['1', '2', '3', '5', '10', 'infinite'].map(v =>
+              <option key={v} value={v}>{v}</option>)}
+          </select>
+        </div>
+        <div style={fieldRowStyle}>
+          <span style={labelStyle}>Direction</span>
+          <select value={p.direction} onChange={e => upd('direction', e.target.value)} style={inputStyle}>
+            {['normal', 'reverse', 'alternate', 'alternate-reverse'].map(v =>
+              <option key={v} value={v}>{v}</option>)}
+          </select>
+        </div>
+        <div style={fieldRowStyle}>
+          <span style={labelStyle}>Fill</span>
+          <select value={p.fillMode} onChange={e => upd('fillMode', e.target.value)} style={inputStyle}>
+            {['forwards', 'backwards', 'both', 'none'].map(v =>
+              <option key={v} value={v}>{v}</option>)}
+          </select>
+        </div>
+        <div style={fieldRowStyle}>
+          <span style={labelStyle}>Raw CSS</span>
+          <input type="text" value={value || ''} onChange={e => onChange(e.target.value)} style={inputStyle} />
+        </div>
+      </>)}
+    </div>
+  );
+}
+
 // ── Layer property editor ─────────────────────────────────────────────────────
 
 const COMMON_FIELDS = [
@@ -533,6 +664,8 @@ function LayerPropertyEditor({ layer, selectionCount, onChange }) {
           }
         </div>
       ))}
+      <div style={sectionLabelStyle}>Animation</div>
+      <AnimationEditor value={layer.animation || ''} onChange={v => setField('animation', v || undefined)} />
     </div>
   );
 }

--- a/packages/lcyt-web/src/components/DskEditorPage.jsx
+++ b/packages/lcyt-web/src/components/DskEditorPage.jsx
@@ -5,20 +5,20 @@ import { useCallback, useEffect, useRef, useState } from 'react';
  *
  * URL: /dsk-editor?server=<backendUrl>&apikey=<key>
  *
- * Allows designing lower-third, bug, and full-screen graphic templates stored
- * as JSON on the backend. Preview mirrors the Playwright renderer output.
- *
- * Phase 2: direct manipulation — drag to move layers, 8-point resize handles,
- * keyboard nudge (arrow keys, Shift+arrow for ×10 step).
+ * Phase 1: template CRUD, layer property editor.
+ * Phase 2: drag-to-move, 8-point resize handles, keyboard nudge.
+ * Phase 3: undo/redo, multi-selection, snap to grid, snap to layer edges,
+ *           ellipse shape type, shape grouping (group/ungroup).
  */
 
-// ── Scale ────────────────────────────────────────────────────────────────────
+// ── Constants ─────────────────────────────────────────────────────────────────
 
-// Preview renders the 1920×1080 canvas at 50% (960×540 display area).
-// Pointer delta in screen space must be divided by SCALE to get template px.
-const SCALE = 0.5;
+const SCALE         = 0.5;   // preview is 50% of 1920×1080
+const GRID_SIZE     = 20;    // template px; used by snap-to-grid
+const SNAP_THRESH   = 10;    // template px; used by snap-to-layer-edges
+const MAX_HISTORY   = 50;
 
-// ── Resize handles ───────────────────────────────────────────────────────────
+// ── Resize handles ────────────────────────────────────────────────────────────
 
 const HANDLE_LIST = ['nw', 'n', 'ne', 'e', 'se', 's', 'sw', 'w'];
 const HANDLE_CURSORS = {
@@ -27,7 +27,6 @@ const HANDLE_CURSORS = {
   sw: 'sw-resize', w:  'w-resize',
 };
 
-/** Anchor point of a handle in template coordinates (relative to canvas origin). */
 function handleAnchor(handle, layer) {
   const x = Number(layer.x) || 0;
   const y = Number(layer.y) || 0;
@@ -39,7 +38,6 @@ function handleAnchor(handle, layer) {
   };
 }
 
-/** Compute updated { x, y, width, height } after dragging a resize handle by (dx, dy) template px. */
 function applyResize(handle, startRect, dx, dy) {
   let { x, y, width, height } = startRect;
   if (handle.includes('e')) width  = width  + dx;
@@ -54,54 +52,85 @@ function applyResize(handle, startRect, dx, dy) {
   };
 }
 
-// ── Preset templates ────────────────────────────────────────────────────────
+// ── Snap helpers ──────────────────────────────────────────────────────────────
+
+function gridSnap(v) {
+  return Math.round(v / GRID_SIZE) * GRID_SIZE;
+}
+
+/**
+ * Snap the primary layer's tentative (x, y) to edges of non-moving layers.
+ * Returns { x, y } adjusted by the best snap offset (≤ SNAP_THRESH) on each axis.
+ */
+function snapToLayerEdges(tentX, tentY, primaryLayer, allLayers, movingIds) {
+  const w = Number(primaryLayer?.width)  || 0;
+  const h = Number(primaryLayer?.height) || 0;
+  if (!w || !h) return { x: tentX, y: tentY };
+
+  const others = allLayers.filter(l =>
+    !movingIds.has(l.id) && l.width != null && l.height != null,
+  );
+
+  // Moving layer edges
+  const me = {
+    l: tentX,     r: tentX + w,   cx: tentX + w / 2,
+    t: tentY,     b: tentY + h,   cy: tentY + h / 2,
+  };
+
+  let bestXd = SNAP_THRESH, bestYd = SNAP_THRESH, snapDx = 0, snapDy = 0;
+
+  for (const o of others) {
+    const ox = o.x || 0, oy = o.y || 0, ow = o.width || 0, oh = o.height || 0;
+    const oe = {
+      l: ox,      r: ox + ow,    cx: ox + ow / 2,
+      t: oy,      b: oy + oh,    cy: oy + oh / 2,
+    };
+    for (const mk of ['l', 'r', 'cx']) {
+      for (const ok of ['l', 'r', 'cx']) {
+        const d = Math.abs(me[mk] - oe[ok]);
+        if (d < bestXd) { bestXd = d; snapDx = oe[ok] - me[mk]; }
+      }
+    }
+    for (const mk of ['t', 'b', 'cy']) {
+      for (const ok of ['t', 'b', 'cy']) {
+        const d = Math.abs(me[mk] - oe[ok]);
+        if (d < bestYd) { bestYd = d; snapDy = oe[ok] - me[mk]; }
+      }
+    }
+  }
+  return { x: tentX + snapDx, y: tentY + snapDy };
+}
+
+// ── Preset templates ──────────────────────────────────────────────────────────
 
 const PRESETS = {
   'Lower Third': {
     background: 'transparent',
     width: 1920,
     height: 1080,
+    groups: [{ id: 'lt', name: 'Lower Third' }],
     layers: [
-      {
-        id: 'bg',
-        type: 'rect',
-        x: 0, y: 790, width: 1920, height: 290,
-        style: { background: '#1a1a2e', opacity: '0.92', 'border-radius': '0' },
-      },
-      {
-        id: 'name',
-        type: 'text',
-        x: 80, y: 840, width: 1760,
+      { id: 'bg',    type: 'rect', x: 0,  y: 790, width: 1920, height: 290, groupId: 'lt',
+        style: { background: '#1a1a2e', opacity: '0.92', 'border-radius': '0' } },
+      { id: 'name',  type: 'text', x: 80, y: 840, width: 1760, groupId: 'lt',
         text: 'Speaker Name',
-        style: { 'font-size': '56px', 'font-family': 'Arial, sans-serif', color: '#ffffff', 'font-weight': 'bold', 'white-space': 'nowrap' },
-      },
-      {
-        id: 'title',
-        type: 'text',
-        x: 80, y: 930, width: 1760,
+        style: { 'font-size': '56px', 'font-family': 'Arial, sans-serif', color: '#ffffff', 'font-weight': 'bold', 'white-space': 'nowrap' } },
+      { id: 'title', type: 'text', x: 80, y: 930, width: 1760, groupId: 'lt',
         text: 'Title / Organisation',
-        style: { 'font-size': '38px', 'font-family': 'Arial, sans-serif', color: '#cccccc', 'white-space': 'nowrap' },
-      },
+        style: { 'font-size': '38px', 'font-family': 'Arial, sans-serif', color: '#cccccc', 'white-space': 'nowrap' } },
     ],
   },
   'Corner Bug': {
     background: 'transparent',
     width: 1920,
     height: 1080,
+    groups: [{ id: 'bug', name: 'Corner Bug' }],
     layers: [
-      {
-        id: 'bug-bg',
-        type: 'rect',
-        x: 40, y: 40, width: 320, height: 100,
-        style: { background: '#000000', opacity: '0.75', 'border-radius': '8px' },
-      },
-      {
-        id: 'bug-text',
-        type: 'text',
-        x: 60, y: 62,
+      { id: 'bug-bg',   type: 'rect', x: 40, y: 40, width: 320, height: 100, groupId: 'bug',
+        style: { background: '#000000', opacity: '0.75', 'border-radius': '8px' } },
+      { id: 'bug-text', type: 'text', x: 60, y: 62, groupId: 'bug',
         text: 'LIVE',
-        style: { 'font-size': '48px', 'font-family': 'Arial, sans-serif', color: '#ff3300', 'font-weight': 'bold', 'letter-spacing': '4px' },
-      },
+        style: { 'font-size': '48px', 'font-family': 'Arial, sans-serif', color: '#ff3300', 'font-weight': 'bold', 'letter-spacing': '4px' } },
     ],
   },
   'Full-screen Title': {
@@ -109,20 +138,12 @@ const PRESETS = {
     width: 1920,
     height: 1080,
     layers: [
-      {
-        id: 'title',
-        type: 'text',
-        x: 0, y: 420, width: 1920,
+      { id: 'title',    type: 'text', x: 0, y: 420, width: 1920,
         text: 'Event Title',
-        style: { 'font-size': '96px', 'font-family': 'Arial, sans-serif', color: '#ffffff', 'font-weight': 'bold', 'text-align': 'center' },
-      },
-      {
-        id: 'subtitle',
-        type: 'text',
-        x: 0, y: 560, width: 1920,
+        style: { 'font-size': '96px', 'font-family': 'Arial, sans-serif', color: '#ffffff', 'font-weight': 'bold', 'text-align': 'center' } },
+      { id: 'subtitle', type: 'text', x: 0, y: 560, width: 1920,
         text: 'Subtitle or Date',
-        style: { 'font-size': '52px', 'font-family': 'Arial, sans-serif', color: '#aaaaaa', 'text-align': 'center' },
-      },
+        style: { 'font-size': '52px', 'font-family': 'Arial, sans-serif', color: '#aaaaaa', 'text-align': 'center' } },
     ],
   },
 };
@@ -131,53 +152,115 @@ const EMPTY_TEMPLATE = {
   background: 'transparent',
   width: 1920,
   height: 1080,
+  groups: [],
   layers: [],
 };
 
-// ── Preview rendering ────────────────────────────────────────────────────────
+// ── Render a single layer element ─────────────────────────────────────────────
+
+function renderLayerElement(layer, isSelected, isInSelection, onPointerDown) {
+  const base = {
+    position: 'absolute',
+    left:  Number(layer.x) || 0,
+    top:   Number(layer.y) || 0,
+    ...(layer.width  != null ? { width:  Number(layer.width)  } : {}),
+    ...(layer.height != null ? { height: Number(layer.height) } : {}),
+    outline: isSelected   ? '3px solid #4af'
+           : isInSelection ? '2px dashed #48c'
+           : undefined,
+    cursor: 'move',
+    boxSizing: 'border-box',
+    userSelect: 'none',
+  };
+
+  const styleProps = {};
+  if (layer.style) {
+    for (const [k, v] of Object.entries(layer.style)) {
+      styleProps[k.replace(/-([a-z])/g, (_, c) => c.toUpperCase())] = v;
+    }
+  }
+  const merged = { ...base, ...styleProps };
+
+  if (layer.type === 'text') {
+    return (
+      <div key={layer.id} style={merged} onPointerDown={onPointerDown}>
+        {layer.text || ''}
+      </div>
+    );
+  }
+  if (layer.type === 'rect') {
+    return <div key={layer.id} style={merged} onPointerDown={onPointerDown} />;
+  }
+  if (layer.type === 'ellipse') {
+    return <div key={layer.id} style={{ ...merged, borderRadius: '50%' }} onPointerDown={onPointerDown} />;
+  }
+  if (layer.type === 'image') {
+    return (
+      <img key={layer.id} src={layer.src || ''} alt=""
+           draggable={false} style={merged} onPointerDown={onPointerDown} />
+    );
+  }
+  return null;
+}
+
+// ── Preview ───────────────────────────────────────────────────────────────────
 
 /**
- * Renders template JSON layers as React JSX in a scaled container.
- * Mirrors the logic in packages/plugins/lcyt-dsk/src/renderer.js renderTemplateToHtml().
- *
- * Phase 2: supports drag-to-move, resize handles, and keyboard nudge.
+ * Phase 3 TemplatePreview.
  *
  * Props:
- *   template         — template JSON object
- *   selectedLayerId  — id of the currently selected layer (or null)
- *   onSelectLayer(id) — called when user clicks a layer (parent toggles selection)
- *   onMoveLayer(id, { x, y }) — called during and after drag-move
- *   onResizeLayer(id, { x, y, width, height }) — called during and after resize-drag
+ *   template        full template JSON
+ *   selectedIds     Set<string> — all highlighted layer IDs
+ *   primaryId       string | null — single "active" layer (for keyboard nudge)
+ *   onSelect        (layerId, additive) => void — null layerId = deselect all
+ *   onDragStart     () => void — push undo history before first movement
+ *   onMoveSelected  (updates: {id, x, y}[]) => void
+ *   onResizeLayer   (id, {x, y, width, height}) => void
+ *   snapGrid        boolean
  */
-function TemplatePreview({ template, selectedLayerId, onSelectLayer, onMoveLayer, onResizeLayer }) {
+function TemplatePreview({
+  template, selectedIds, primaryId,
+  onSelect, onDragStart, onMoveSelected, onResizeLayer, snapGrid,
+}) {
   const t = template || EMPTY_TEMPLATE;
   const layers = Array.isArray(t.layers) ? t.layers : [];
 
   const containerRef = useRef(null);
-  // dragRef.current: null | { type: 'move'|'resize'|'background', layerId?, handle?,
-  //                            startPointer, startRect?, hasMoved }
   const dragRef = useRef(null);
+  // dragRef.current shape:
+  //   { type:'move',   layerId, shiftKey, startPointer, startPositions:Map, dragIds:Set, hasMoved, historyPushed }
+  //   { type:'resize', layerId, handle,   startPointer, startRect, hasMoved, historyPushed }
+  //   { type:'background' }
 
-  // ── Drag initiation ───────────────────────────────────────────────────────
+  // ── Drag start ────────────────────────────────────────────────────────────
 
   function startLayerDrag(e, layerId) {
     e.stopPropagation();
     const layer = layers.find(l => l.id === layerId);
-    if (!layer) return;
+
+    // Which layers will move together?
+    let dragIds;
+    if (selectedIds.has(layerId)) {
+      dragIds = new Set(selectedIds);
+    } else if (layer?.groupId) {
+      dragIds = new Set(layers.filter(l => l.groupId === layer.groupId).map(l => l.id));
+    } else {
+      dragIds = new Set([layerId]);
+    }
+
+    const startPositions = new Map(
+      [...dragIds].map(id => {
+        const l = layers.find(ll => ll.id === id);
+        return [id, { x: Number(l?.x) || 0, y: Number(l?.y) || 0 }];
+      }),
+    );
+
     dragRef.current = {
-      type: 'move',
-      layerId,
+      type: 'move', layerId, shiftKey: e.shiftKey,
       startPointer: { x: e.clientX, y: e.clientY },
-      startRect: {
-        x:      Number(layer.x)      || 0,
-        y:      Number(layer.y)      || 0,
-        width:  Number(layer.width)  || 0,
-        height: Number(layer.height) || 0,
-      },
-      hasMoved: false,
+      startPositions, dragIds,
+      hasMoved: false, historyPushed: false,
     };
-    // Capture pointer on the container so pointermove fires there even when
-    // the cursor leaves the layer element during a fast drag.
     containerRef.current?.setPointerCapture(e.pointerId);
   }
 
@@ -186,25 +269,20 @@ function TemplatePreview({ template, selectedLayerId, onSelectLayer, onMoveLayer
     const layer = layers.find(l => l.id === layerId);
     if (!layer) return;
     dragRef.current = {
-      type: 'resize',
-      layerId,
-      handle,
+      type: 'resize', layerId, handle,
       startPointer: { x: e.clientX, y: e.clientY },
       startRect: {
-        x:      Number(layer.x)      || 0,
-        y:      Number(layer.y)      || 0,
-        width:  Number(layer.width)  || 0,
-        height: Number(layer.height) || 0,
+        x: Number(layer.x) || 0, y: Number(layer.y) || 0,
+        width: Number(layer.width) || 0, height: Number(layer.height) || 0,
       },
-      hasMoved: false,
+      hasMoved: false, historyPushed: false,
     };
     containerRef.current?.setPointerCapture(e.pointerId);
   }
 
-  // ── Container pointer handlers ────────────────────────────────────────────
+  // ── Container pointer events ──────────────────────────────────────────────
 
   function onContainerPointerDown(e) {
-    // Fires only for background clicks — layer/handle events call stopPropagation.
     dragRef.current = { type: 'background' };
   }
 
@@ -212,24 +290,54 @@ function TemplatePreview({ template, selectedLayerId, onSelectLayer, onMoveLayer
     const drag = dragRef.current;
     if (!drag || drag.type === 'background') return;
 
-    const dx = (e.clientX - drag.startPointer.x) / SCALE;
-    const dy = (e.clientY - drag.startPointer.y) / SCALE;
+    const rawDx = (e.clientX - drag.startPointer.x) / SCALE;
+    const rawDy = (e.clientY - drag.startPointer.y) / SCALE;
 
-    // Debounce: require > 3 screen px before marking as a real drag.
-    if (!drag.hasMoved &&
-        (Math.abs(e.clientX - drag.startPointer.x) > 3 ||
-         Math.abs(e.clientY - drag.startPointer.y) > 3)) {
+    if (!drag.hasMoved && (Math.abs(e.clientX - drag.startPointer.x) > 3 ||
+                           Math.abs(e.clientY - drag.startPointer.y) > 3)) {
       drag.hasMoved = true;
     }
     if (!drag.hasMoved) return;
 
+    // Push undo history on first actual movement
+    if (!drag.historyPushed) {
+      drag.historyPushed = true;
+      onDragStart();
+    }
+
     if (drag.type === 'move') {
-      onMoveLayer(drag.layerId, {
-        x: Math.round(drag.startRect.x + dx),
-        y: Math.round(drag.startRect.y + dy),
-      });
+      const primaryLayer = layers.find(l => l.id === drag.layerId);
+      const primaryStart = drag.startPositions.get(drag.layerId);
+
+      // Tentative position for primary layer
+      let tentX = primaryStart.x + rawDx;
+      let tentY = primaryStart.y + rawDy;
+
+      // Grid snap (applied to primary, same delta to all)
+      if (snapGrid) {
+        tentX = gridSnap(tentX);
+        tentY = gridSnap(tentY);
+      }
+
+      // Layer edge snap (applied to primary)
+      if (primaryLayer?.width && primaryLayer?.height) {
+        const snapped = snapToLayerEdges(tentX, tentY, primaryLayer, layers, drag.dragIds);
+        tentX = snapped.x;
+        tentY = snapped.y;
+      }
+
+      const snappedDx = tentX - primaryStart.x;
+      const snappedDy = tentY - primaryStart.y;
+
+      const updates = [...drag.startPositions.entries()].map(([id, sp]) => ({
+        id,
+        x: Math.round(sp.x + snappedDx),
+        y: Math.round(sp.y + snappedDy),
+      }));
+      onMoveSelected(updates);
+
     } else if (drag.type === 'resize') {
-      onResizeLayer(drag.layerId, applyResize(drag.handle, drag.startRect, dx, dy));
+      onResizeLayer(drag.layerId, applyResize(drag.handle, drag.startRect, rawDx, rawDy));
     }
   }
 
@@ -237,29 +345,26 @@ function TemplatePreview({ template, selectedLayerId, onSelectLayer, onMoveLayer
     const drag = dragRef.current;
     dragRef.current = null;
     if (!drag) return;
-
     if (drag.type === 'background') {
-      // Click on empty canvas area → deselect.
-      onSelectLayer(null);
+      onSelect(null, false);
     } else if (!drag.hasMoved) {
-      // Pointer went down and up without moving → treat as a select/deselect click.
-      onSelectLayer(drag.layerId);
+      onSelect(drag.layerId, drag.shiftKey);
     }
   }
 
   // ── Keyboard nudge ────────────────────────────────────────────────────────
 
   function onContainerKeyDown(e) {
-    if (!selectedLayerId) return;
-    const layer = layers.find(l => l.id === selectedLayerId);
+    if (!primaryId) return;
+    const layer = layers.find(l => l.id === primaryId);
     if (!layer) return;
     const step = e.shiftKey ? 10 : 1;
     const x = Number(layer.x) || 0;
     const y = Number(layer.y) || 0;
-    if (e.key === 'ArrowLeft')  { onMoveLayer(selectedLayerId, { x: x - step, y }); e.preventDefault(); }
-    if (e.key === 'ArrowRight') { onMoveLayer(selectedLayerId, { x: x + step, y }); e.preventDefault(); }
-    if (e.key === 'ArrowUp')    { onMoveLayer(selectedLayerId, { x, y: y - step }); e.preventDefault(); }
-    if (e.key === 'ArrowDown')  { onMoveLayer(selectedLayerId, { x, y: y + step }); e.preventDefault(); }
+    if (e.key === 'ArrowLeft')  { onMoveSelected([{ id: primaryId, x: x - step, y }]); e.preventDefault(); }
+    if (e.key === 'ArrowRight') { onMoveSelected([{ id: primaryId, x: x + step, y }]); e.preventDefault(); }
+    if (e.key === 'ArrowUp')    { onMoveSelected([{ id: primaryId, x, y: y - step }]); e.preventDefault(); }
+    if (e.key === 'ArrowDown')  { onMoveSelected([{ id: primaryId, x, y: y + step }]); e.preventDefault(); }
   }
 
   // ── Render ────────────────────────────────────────────────────────────────
@@ -269,260 +374,161 @@ function TemplatePreview({ template, selectedLayerId, onSelectLayer, onMoveLayer
       ref={containerRef}
       tabIndex={0}
       style={{
-        width: 960,
-        height: 540,
-        position: 'relative',
-        overflow: 'hidden',
-        flexShrink: 0,
-        border: '2px solid #444',
-        borderRadius: 4,
-        cursor: 'default',
-        outline: 'none',
-        touchAction: 'none',
+        width: 960, height: 540, position: 'relative', overflow: 'hidden',
+        flexShrink: 0, border: '2px solid #444', borderRadius: 4,
+        cursor: 'default', outline: 'none', touchAction: 'none',
       }}
       onPointerDown={onContainerPointerDown}
       onPointerMove={onContainerPointerMove}
       onPointerUp={onContainerPointerUp}
       onKeyDown={onContainerKeyDown}
     >
-      {/* Canvas at 1920×1080 scaled to 50% */}
       <div style={{
-        width: 1920,
-        height: 1080,
-        position: 'absolute',
-        top: 0,
-        left: 0,
-        transform: 'scale(0.5)',
-        transformOrigin: 'top left',
+        width: 1920, height: 1080, position: 'absolute', top: 0, left: 0,
+        transform: 'scale(0.5)', transformOrigin: 'top left',
         background: t.background || 'transparent',
         backgroundImage: t.background === 'transparent' || !t.background
           ? 'repeating-conic-gradient(#2a2a2a 0% 25%, #1a1a1a 0% 50%) 0 0 / 40px 40px'
           : undefined,
       }}>
         {layers.flatMap((layer) => {
-          const isSelected = layer.id === selectedLayerId;
-          const base = {
-            position: 'absolute',
-            left: Number(layer.x) || 0,
-            top: Number(layer.y) || 0,
-            ...(layer.width  != null ? { width:  Number(layer.width)  } : {}),
-            ...(layer.height != null ? { height: Number(layer.height) } : {}),
-            outline: isSelected ? '3px solid #4af' : undefined,
-            cursor: 'move',
-            boxSizing: 'border-box',
-            userSelect: 'none',
-          };
+          const isSelected    = layer.id === primaryId && selectedIds.size === 1;
+          const isInSelection = selectedIds.has(layer.id);
 
-          // Convert kebab-case CSS keys to camelCase for React
-          const styleProps = {};
-          if (layer.style) {
-            for (const [k, v] of Object.entries(layer.style)) {
-              const camel = k.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
-              styleProps[camel] = v;
-            }
-          }
+          const el = renderLayerElement(
+            layer, isSelected, isInSelection && !isSelected,
+            e => startLayerDrag(e, layer.id),
+          );
+          if (!el) return [];
 
-          const merged = { ...base, ...styleProps };
+          if (!isSelected) return [el];
 
-          let layerEl;
-          if (layer.type === 'text') {
-            layerEl = (
-              <div key={layer.id} style={merged}
-                   onPointerDown={e => startLayerDrag(e, layer.id)}>
-                {layer.text || ''}
-              </div>
-            );
-          } else if (layer.type === 'rect') {
-            layerEl = (
-              <div key={layer.id} style={merged}
-                   onPointerDown={e => startLayerDrag(e, layer.id)} />
-            );
-          } else if (layer.type === 'image') {
-            layerEl = (
-              <img key={layer.id} src={layer.src || ''} alt=""
-                   draggable={false}
-                   style={merged}
-                   onPointerDown={e => startLayerDrag(e, layer.id)} />
-            );
-          } else {
-            return [];
-          }
-
-          if (!isSelected) return [layerEl];
-
-          // Render 8 resize handles for the selected layer.
-          // Handles are in template px (1920×1080 space) — they scale to 8×8 px
-          // at 50% preview scale (16px template = 8px display).
+          // Add 8 resize handles for the single-selected (primary) layer
           const handles = HANDLE_LIST.map(handle => {
             const { left, top } = handleAnchor(handle, layer);
             return (
-              <div
-                key={`${layer.id}-${handle}`}
-                style={{
-                  position: 'absolute',
-                  left,
-                  top,
-                  width: 16,
-                  height: 16,
-                  background: '#4af',
-                  border: '2px solid #fff',
-                  borderRadius: 2,
-                  cursor: HANDLE_CURSORS[handle],
-                  zIndex: 9999,
-                  transform: 'translate(-50%, -50%)',
-                  boxSizing: 'border-box',
-                  touchAction: 'none',
-                }}
-                onPointerDown={e => startHandleDrag(e, layer.id, handle)}
+              <div key={`${layer.id}-${handle}`} style={{
+                position: 'absolute', left, top,
+                width: 16, height: 16,
+                background: '#4af', border: '2px solid #fff', borderRadius: 2,
+                cursor: HANDLE_CURSORS[handle], zIndex: 9999,
+                transform: 'translate(-50%, -50%)', boxSizing: 'border-box',
+                touchAction: 'none',
+              }}
+              onPointerDown={e => startHandleDrag(e, layer.id, handle)}
               />
             );
           });
-
-          return [layerEl, ...handles];
+          return [el, ...handles];
         })}
       </div>
     </div>
   );
 }
 
-// ── Layer property editor ────────────────────────────────────────────────────
+// ── Layer property editor ─────────────────────────────────────────────────────
 
 const COMMON_FIELDS = [
   { key: 'x', label: 'X', type: 'number' },
   { key: 'y', label: 'Y', type: 'number' },
-  { key: 'width', label: 'Width', type: 'number' },
+  { key: 'width',  label: 'Width',  type: 'number' },
   { key: 'height', label: 'Height', type: 'number' },
 ];
 
 const STYLE_FIELDS_RECT = [
+  { key: 'background',   label: 'Background',   type: 'color-text' },
+  { key: 'opacity',      label: 'Opacity',      type: 'text', placeholder: '0.9' },
+  { key: 'border-radius',label: 'Border radius',type: 'text', placeholder: '8px' },
+];
+
+const STYLE_FIELDS_ELLIPSE = [
   { key: 'background', label: 'Background', type: 'color-text' },
-  { key: 'opacity', label: 'Opacity', type: 'text', placeholder: '0.9' },
-  { key: 'border-radius', label: 'Border radius', type: 'text', placeholder: '8px' },
+  { key: 'opacity',    label: 'Opacity',    type: 'text', placeholder: '0.9' },
 ];
 
 const STYLE_FIELDS_TEXT = [
-  { key: 'font-family', label: 'Font family', type: 'text', placeholder: 'Arial, sans-serif' },
-  { key: 'font-size', label: 'Font size', type: 'text', placeholder: '48px' },
-  { key: 'font-weight', label: 'Font weight', type: 'text', placeholder: 'bold' },
-  { key: 'color', label: 'Color', type: 'color-text' },
+  { key: 'font-family',  label: 'Font family',   type: 'text',   placeholder: 'Arial, sans-serif' },
+  { key: 'font-size',    label: 'Font size',      type: 'text',   placeholder: '48px' },
+  { key: 'font-weight',  label: 'Font weight',    type: 'text',   placeholder: 'bold' },
+  { key: 'color',        label: 'Color',          type: 'color-text' },
   { key: 'letter-spacing', label: 'Letter spacing', type: 'text', placeholder: '2px' },
-  { key: 'text-align', label: 'Text align', type: 'select', options: ['left', 'center', 'right'] },
-  { key: 'white-space', label: 'White space', type: 'select', options: ['normal', 'nowrap', 'pre'] },
+  { key: 'text-align',   label: 'Text align',     type: 'select', options: ['left', 'center', 'right'] },
+  { key: 'white-space',  label: 'White space',    type: 'select', options: ['normal', 'nowrap', 'pre'] },
 ];
 
 function ColorTextInput({ value, onChange }) {
   return (
     <div style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
-      <input
-        type="color"
+      <input type="color"
         value={value && value.startsWith('#') ? value.slice(0, 7) : '#000000'}
         onChange={e => onChange(e.target.value)}
         style={{ width: 32, height: 24, padding: 0, border: 'none', cursor: 'pointer', flexShrink: 0 }}
       />
-      <input
-        type="text"
-        value={value || ''}
-        onChange={e => onChange(e.target.value)}
-        style={inputStyle}
-      />
+      <input type="text" value={value || ''} onChange={e => onChange(e.target.value)} style={inputStyle} />
     </div>
   );
 }
 
-function LayerPropertyEditor({ layer, onChange }) {
+function LayerPropertyEditor({ layer, selectionCount, onChange }) {
+  if (selectionCount > 1 && !layer) {
+    return <div style={{ color: '#888', fontSize: 13, padding: '16px 0' }}>{selectionCount} layers selected.</div>;
+  }
   if (!layer) {
-    return (
-      <div style={{ color: '#888', fontSize: 13, padding: '16px 0' }}>
-        Select a layer to edit its properties.
-      </div>
-    );
+    return <div style={{ color: '#888', fontSize: 13, padding: '16px 0' }}>Select a layer to edit its properties.</div>;
   }
 
   function setField(key, value) {
-    onChange({ ...layer, [key]: value === '' ? undefined : (key === 'x' || key === 'y' || key === 'width' || key === 'height' ? Number(value) : value) });
+    const numericKeys = ['x', 'y', 'width', 'height'];
+    onChange({ ...layer, [key]: value === '' ? undefined : (numericKeys.includes(key) ? Number(value) : value) });
   }
-
   function setStyle(cssKey, value) {
     const style = { ...(layer.style || {}) };
-    if (value === '' || value === undefined) {
-      delete style[cssKey];
-    } else {
-      style[cssKey] = value;
-    }
+    if (value === '' || value === undefined) delete style[cssKey]; else style[cssKey] = value;
     onChange({ ...layer, style });
   }
 
-  const styleFields = layer.type === 'text' ? STYLE_FIELDS_TEXT : layer.type === 'rect' ? STYLE_FIELDS_RECT : [];
+  const styleFields = layer.type === 'text'    ? STYLE_FIELDS_TEXT
+                    : layer.type === 'rect'    ? STYLE_FIELDS_RECT
+                    : layer.type === 'ellipse' ? STYLE_FIELDS_ELLIPSE
+                    : [];
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-      {/* ID & type (read-only display) */}
       <div style={fieldRowStyle}>
         <span style={labelStyle}>ID</span>
-        <input
-          type="text"
-          value={layer.id || ''}
-          onChange={e => setField('id', e.target.value)}
-          style={inputStyle}
-        />
+        <input type="text" value={layer.id || ''} onChange={e => setField('id', e.target.value)} style={inputStyle} />
       </div>
       <div style={fieldRowStyle}>
         <span style={labelStyle}>Type</span>
         <span style={{ color: '#aaa', fontSize: 13 }}>{layer.type}</span>
       </div>
-
-      {/* Text content */}
       {layer.type === 'text' && (
         <div style={fieldRowStyle}>
           <span style={labelStyle}>Text</span>
-          <input
-            type="text"
-            value={layer.text || ''}
-            onChange={e => setField('text', e.target.value)}
-            style={inputStyle}
-          />
+          <input type="text" value={layer.text || ''} onChange={e => setField('text', e.target.value)} style={inputStyle} />
         </div>
       )}
-
-      {/* Position/size */}
-      <div style={{ borderTop: '1px solid #333', paddingTop: 6, marginTop: 2, color: '#777', fontSize: 11, textTransform: 'uppercase', letterSpacing: 1 }}>Position & Size</div>
+      <div style={sectionLabelStyle}>Position & Size</div>
       {COMMON_FIELDS.map(f => (
         <div key={f.key} style={fieldRowStyle}>
           <span style={labelStyle}>{f.label}</span>
-          <input
-            type="number"
-            value={layer[f.key] ?? ''}
-            onChange={e => setField(f.key, e.target.value)}
-            style={{ ...inputStyle, width: 100 }}
-          />
+          <input type="number" value={layer[f.key] ?? ''} onChange={e => setField(f.key, e.target.value)}
+                 style={{ ...inputStyle, width: 100 }} />
         </div>
       ))}
-
-      {/* Style fields */}
-      {styleFields.length > 0 && (
-        <div style={{ borderTop: '1px solid #333', paddingTop: 6, marginTop: 2, color: '#777', fontSize: 11, textTransform: 'uppercase', letterSpacing: 1 }}>Style</div>
-      )}
+      {styleFields.length > 0 && <div style={sectionLabelStyle}>Style</div>}
       {styleFields.map(f => (
         <div key={f.key} style={fieldRowStyle}>
           <span style={labelStyle}>{f.label}</span>
           {f.type === 'color-text'
             ? <ColorTextInput value={layer.style?.[f.key] || ''} onChange={v => setStyle(f.key, v)} />
             : f.type === 'select'
-              ? (
-                <select value={layer.style?.[f.key] || ''} onChange={e => setStyle(f.key, e.target.value)} style={inputStyle}>
+              ? <select value={layer.style?.[f.key] || ''} onChange={e => setStyle(f.key, e.target.value)} style={inputStyle}>
                   <option value="">—</option>
                   {f.options.map(o => <option key={o} value={o}>{o}</option>)}
                 </select>
-              )
-              : (
-                <input
-                  type="text"
-                  value={layer.style?.[f.key] || ''}
-                  placeholder={f.placeholder || ''}
-                  onChange={e => setStyle(f.key, e.target.value)}
-                  style={inputStyle}
-                />
-              )
+              : <input type="text" value={layer.style?.[f.key] || ''} placeholder={f.placeholder || ''}
+                       onChange={e => setStyle(f.key, e.target.value)} style={inputStyle} />
           }
         </div>
       ))}
@@ -530,111 +536,128 @@ function LayerPropertyEditor({ layer, onChange }) {
   );
 }
 
-// ── Styles ───────────────────────────────────────────────────────────────────
+// ── Styles ────────────────────────────────────────────────────────────────────
 
 const inputStyle = {
-  background: '#1e1e1e',
-  border: '1px solid #444',
-  color: '#eee',
-  borderRadius: 3,
-  padding: '3px 6px',
-  fontSize: 13,
-  flex: 1,
-  minWidth: 0,
-  boxSizing: 'border-box',
+  background: '#1e1e1e', border: '1px solid #444', color: '#eee',
+  borderRadius: 3, padding: '3px 6px', fontSize: 13,
+  flex: 1, minWidth: 0, boxSizing: 'border-box',
 };
-
-const fieldRowStyle = {
-  display: 'flex',
-  alignItems: 'center',
-  gap: 8,
+const fieldRowStyle    = { display: 'flex', alignItems: 'center', gap: 8 };
+const labelStyle       = { color: '#999', fontSize: 12, width: 90, flexShrink: 0, textAlign: 'right' };
+const sectionLabelStyle = {
+  borderTop: '1px solid #333', paddingTop: 6, marginTop: 2,
+  color: '#777', fontSize: 11, textTransform: 'uppercase', letterSpacing: 1,
 };
-
-const labelStyle = {
-  color: '#999',
-  fontSize: 12,
-  width: 90,
-  flexShrink: 0,
-  textAlign: 'right',
-};
-
 const btnStyle = {
-  background: '#2a2a2a',
-  border: '1px solid #555',
-  color: '#ddd',
-  borderRadius: 4,
-  padding: '4px 10px',
-  fontSize: 13,
-  cursor: 'pointer',
+  background: '#2a2a2a', border: '1px solid #555', color: '#ddd',
+  borderRadius: 4, padding: '4px 10px', fontSize: 13, cursor: 'pointer',
 };
+const btnPrimaryStyle = { ...btnStyle, background: '#2255aa', border: '1px solid #4488dd', color: '#fff' };
+const btnDangerStyle  = { ...btnStyle, background: '#550000', border: '1px solid #882222', color: '#ffaaaa' };
+const btnActiveStyle  = { ...btnStyle, background: '#1a3a1a', border: '1px solid #44aa44', color: '#88ee88' };
 
-const btnPrimaryStyle = {
-  ...btnStyle,
-  background: '#2255aa',
-  border: '1px solid #4488dd',
-  color: '#fff',
-};
+// ── Counters ──────────────────────────────────────────────────────────────────
 
-const btnDangerStyle = {
-  ...btnStyle,
-  background: '#550000',
-  border: '1px solid #882222',
-  color: '#ffaaaa',
-};
+let _layerCounter = 0, _groupCounter = 0;
+function newLayerId(type) { _layerCounter += 1; return `${type}-${_layerCounter}`; }
+function newGroupId()     { _groupCounter += 1; return `grp-${_groupCounter}`; }
 
-// ── Main component ───────────────────────────────────────────────────────────
-
-let _layerCounter = 0;
-function newLayerId(type) {
-  _layerCounter += 1;
-  return `${type}-${_layerCounter}`;
-}
+// ── Main component ────────────────────────────────────────────────────────────
 
 export function DskEditorPage() {
-  const params = new URLSearchParams(window.location.search);
-  const apiKey = params.get('apikey') || '';
+  const params    = new URLSearchParams(window.location.search);
+  const apiKey    = params.get('apikey') || '';
   const serverUrl = (params.get('server') || '').replace(/\/$/, '');
 
-  const [templates, setTemplates]       = useState([]);   // { id, name, updated_at }[]
-  const [selectedId, setSelectedId]     = useState(null); // currently loaded template id
+  const [templates, setTemplates]     = useState([]);
+  const [selectedId, setSelectedId]   = useState(null);   // backend template id
   const [templateName, setTemplateName] = useState('');
-  const [template, setTemplate]         = useState(EMPTY_TEMPLATE);
-  const [selectedLayerId, setSelectedLayerId] = useState(null);
-  const [status, setStatus]             = useState('');   // save feedback
-  const [loading, setLoading]           = useState(false);
+  const [template, setTemplate]       = useState(EMPTY_TEMPLATE);
+  const [selectedIds, setSelectedIds] = useState(new Set()); // canvas multi-selection
+  const [primaryId, setPrimaryId]     = useState(null);    // property-panel target
+  const [snapGrid, setSnapGrid]       = useState(false);
+  const [status, setStatus]           = useState('');
+  const [loading, setLoading]         = useState(false);
 
-  const isDirty = useRef(false);
+  const isDirty    = useRef(false);
+  const historyRef = useRef({ past: [], future: [] });
+  const templateRef = useRef(template); // mirror for use inside event listeners
+  useEffect(() => { templateRef.current = template; }, [template]);
 
-  // ── API helpers ──────────────────────────────────────────────────────────
+  // ── Undo / redo ─────────────────────────────────────────────────────────
+
+  function pushHistory(tmpl) {
+    historyRef.current.past.push(JSON.stringify(tmpl));
+    historyRef.current.future = [];
+    if (historyRef.current.past.length > MAX_HISTORY) historyRef.current.past.shift();
+  }
+
+  // Global keyboard handler — attached once so it always has the latest template
+  useEffect(() => {
+    function onGlobalKey(e) {
+      const mod = e.ctrlKey || e.metaKey;
+      if (!mod) return;
+      if (e.key === 'z' && !e.shiftKey) {
+        e.preventDefault();
+        const { past, future } = historyRef.current;
+        if (!past.length) return;
+        future.push(JSON.stringify(templateRef.current));
+        setTemplate(JSON.parse(past.pop()));
+        isDirty.current = true;
+      }
+      if (e.key === 'y' || (e.key === 'z' && e.shiftKey)) {
+        e.preventDefault();
+        const { past, future } = historyRef.current;
+        if (!future.length) return;
+        past.push(JSON.stringify(templateRef.current));
+        setTemplate(JSON.parse(future.pop()));
+        isDirty.current = true;
+      }
+    }
+    window.addEventListener('keydown', onGlobalKey);
+    return () => window.removeEventListener('keydown', onGlobalKey);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const canUndo = historyRef.current.past.length > 0;
+  const canRedo = historyRef.current.future.length > 0;
+
+  function undo() {
+    const { past, future } = historyRef.current;
+    if (!past.length) return;
+    future.push(JSON.stringify(templateRef.current));
+    setTemplate(JSON.parse(past.pop()));
+    isDirty.current = true;
+  }
+  function redo() {
+    const { past, future } = historyRef.current;
+    if (!future.length) return;
+    past.push(JSON.stringify(templateRef.current));
+    setTemplate(JSON.parse(future.pop()));
+    isDirty.current = true;
+  }
+
+  // ── API ──────────────────────────────────────────────────────────────────
 
   function apiFetch(path, opts = {}) {
     return fetch(`${serverUrl}${path}`, {
       ...opts,
-      headers: {
-        'Content-Type': 'application/json',
-        'X-API-Key': apiKey,
-        ...(opts.headers || {}),
-      },
+      headers: { 'Content-Type': 'application/json', 'X-API-Key': apiKey, ...(opts.headers || {}) },
     });
   }
-
-  // ── Template list ────────────────────────────────────────────────────────
 
   const fetchTemplates = useCallback(async () => {
     if (!serverUrl || !apiKey) return;
     try {
       const res = await apiFetch(`/dsk/${encodeURIComponent(apiKey)}/templates`);
       if (!res.ok) throw new Error(await res.text());
-      const data = await res.json();
-      setTemplates(data.templates || []);
-    } catch (err) {
-      setStatus(`Error loading templates: ${err.message}`);
-    }
+      setTemplates((await res.json()).templates || []);
+    } catch (err) { setStatus(`Error loading templates: ${err.message}`); }
   }, [serverUrl, apiKey]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => { fetchTemplates(); }, [fetchTemplates]);
 
-  // ── Load template for editing ────────────────────────────────────────────
+  // ── Template lifecycle ───────────────────────────────────────────────────
 
   async function loadTemplate(id) {
     try {
@@ -644,22 +667,19 @@ export function DskEditorPage() {
       setSelectedId(row.id);
       setTemplateName(row.name);
       setTemplate(row.templateJson || EMPTY_TEMPLATE);
-      setSelectedLayerId(null);
+      clearSelection();
+      historyRef.current = { past: [], future: [] };
       isDirty.current = false;
       setStatus('');
-    } catch (err) {
-      setStatus(`Error loading template: ${err.message}`);
-    }
+    } catch (err) { setStatus(`Error loading template: ${err.message}`); }
   }
 
-  // ── New template from preset ─────────────────────────────────────────────
-
   function newFromPreset(presetName) {
-    const preset = PRESETS[presetName];
     setSelectedId(null);
     setTemplateName(presetName);
-    setTemplate(JSON.parse(JSON.stringify(preset))); // deep copy
-    setSelectedLayerId(null);
+    setTemplate(JSON.parse(JSON.stringify(PRESETS[presetName])));
+    clearSelection();
+    historyRef.current = { past: [], future: [] };
     isDirty.current = true;
     setStatus('');
   }
@@ -668,95 +688,116 @@ export function DskEditorPage() {
     setSelectedId(null);
     setTemplateName('New Template');
     setTemplate(JSON.parse(JSON.stringify(EMPTY_TEMPLATE)));
-    setSelectedLayerId(null);
+    clearSelection();
+    historyRef.current = { past: [], future: [] };
     isDirty.current = true;
     setStatus('');
   }
 
-  // ── Save ─────────────────────────────────────────────────────────────────
-
   async function saveTemplate() {
     if (!templateName.trim()) { setStatus('Template name is required'); return; }
-    setLoading(true);
-    setStatus('Saving…');
+    setLoading(true); setStatus('Saving…');
     try {
       let res;
       if (selectedId) {
-        // Update existing by id
         res = await apiFetch(`/dsk/${encodeURIComponent(apiKey)}/templates/${selectedId}`, {
-          method: 'PUT',
-          body: JSON.stringify({ name: templateName.trim(), template }),
+          method: 'PUT', body: JSON.stringify({ name: templateName.trim(), template }),
         });
       } else {
-        // Create new
         res = await apiFetch(`/dsk/${encodeURIComponent(apiKey)}/templates`, {
-          method: 'POST',
-          body: JSON.stringify({ name: templateName.trim(), template }),
+          method: 'POST', body: JSON.stringify({ name: templateName.trim(), template }),
         });
       }
       if (!res.ok) throw new Error(await res.text());
       const data = await res.json();
       if (!selectedId) setSelectedId(data.id);
-      isDirty.current = false;
-      setStatus('Saved.');
+      isDirty.current = false; setStatus('Saved.');
       await fetchTemplates();
-    } catch (err) {
-      setStatus(`Save error: ${err.message}`);
-    } finally {
-      setLoading(false);
-    }
+    } catch (err) { setStatus(`Save error: ${err.message}`);
+    } finally { setLoading(false); }
   }
 
-  // ── Delete template ──────────────────────────────────────────────────────
-
-  async function deleteTemplate(id, name) {
+  async function deleteTemplateById(id, name) {
     if (!window.confirm(`Delete template "${name}"?`)) return;
     try {
       const res = await apiFetch(`/dsk/${encodeURIComponent(apiKey)}/templates/${id}`, { method: 'DELETE' });
       if (!res.ok) throw new Error(await res.text());
-      if (selectedId === id) {
-        setSelectedId(null);
-        setTemplateName('');
-        setTemplate(EMPTY_TEMPLATE);
-        setSelectedLayerId(null);
-      }
-      await fetchTemplates();
-      setStatus('Deleted.');
-    } catch (err) {
-      setStatus(`Delete error: ${err.message}`);
-    }
+      if (selectedId === id) { setSelectedId(null); setTemplateName(''); setTemplate(EMPTY_TEMPLATE); clearSelection(); }
+      await fetchTemplates(); setStatus('Deleted.');
+    } catch (err) { setStatus(`Delete error: ${err.message}`); }
   }
 
-  // ── Layer management ─────────────────────────────────────────────────────
+  // ── Selection ────────────────────────────────────────────────────────────
+
+  function clearSelection() {
+    setSelectedIds(new Set());
+    setPrimaryId(null);
+  }
+
+  /** Called by TemplatePreview on click. id=null = deselect all. */
+  function handleCanvasSelect(id, additive) {
+    if (!id) { clearSelection(); return; }
+    const layer = template.layers.find(l => l.id === id);
+    const groupMemberIds = layer?.groupId
+      ? template.layers.filter(l => l.groupId === layer.groupId).map(l => l.id)
+      : [id];
+
+    if (additive) {
+      setSelectedIds(prev => {
+        const next = new Set(prev);
+        const allIn = groupMemberIds.every(mid => next.has(mid));
+        if (allIn) groupMemberIds.forEach(mid => next.delete(mid));
+        else       groupMemberIds.forEach(mid => next.add(mid));
+        return next;
+      });
+    } else {
+      setSelectedIds(new Set(groupMemberIds));
+    }
+    setPrimaryId(id);
+  }
+
+  function selectLayerFromList(id) {
+    const layer = template.layers.find(l => l.id === id);
+    const groupMemberIds = layer?.groupId
+      ? template.layers.filter(l => l.groupId === layer.groupId).map(l => l.id)
+      : [id];
+    setSelectedIds(new Set(groupMemberIds));
+    setPrimaryId(id);
+  }
+
+  // ── Layer mutations ──────────────────────────────────────────────────────
 
   function addLayer(type) {
+    pushHistory(template);
     const id = newLayerId(type);
-    const newLayer = type === 'rect'
-      ? { id, type: 'rect', x: 100, y: 100, width: 400, height: 100, style: { background: '#333333', opacity: '0.9' } }
-      : type === 'text'
-        ? { id, type: 'text', x: 100, y: 100, text: 'Text', style: { 'font-size': '48px', 'font-family': 'Arial, sans-serif', color: '#ffffff' } }
-        : { id, type: 'image', x: 0, y: 0, width: 400, height: 300, src: '' };
-
+    const defaults = {
+      rect:    { id, type: 'rect',    x: 100, y: 100, width: 400, height: 100, style: { background: '#333333', opacity: '0.9' } },
+      ellipse: { id, type: 'ellipse', x: 200, y: 200, width: 200, height: 200, style: { background: '#336699' } },
+      text:    { id, type: 'text',    x: 100, y: 100, text: 'Text', style: { 'font-size': '48px', 'font-family': 'Arial, sans-serif', color: '#ffffff' } },
+      image:   { id, type: 'image',   x: 0,   y: 0,   width: 400, height: 300, src: '' },
+    };
+    const newLayer = defaults[type] || defaults.rect;
     setTemplate(t => ({ ...t, layers: [...(t.layers || []), newLayer] }));
-    setSelectedLayerId(id);
+    setSelectedIds(new Set([id]));
+    setPrimaryId(id);
     isDirty.current = true;
   }
 
   function updateLayer(updated) {
-    setTemplate(t => ({
-      ...t,
-      layers: t.layers.map(l => l.id === updated.id ? updated : l),
-    }));
+    pushHistory(template);
+    setTemplate(t => ({ ...t, layers: t.layers.map(l => l.id === updated.id ? updated : l) }));
     isDirty.current = true;
   }
 
   function deleteLayer(id) {
+    pushHistory(template);
     setTemplate(t => ({ ...t, layers: t.layers.filter(l => l.id !== id) }));
-    if (selectedLayerId === id) setSelectedLayerId(null);
+    if (primaryId === id) clearSelection();
     isDirty.current = true;
   }
 
-  function moveLayer(id, dir) {
+  function reorderLayer(id, dir) {
+    pushHistory(template);
     setTemplate(t => {
       const layers = [...t.layers];
       const idx = layers.findIndex(l => l.id === id);
@@ -769,29 +810,87 @@ export function DskEditorPage() {
     isDirty.current = true;
   }
 
-  // ── Direct manipulation callbacks (Phase 2) ───────────────────────────────
+  // ── Phase 2 direct-manipulation callbacks ────────────────────────────────
 
-  function moveLayerPosition(id, { x, y }) {
+  /** Called by TemplatePreview when a drag begins (push undo before first move). */
+  function handleDragStart() {
+    pushHistory(template);
+  }
+
+  /** Called continuously during drag with updated positions for all moving layers. */
+  function handleMoveSelected(updates) {
     setTemplate(t => ({
       ...t,
-      layers: t.layers.map(l => l.id === id ? { ...l, x, y } : l),
+      layers: t.layers.map(l => {
+        const upd = updates.find(u => u.id === l.id);
+        return upd ? { ...l, x: upd.x, y: upd.y } : l;
+      }),
     }));
     isDirty.current = true;
   }
 
-  function resizeLayerRect(id, { x, y, width, height }) {
+  function handleResizeLayer(id, rect) {
     setTemplate(t => ({
       ...t,
-      layers: t.layers.map(l => l.id === id ? { ...l, x, y, width, height } : l),
+      layers: t.layers.map(l => l.id === id ? { ...l, ...rect } : l),
     }));
+    isDirty.current = true;
+  }
+
+  // ── Phase 3 group management ─────────────────────────────────────────────
+
+  /** Group all currently selected layers into a new named group. */
+  function groupSelected() {
+    if (selectedIds.size < 2) return;
+    // Don't group if they already all belong to the same group
+    const existingGroupIds = new Set(
+      template.layers.filter(l => selectedIds.has(l.id) && l.groupId).map(l => l.groupId),
+    );
+    if (existingGroupIds.size === 1 &&
+        template.layers.filter(l => l.groupId === [...existingGroupIds][0]).every(l => selectedIds.has(l.id))) {
+      return; // already one coherent group
+    }
+    pushHistory(template);
+    const gid  = newGroupId();
+    const name = `Group ${_groupCounter}`;
+    setTemplate(t => ({
+      ...t,
+      groups: [...(t.groups || []), { id: gid, name }],
+      layers: t.layers.map(l => selectedIds.has(l.id) ? { ...l, groupId: gid } : l),
+    }));
+    isDirty.current = true;
+  }
+
+  /** Remove group membership from all selected layers. */
+  function ungroupSelected() {
+    const groupIds = new Set(
+      template.layers.filter(l => selectedIds.has(l.id) && l.groupId).map(l => l.groupId),
+    );
+    if (!groupIds.size) return;
+    pushHistory(template);
+    setTemplate(t => ({
+      ...t,
+      groups: (t.groups || []).filter(g => !groupIds.has(g.id)),
+      layers: t.layers.map(l => {
+        if (!groupIds.has(l.groupId)) return l;
+        const { groupId: _gid, ...rest } = l;
+        return rest;
+      }),
+    }));
+    clearSelection();
     isDirty.current = true;
   }
 
   // ── Derived ──────────────────────────────────────────────────────────────
 
-  const selectedLayer = template.layers?.find(l => l.id === selectedLayerId) || null;
+  const primaryLayer    = template.layers?.find(l => l.id === primaryId) || null;
+  const canGroup        = selectedIds.size >= 2;
+  const canUngroup      = [...selectedIds].some(id => template.layers.find(l => l.id === id)?.groupId);
 
-  // ── Guard ────────────────────────────────────────────────────────────────
+  // Group name lookup
+  const groupNameById = Object.fromEntries((template.groups || []).map(g => [g.id, g.name]));
+
+  // ── Guard ─────────────────────────────────────────────────────────────────
 
   if (!serverUrl || !apiKey) {
     return (
@@ -801,162 +900,142 @@ export function DskEditorPage() {
     );
   }
 
-  // ── Render ───────────────────────────────────────────────────────────────
+  // ── Render ────────────────────────────────────────────────────────────────
 
   return (
     <div style={{ display: 'flex', height: '100vh', background: '#111', color: '#ddd', fontFamily: 'sans-serif', overflow: 'hidden' }}>
 
-      {/* Left panel — template list */}
+      {/* ── Left: template list ── */}
       <div style={{ width: 220, borderRight: '1px solid #333', display: 'flex', flexDirection: 'column', flexShrink: 0 }}>
-        <div style={{ padding: '10px 12px', borderBottom: '1px solid #333', fontWeight: 'bold', fontSize: 14, color: '#bbb' }}>
-          Templates
-        </div>
-
-        {/* Preset buttons */}
+        <div style={{ padding: '10px 12px', borderBottom: '1px solid #333', fontWeight: 'bold', fontSize: 14, color: '#bbb' }}>Templates</div>
         <div style={{ padding: '8px 10px', borderBottom: '1px solid #333', display: 'flex', flexDirection: 'column', gap: 4 }}>
           <div style={{ fontSize: 11, color: '#666', textTransform: 'uppercase', letterSpacing: 1, marginBottom: 2 }}>New from preset</div>
           {Object.keys(PRESETS).map(name => (
-            <button key={name} onClick={() => newFromPreset(name)} style={{ ...btnStyle, textAlign: 'left', fontSize: 12 }}>
-              {name}
-            </button>
+            <button key={name} onClick={() => newFromPreset(name)} style={{ ...btnStyle, textAlign: 'left', fontSize: 12 }}>{name}</button>
           ))}
-          <button onClick={newBlank} style={{ ...btnStyle, textAlign: 'left', fontSize: 12 }}>
-            Blank
-          </button>
+          <button onClick={newBlank} style={{ ...btnStyle, textAlign: 'left', fontSize: 12 }}>Blank</button>
         </div>
-
-        {/* Template list */}
         <div style={{ flex: 1, overflowY: 'auto' }}>
-          {templates.length === 0 && (
-            <div style={{ padding: 12, color: '#555', fontSize: 13 }}>No templates yet.</div>
-          )}
+          {templates.length === 0 && <div style={{ padding: 12, color: '#555', fontSize: 13 }}>No templates yet.</div>}
           {templates.map(t => (
-            <div
-              key={t.id}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                padding: '8px 10px',
-                cursor: 'pointer',
-                background: t.id === selectedId ? '#1e3a5f' : 'transparent',
-                borderBottom: '1px solid #222',
-              }}
-              onClick={() => loadTemplate(t.id)}
-            >
+            <div key={t.id} style={{
+              display: 'flex', alignItems: 'center', padding: '8px 10px', cursor: 'pointer',
+              background: t.id === selectedId ? '#1e3a5f' : 'transparent', borderBottom: '1px solid #222',
+            }} onClick={() => loadTemplate(t.id)}>
               <span style={{ flex: 1, fontSize: 13, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{t.name}</span>
-              <button
-                onClick={e => { e.stopPropagation(); deleteTemplate(t.id, t.name); }}
-                title="Delete"
-                style={{ ...btnDangerStyle, padding: '2px 6px', fontSize: 11, marginLeft: 4 }}
-              >
-                ✕
-              </button>
+              <button onClick={e => { e.stopPropagation(); deleteTemplateById(t.id, t.name); }}
+                      title="Delete" style={{ ...btnDangerStyle, padding: '2px 6px', fontSize: 11, marginLeft: 4 }}>✕</button>
             </div>
           ))}
         </div>
       </div>
 
-      {/* Main area */}
+      {/* ── Main area ── */}
       <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
 
         {/* Toolbar */}
-        <div style={{ padding: '8px 12px', borderBottom: '1px solid #333', display: 'flex', alignItems: 'center', gap: 10, flexShrink: 0 }}>
-          <input
-            type="text"
-            value={templateName}
+        <div style={{ padding: '8px 12px', borderBottom: '1px solid #333', display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0, flexWrap: 'wrap' }}>
+          <input type="text" value={templateName}
             onChange={e => { setTemplateName(e.target.value); isDirty.current = true; }}
-            placeholder="Template name"
-            style={{ ...inputStyle, width: 220 }}
-          />
+            placeholder="Template name" style={{ ...inputStyle, width: 200 }} />
 
           <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-            <span style={{ fontSize: 12, color: '#888' }}>Background:</span>
-            <input
-              type="color"
+            <span style={{ fontSize: 12, color: '#888' }}>BG:</span>
+            <input type="color"
               value={template.background && template.background !== 'transparent' ? template.background.slice(0, 7) : '#000000'}
               onChange={e => { setTemplate(t => ({ ...t, background: e.target.value })); isDirty.current = true; }}
-              style={{ width: 32, height: 24, padding: 0, border: 'none', cursor: 'pointer' }}
-            />
-            <input
-              type="text"
-              value={template.background || 'transparent'}
+              style={{ width: 28, height: 22, padding: 0, border: 'none', cursor: 'pointer' }} />
+            <input type="text" value={template.background || 'transparent'}
               onChange={e => { setTemplate(t => ({ ...t, background: e.target.value })); isDirty.current = true; }}
-              style={{ ...inputStyle, width: 120 }}
-            />
+              style={{ ...inputStyle, width: 110 }} />
           </div>
 
-          <span style={{ flex: 1 }} />
-          {status && <span style={{ fontSize: 12, color: status.startsWith('Error') ? '#f88' : '#8d8' }}>{status}</span>}
-          <button onClick={saveTemplate} disabled={loading} style={btnPrimaryStyle}>
-            {loading ? 'Saving…' : 'Save'}
+          {/* Undo / Redo */}
+          <button onClick={undo} disabled={!canUndo} title="Undo (Ctrl+Z)" style={{ ...btnStyle, opacity: canUndo ? 1 : 0.4 }}>↩</button>
+          <button onClick={redo} disabled={!canRedo} title="Redo (Ctrl+Y)" style={{ ...btnStyle, opacity: canRedo ? 1 : 0.4 }}>↪</button>
+
+          {/* Snap to grid */}
+          <button onClick={() => setSnapGrid(v => !v)} title="Snap to grid"
+                  style={snapGrid ? btnActiveStyle : btnStyle}>
+            ⊞ {snapGrid ? 'Grid on' : 'Grid'}
           </button>
+
+          <span style={{ flex: 1 }} />
+          {status && <span style={{ fontSize: 12, color: status.startsWith('Error') || status.startsWith('Save error') ? '#f88' : '#8d8' }}>{status}</span>}
+          <button onClick={saveTemplate} disabled={loading} style={btnPrimaryStyle}>{loading ? 'Saving…' : 'Save'}</button>
         </div>
 
         {/* Content area */}
         <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
 
-          {/* Preview + layers panel */}
+          {/* Preview + layer list */}
           <div style={{ flex: 1, display: 'flex', flexDirection: 'column', padding: 12, gap: 10, overflow: 'auto' }}>
 
-            {/* Preview */}
             <TemplatePreview
               template={template}
-              selectedLayerId={selectedLayerId}
-              onSelectLayer={id => setSelectedLayerId(id === selectedLayerId ? null : id)}
-              onMoveLayer={moveLayerPosition}
-              onResizeLayer={resizeLayerRect}
+              selectedIds={selectedIds}
+              primaryId={primaryId}
+              onSelect={handleCanvasSelect}
+              onDragStart={handleDragStart}
+              onMoveSelected={handleMoveSelected}
+              onResizeLayer={handleResizeLayer}
+              snapGrid={snapGrid}
             />
 
-            {/* Layer list */}
-            <div>
-              <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
-                <span style={{ fontSize: 13, color: '#bbb', fontWeight: 'bold' }}>Layers</span>
-                <span style={{ flex: 1 }} />
-                <button onClick={() => addLayer('rect')} style={{ ...btnStyle, fontSize: 12 }}>+ Rect</button>
-                <button onClick={() => addLayer('text')} style={{ ...btnStyle, fontSize: 12 }}>+ Text</button>
-              </div>
-
-              {(template.layers || []).length === 0 && (
-                <div style={{ color: '#555', fontSize: 13 }}>No layers. Add a rect or text layer above.</div>
-              )}
-
-              {[...(template.layers || [])].reverse().map((layer, revIdx) => {
-                const realIdx = (template.layers.length - 1) - revIdx;
-                const isSelected = layer.id === selectedLayerId;
-                return (
-                  <div
-                    key={layer.id}
-                    style={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      padding: '4px 8px',
-                      marginBottom: 2,
-                      background: isSelected ? '#1e3a5f' : '#1a1a1a',
-                      borderRadius: 3,
-                      cursor: 'pointer',
-                      border: isSelected ? '1px solid #4488dd' : '1px solid transparent',
-                    }}
-                    onClick={() => setSelectedLayerId(isSelected ? null : layer.id)}
-                  >
-                    <span style={{ fontSize: 11, color: '#666', width: 40, flexShrink: 0 }}>{layer.type}</span>
-                    <span style={{ flex: 1, fontSize: 13, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                      {layer.id}
-                      {layer.type === 'text' && layer.text ? <span style={{ color: '#777', marginLeft: 8 }}>"{layer.text}"</span> : null}
-                    </span>
-                    <button onClick={e => { e.stopPropagation(); moveLayer(layer.id, -1); }} title="Move up (higher z-index)" style={{ ...btnStyle, padding: '1px 5px', fontSize: 11 }}>↑</button>
-                    <button onClick={e => { e.stopPropagation(); moveLayer(layer.id, 1); }} title="Move down (lower z-index)" style={{ ...btnStyle, padding: '1px 5px', fontSize: 11 }}>↓</button>
-                    <button onClick={e => { e.stopPropagation(); deleteLayer(layer.id); }} title="Delete layer" style={{ ...btnDangerStyle, padding: '1px 5px', fontSize: 11, marginLeft: 4 }}>✕</button>
-                  </div>
-                );
-              })}
+            {/* Layer list header */}
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
+              <span style={{ fontSize: 13, color: '#bbb', fontWeight: 'bold' }}>Layers</span>
+              <span style={{ flex: 1 }} />
+              <button onClick={() => addLayer('ellipse')} style={{ ...btnStyle, fontSize: 12 }}>+ Ellipse</button>
+              <button onClick={() => addLayer('rect')}    style={{ ...btnStyle, fontSize: 12 }}>+ Rect</button>
+              <button onClick={() => addLayer('text')}    style={{ ...btnStyle, fontSize: 12 }}>+ Text</button>
+              {canGroup   && <button onClick={groupSelected}   title="Group selected layers" style={{ ...btnStyle, fontSize: 12 }}>Group</button>}
+              {canUngroup && <button onClick={ungroupSelected} title="Remove from group"     style={{ ...btnDangerStyle, fontSize: 12 }}>Ungroup</button>}
             </div>
+
+            {(template.layers || []).length === 0 && (
+              <div style={{ color: '#555', fontSize: 13 }}>No layers yet.</div>
+            )}
+
+            {[...(template.layers || [])].reverse().map((layer) => {
+              const isInSel  = selectedIds.has(layer.id);
+              const isPrimary = layer.id === primaryId;
+              const gName    = layer.groupId ? groupNameById[layer.groupId] || layer.groupId : null;
+              return (
+                <div key={layer.id} style={{
+                  display: 'flex', alignItems: 'center', padding: '4px 8px', marginBottom: 2,
+                  background: isInSel ? '#1e3a5f' : '#1a1a1a', borderRadius: 3, cursor: 'pointer',
+                  border: isPrimary ? '1px solid #4488dd' : isInSel ? '1px solid #336' : '1px solid transparent',
+                }} onClick={() => selectLayerFromList(layer.id)}>
+                  <span style={{ fontSize: 11, color: '#666', width: 44, flexShrink: 0 }}>{layer.type}</span>
+                  <span style={{ flex: 1, fontSize: 13, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {layer.id}
+                    {layer.type === 'text' && layer.text
+                      ? <span style={{ color: '#777', marginLeft: 6 }}>"{layer.text}"</span>
+                      : null}
+                  </span>
+                  {gName && (
+                    <span style={{ fontSize: 10, color: '#6af', background: '#1a2a3a', borderRadius: 3,
+                                   padding: '1px 5px', marginRight: 4, flexShrink: 0, maxWidth: 80,
+                                   overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                          title={gName}>
+                      {gName}
+                    </span>
+                  )}
+                  <button onClick={e => { e.stopPropagation(); reorderLayer(layer.id, -1); }} title="Move up" style={{ ...btnStyle, padding: '1px 5px', fontSize: 11 }}>↑</button>
+                  <button onClick={e => { e.stopPropagation(); reorderLayer(layer.id,  1); }} title="Move down" style={{ ...btnStyle, padding: '1px 5px', fontSize: 11 }}>↓</button>
+                  <button onClick={e => { e.stopPropagation(); deleteLayer(layer.id); }}    title="Delete" style={{ ...btnDangerStyle, padding: '1px 5px', fontSize: 11, marginLeft: 4 }}>✕</button>
+                </div>
+              );
+            })}
           </div>
 
           {/* Properties panel */}
           <div style={{ width: 280, borderLeft: '1px solid #333', padding: 12, overflowY: 'auto', flexShrink: 0 }}>
             <div style={{ fontSize: 13, color: '#bbb', fontWeight: 'bold', marginBottom: 10 }}>Properties</div>
             <LayerPropertyEditor
-              layer={selectedLayer}
+              layer={primaryLayer}
+              selectionCount={selectedIds.size}
               onChange={updateLayer}
             />
           </div>

--- a/packages/plugins/lcyt-dsk/src/api.js
+++ b/packages/plugins/lcyt-dsk/src/api.js
@@ -30,7 +30,7 @@ import { createDskRouter } from './routes/dsk.js';
 import { createDskTemplatesRouter } from './routes/dsk-templates.js';
 import { createImagesRouter } from './routes/images.js';
 import { createDskRtmpRouter } from './routes/dsk-rtmp.js';
-import { createEditorAuth } from './middleware/editor-auth.js';
+import { createEditorAuth, editorAuthOrBearer } from './middleware/editor-auth.js';
 export { deleteAllImages } from './db/images.js';
 
 /**
@@ -69,8 +69,8 @@ export function createDskRouters(db, store, auth, relayManager) {
     dskRouter: createDskRouter(db, store),
     /** Mount at /dsk  — authenticated template CRUD + renderer control */
     dskTemplatesRouter: createDskTemplatesRouter(db, auth, editorAuth, relayManager),
-    /** Mount at /images — authenticated upload; public serve */
-    imagesRouter: createImagesRouter(db, auth),
+    /** Mount at /images — authenticated upload (JWT or X-API-Key); public serve */
+    imagesRouter: createImagesRouter(db, editorAuthOrBearer(auth, editorAuth)),
     /** Mount at /dsk-rtmp — nginx-rtmp on_publish callbacks */
     dskRtmpRouter: createDskRtmpRouter(relayManager),
   };

--- a/packages/plugins/lcyt-dsk/src/renderer.js
+++ b/packages/plugins/lcyt-dsk/src/renderer.js
@@ -73,7 +73,7 @@ export function renderTemplateToHtml(templateJson) {
   const bg = t.background ?? 'transparent';
   const w  = t.width  ?? 1920;
   const h  = t.height ?? 1080;
-  const layers = Array.isArray(t.layers) ? t.layers : [];
+  const layers = Array.isArray(t.layers) ? t.layers.filter(l => l.visible !== false) : [];
 
   const layerHtml = layers.map((layer) => {
     const id        = layer.id ? ` id="${escHtml(layer.id)}"` : '';

--- a/packages/plugins/lcyt-dsk/src/renderer.js
+++ b/packages/plugins/lcyt-dsk/src/renderer.js
@@ -96,6 +96,10 @@ export function renderTemplateToHtml(templateJson) {
       return `<div${id} style="${style}">${escHtml(layer.text ?? '')}</div>`;
     } else if (layer.type === 'rect') {
       return `<div${id} style="${style}"></div>`;
+    } else if (layer.type === 'ellipse') {
+      // Render as a rectangle with border-radius:50% — extra style appended last so it wins.
+      const ellipseStyle = [style, 'border-radius:50%'].filter(Boolean).join(';');
+      return `<div${id} style="${ellipseStyle}"></div>`;
     } else if (layer.type === 'image') {
       return `<img${id} src="${escHtml(layer.src ?? '')}" style="${style}" alt="">`;
     }

--- a/packages/plugins/lcyt-dsk/src/renderer.js
+++ b/packages/plugins/lcyt-dsk/src/renderer.js
@@ -118,6 +118,21 @@ export function renderTemplateToHtml(templateJson) {
     background:${bg};
   }
   #root { position:relative; width:${w}px; height:${h}px; overflow:hidden; }
+
+  /* LCYT built-in animation keyframes */
+  @keyframes lcyt-fadeIn      { from { opacity: 0 } to { opacity: 1 } }
+  @keyframes lcyt-fadeOut     { from { opacity: 1 } to { opacity: 0 } }
+  @keyframes lcyt-slideInLeft  { from { transform: translateX(-100%) } to { transform: translateX(0) } }
+  @keyframes lcyt-slideInRight { from { transform: translateX(100%)  } to { transform: translateX(0) } }
+  @keyframes lcyt-slideInUp    { from { transform: translateY(100%)  } to { transform: translateY(0) } }
+  @keyframes lcyt-slideInDown  { from { transform: translateY(-100%) } to { transform: translateY(0) } }
+  @keyframes lcyt-slideOutLeft  { from { transform: translateX(0) } to { transform: translateX(-100%) } }
+  @keyframes lcyt-slideOutRight { from { transform: translateX(0) } to { transform: translateX(100%)  } }
+  @keyframes lcyt-zoomIn  { from { transform: scale(0);   opacity: 0 } to { transform: scale(1);   opacity: 1 } }
+  @keyframes lcyt-zoomOut { from { transform: scale(1);   opacity: 1 } to { transform: scale(0);   opacity: 0 } }
+  @keyframes lcyt-pulse   { 0%, 100% { transform: scale(1) } 50% { transform: scale(1.05) } }
+  @keyframes lcyt-blink   { 0%, 100% { opacity: 1 } 50% { opacity: 0 } }
+  @keyframes lcyt-typewriter { from { clip-path: inset(0 100% 0 0) } to { clip-path: inset(0 0% 0 0) } }
 </style>
 </head>
 <body>

--- a/packages/plugins/lcyt-dsk/src/routes/images.js
+++ b/packages/plugins/lcyt-dsk/src/routes/images.js
@@ -17,9 +17,10 @@ import {
 
 const GRAPHICS_BASE_DIR = resolve(process.env.GRAPHICS_DIR || '/data/images');
 
-const ACCEPTED_MIMES = new Set(['image/png', 'image/webp', 'image/svg+xml']);
+const ACCEPTED_MIMES = new Set(['image/png', 'image/jpeg', 'image/webp', 'image/svg+xml']);
 const MIME_TO_EXT = {
   'image/png':     '.png',
+  'image/jpeg':    '.jpg',
   'image/webp':    '.webp',
   'image/svg+xml': '.svg',
 };
@@ -123,7 +124,7 @@ export function createImagesRouter(db, auth) {
       // Validate MIME
       if (!ACCEPTED_MIMES.has(mimeType)) {
         fileStream.resume();
-        return abort(400, `Unsupported file type: ${mimeType}. Accepted: PNG, WebP, SVG`);
+        return abort(400, `Unsupported file type: ${mimeType}. Accepted: PNG, JPEG, WebP, SVG`);
       }
 
       const ext = MIME_TO_EXT[mimeType] || extname(originalFilename) || '';


### PR DESCRIPTION


Layer management:
- Visibility toggle (●/○ eye button per layer; hidden layers dimmed in list
  and excluded from Playwright HTML renderer output)
- Duplicate layer button (⧉) — copies layer with 20px offset, auto-selects
- Copy/paste: Ctrl+C copies selected layers, Ctrl+V pastes with 20px offset

Alignment tools (shown when ≥2 layers selected):
- Align Left / Center-H / Right and Top / Middle-V / Bottom
- Computes bounding box of all selected layers and aligns to its edges/center

Property panel:
- Global opacity slider (0–100%) for all layer types via layer.style.opacity;
  replaces the raw text field that was only on rect/ellipse
- Border & Shadow section for all layer types (border, box-shadow CSS fields)
- Text-specific: text-shadow and -webkit-text-stroke fields
- Text font-weight is now a dropdown (normal/bold/100-900) + italic dropdown
- Aspect-ratio lock toggle for image layers (on by default); resize handles
  maintain the original width:height ratio when locked
- Image layer src field shown in properties panel

Safe area guides:
- Toggle button in toolbar (⬜ Safe) shows broadcast standard guide overlays
  on the preview: yellow dashed = 90% title-safe, orange dashed = 80% action-safe
- Guides are display-only and not saved or rendered by Playwright

https://claude.ai/code/session_018rr6RxmRPoyHf1Mc8Liz7s