### PR TITLE
DSK Viewports

### DIFF
--- a/packages/lcyt-backend/src/routes/captions.js
+++ b/packages/lcyt-backend/src/routes/captions.js
@@ -81,7 +81,7 @@ export function createCaptionsRouter(store, auth, db, relayManager = null, dskPr
         // Handled by the lcyt-dsk plugin processor injected at startup.
         if (dskProcessor) {
           for (const caption of resolvedCaptions) {
-            caption.text = await dskProcessor(session.apiKey, caption.text || '');
+            caption.text = await dskProcessor(session.apiKey, caption.text || '', caption.codes ?? {});
           }
         }
 

--- a/packages/lcyt-backend/src/store.js
+++ b/packages/lcyt-backend/src/store.js
@@ -47,6 +47,12 @@ export class SessionStore {
     this.onSessionEnd = null;
     /** @type {Map<string, Set<import('express').Response>>} DSK SSE subscribers keyed by apiKey */
     this._dskSubscribers = new Map();
+    /**
+     * Server-side active graphics state for delta +/- operations.
+     * Keyed by apiKey.
+     * @type {Map<string, { default: string[], viewports: { [name]: string[] } }>}
+     */
+    this._dskGraphicsState = new Map();
     this._startCleanup();
   }
 
@@ -95,6 +101,28 @@ export class SessionStore {
       }
     }
     if (set.size === 0) this._dskSubscribers.delete(apiKey);
+  }
+
+  /**
+   * Get the current DSK graphics state for an API key.
+   * Creates an empty state if none exists yet.
+   * @param {string} apiKey
+   * @returns {{ default: string[], viewports: { [name]: string[] } }}
+   */
+  getDskGraphicsState(apiKey) {
+    if (!this._dskGraphicsState.has(apiKey)) {
+      this._dskGraphicsState.set(apiKey, { default: [], viewports: {} });
+    }
+    return this._dskGraphicsState.get(apiKey);
+  }
+
+  /**
+   * Persist updated DSK graphics state for an API key.
+   * @param {string} apiKey
+   * @param {{ default: string[], viewports: { [name]: string[] } }} state
+   */
+  setDskGraphicsState(apiKey, state) {
+    this._dskGraphicsState.set(apiKey, state);
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/lcyt-web/src/components/DskControlPage.jsx
+++ b/packages/lcyt-web/src/components/DskControlPage.jsx
@@ -246,6 +246,13 @@ export function DskControlPage() {
           }
         </div>
 
+        <a
+          href={`/dsk-viewports?server=${encodeURIComponent(serverUrl)}&apikey=${encodeURIComponent(apiKey)}`}
+          style={{ ...btnStyle, textDecoration: 'none', display: 'inline-flex', alignItems: 'center', fontSize: 13 }}
+        >
+          Manage Viewports
+        </a>
+
         {statusMsg && (
           <span style={{ fontSize: 12, color: statusMsg.startsWith('Error') || statusMsg.includes('error') ? '#f88' : '#8d8', maxWidth: 300, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
             {statusMsg}

--- a/packages/lcyt-web/src/components/DskEditorPage.jsx
+++ b/packages/lcyt-web/src/components/DskEditorPage.jsx
@@ -188,7 +188,9 @@ function renderLayerElement(layer, isSelected, isInSelection, onPointerDown) {
   if (layer.type === 'text') {
     return (
       <div key={layer.id} style={merged} onPointerDown={onPointerDown}>
-        {layer.text || ''}
+        {layer.binding
+          ? <span style={{ opacity: 0.55, fontStyle: 'italic' }}>⟳{layer.binding}</span>
+          : (layer.text || '')}
       </div>
     );
   }
@@ -673,6 +675,12 @@ function LayerPropertyEditor({ layer, selectionCount, aspectLock, onAspectLock, 
         <div style={fieldRowStyle}>
           <span style={labelStyle}>Text</span>
           <input type="text" value={layer.text || ''} onChange={e => setField('text', e.target.value)} style={inputStyle} />
+        </div>
+      )}
+      {layer.type === 'text' && (
+        <div style={fieldRowStyle}>
+          <span style={labelStyle} title="When set, text is auto-updated from caption codes (section, stanza, speaker…) via SSE bindings. Leave blank for static text.">Binding</span>
+          <input type="text" value={layer.binding || ''} onChange={e => setField('binding', e.target.value)} style={inputStyle} placeholder="section, stanza, speaker…" />
         </div>
       )}
       {layer.type === 'image' && (
@@ -1391,9 +1399,11 @@ export function DskEditorPage() {
                   <span style={{ fontSize: 11, color: '#666', width: 44, flexShrink: 0 }}>{layer.type}</span>
                   <span style={{ flex: 1, fontSize: 13, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                     {layer.id}
-                    {layer.type === 'text' && layer.text
-                      ? <span style={{ color: '#777', marginLeft: 6 }}>"{layer.text}"</span>
-                      : null}
+                    {layer.type === 'text' && layer.binding
+                      ? <span style={{ color: '#44bb88', marginLeft: 6 }}>⟳{layer.binding}</span>
+                      : layer.type === 'text' && layer.text
+                        ? <span style={{ color: '#777', marginLeft: 6 }}>"{layer.text}"</span>
+                        : null}
                   </span>
                   {gName && (
                     <span style={{ fontSize: 10, color: '#6af', background: '#1a2a3a', borderRadius: 3,

--- a/packages/lcyt-web/src/components/DskPage.jsx
+++ b/packages/lcyt-web/src/components/DskPage.jsx
@@ -50,12 +50,16 @@ export function DskPage() {
   const serverUrl = resolveServer();
 
   // ── State ───────────────────────────────────────────────
-  const [images, setImages]         = useState([]); // [{ id, shorthand, mimeType, url, settingsJson }]
+  const [images, setImages]           = useState([]); // [{ id, shorthand, mimeType, url, settingsJson }]
   const [activeNames, setActiveNames] = useState([]); // string[]
-  const [ccText, setCcText]         = useState('');
-  const [status, setStatus]         = useState('connecting');
+  const [ccText, setCcText]           = useState('');
+  const [status, setStatus]           = useState('connecting');
   // viewport dimensions (null = use 100vw/100vh)
   const [vpDimensions, setVpDimensions] = useState(null); // { width, height } | null
+  // text layers from viewport config: [{ id, binding, x, y, width, height, fontSize, ... }]
+  const [textLayers, setTextLayers]   = useState([]);
+  // live bindings from caption codes: { section: 'Gospel', stanza: '...', ... }
+  const [bindings, setBindings]       = useState({});
 
   // CSS scale to fit viewport dimensions into the window
   const [scale, setScale] = useState(1);
@@ -76,7 +80,7 @@ export function DskPage() {
     } catch { /* non-fatal */ }
   }
 
-  // ── Viewport dimensions ─────────────────────────────────
+  // ── Viewport dimensions + text layers ───────────────────
   async function fetchViewportDimensions() {
     if (!serverUrl || !apiKey || !viewportName) return;
     try {
@@ -84,7 +88,10 @@ export function DskPage() {
       if (!res.ok) return;
       const data = await res.json();
       const vp = (data.viewports || []).find(v => v.name === viewportName);
-      if (vp) setVpDimensions({ width: vp.width, height: vp.height });
+      if (vp) {
+        setVpDimensions({ width: vp.width, height: vp.height });
+        setTextLayers(Array.isArray(vp.textLayers) ? vp.textLayers : []);
+      }
     } catch { /* non-fatal */ }
   }
 
@@ -109,6 +116,16 @@ export function DskPage() {
       try {
         const payload = JSON.parse(e.data);
         setActiveNames(resolveActiveNames(payload, viewportName));
+      } catch {}
+    });
+
+    es.addEventListener('bindings', (e) => {
+      if (!mounted.current) return;
+      try {
+        const { codes } = JSON.parse(e.data);
+        if (codes && typeof codes === 'object') {
+          setBindings(prev => ({ ...prev, ...codes }));
+        }
       } catch {}
     });
 
@@ -209,6 +226,20 @@ export function DskPage() {
         );
       })}
 
+      {/* Text layers bound to caption codes (section, stanza, speaker, etc.) */}
+      {textLayers.map((layer, idx) => {
+        const value = layer.binding ? (bindings[layer.binding] ?? '') : (layer.text ?? '');
+        if (!value) return null;
+        return (
+          <div
+            key={layer.id || idx}
+            style={buildTextLayerStyle(layer, activeNames.length + idx + 1)}
+          >
+            {value}
+          </div>
+        );
+      })}
+
       {/* CC burn-in text (cc=1 mode only) */}
       {ccMode && ccText && (
         <div style={{
@@ -255,15 +286,33 @@ export function DskPage() {
  * Resolve which image names to show for this viewport given the SSE payload.
  *
  * Supports both the new format { default, viewports, ts } and the legacy format { names, ts }.
+ *
+ * Landscape aliases: when no viewportName is set (default landscape display),
+ * check viewports.landscape / .default / .main before falling back to payload.default.
+ * This allows metacodes like <!-- graphics[landscape]:logo --> to target this display.
  */
+const LANDSCAPE_ALIASES_DISPLAY = ['landscape', 'default', 'main'];
+
 function resolveActiveNames(payload, viewportName) {
   // Legacy format: { names: [...] }
   if (Array.isArray(payload.names)) return payload.names;
 
   // New format: { default: [...], viewports: { name: [...] } }
   const { default: defaultNames, viewports } = payload;
-  if (viewportName && viewports && viewports[viewportName] !== undefined) {
-    return viewports[viewportName];
+
+  if (viewportName) {
+    if (viewports && viewports[viewportName] !== undefined) {
+      return viewports[viewportName];
+    }
+    return Array.isArray(defaultNames) ? defaultNames : [];
+  }
+
+  // No viewportName — this is the landscape default display page.
+  // Check landscape alias slots before falling back to defaultNames.
+  if (viewports) {
+    for (const alias of LANDSCAPE_ALIASES_DISPLAY) {
+      if (viewports[alias] !== undefined) return viewports[alias];
+    }
   }
   return Array.isArray(defaultNames) ? defaultNames : [];
 }
@@ -275,6 +324,30 @@ function resolveActiveNames(payload, viewportName) {
 function getViewportSettings(settingsJson, viewportName) {
   if (!viewportName || !settingsJson?.viewports) return {};
   return settingsJson.viewports[viewportName] ?? {};
+}
+
+/**
+ * Build CSS style for a text layer container.
+ */
+function buildTextLayerStyle(layer, zIndex) {
+  return {
+    position:   'absolute',
+    zIndex,
+    pointerEvents: 'none',
+    left:       layer.x      != null ? layer.x      : 0,
+    top:        layer.y      != null ? layer.y      : 0,
+    width:      layer.width  != null ? layer.width  : 'auto',
+    height:     layer.height != null ? layer.height : 'auto',
+    fontSize:   layer.fontSize   != null ? layer.fontSize   : 48,
+    fontWeight: layer.fontWeight != null ? layer.fontWeight : 'bold',
+    color:      layer.color      || '#ffffff',
+    textAlign:  layer.textAlign  || 'left',
+    textShadow: layer.textShadow || 'none',
+    fontFamily: layer.fontFamily || 'sans-serif',
+    whiteSpace: 'pre-wrap',
+    lineHeight: layer.lineHeight || 1.3,
+    overflow:   'hidden',
+  };
 }
 
 /**

--- a/packages/lcyt-web/src/components/DskPage.jsx
+++ b/packages/lcyt-web/src/components/DskPage.jsx
@@ -8,14 +8,25 @@ import { useEffect, useRef, useState } from 'react';
  *   server=<backendUrl>   Backend URL (falls back to localStorage lcyt-config)
  *   cc=1                  Also render caption text (CC burn-in mode)
  *   bg=<hex>              Override background colour (default: #00B140 chroma green)
+ *   viewport=<name>       Named viewport — applies per-viewport image settings and dimensions.
+ *                         If omitted, landscape defaults are used (unchanged behaviour).
  *
  * The page:
- * 1. Fetches GET <server>/dsk/<apikey>/images — pre-loads all images into hidden <img> elements
- * 2. Opens SSE on GET <server>/dsk/<apikey>/events
- * 3. On 'graphics' event: makes the named images visible (zero-latency — already in browser memory)
- * 4. On 'text' event (cc=1): renders the stripped caption text
- * 5. On 'reload' event: re-fetches the image list to pick up newly uploaded images
- * 6. Reconnects SSE with exponential backoff on disconnect
+ * 1. Fetches GET <server>/dsk/<apikey>/images — pre-loads images and their settingsJson
+ * 2. If viewport param is set, fetches GET <server>/dsk/<apikey>/viewports/public for dimensions
+ * 3. Opens SSE on GET <server>/dsk/<apikey>/events
+ * 4. On 'graphics' event: selects active names for this viewport (viewport-specific or default)
+ * 5. On 'text' event (cc=1): renders the stripped caption text
+ * 6. On 'reload' event: re-fetches the image list
+ * 7. Reconnects SSE with exponential backoff on disconnect
+ *
+ * Per-viewport image settings (from image.settingsJson.viewports[viewportName]):
+ *   visible:   boolean — hide this image on this viewport even when active (default: true)
+ *   x:         number  — absolute left position in px (default: 0, full-width)
+ *   y:         number  — absolute top position in px (default: 0)
+ *   width:     number  — width in px (default: 100% of container)
+ *   height:    number  — height in px (default: auto)
+ *   animation: string  — CSS animation shorthand, e.g. "lcyt-fadeIn 0.5s" (default: none)
  */
 export function DskPage() {
   // ── URL params ──────────────────────────────────────────
@@ -24,8 +35,9 @@ export function DskPage() {
   const apiKey = pathParts[2] || '';
 
   const params = new URLSearchParams(window.location.search);
-  const ccMode  = params.get('cc') === '1';
-  const bgColor = params.get('bg') || '#00B140';
+  const ccMode      = params.get('cc') === '1';
+  const bgColor     = params.get('bg') || '#00B140';
+  const viewportName = params.get('viewport') || null;
 
   function resolveServer() {
     const fromUrl = params.get('server');
@@ -38,12 +50,15 @@ export function DskPage() {
   const serverUrl = resolveServer();
 
   // ── State ───────────────────────────────────────────────
-  const [images, setImages]         = useState([]); // [{ id, shorthand, mimeType, url }]
-  // Ordered array from the last <!-- graphics:... --> metacode.
-  // Index 0 = bottom-most layer, index N-1 = top-most layer (matches server-side overlay order).
+  const [images, setImages]         = useState([]); // [{ id, shorthand, mimeType, url, settingsJson }]
   const [activeNames, setActiveNames] = useState([]); // string[]
   const [ccText, setCcText]         = useState('');
-  const [status, setStatus]         = useState('connecting'); // 'connecting' | 'connected' | 'error'
+  const [status, setStatus]         = useState('connecting');
+  // viewport dimensions (null = use 100vw/100vh)
+  const [vpDimensions, setVpDimensions] = useState(null); // { width, height } | null
+
+  // CSS scale to fit viewport dimensions into the window
+  const [scale, setScale] = useState(1);
 
   const esRef       = useRef(null);
   const retryDelay  = useRef(1000);
@@ -58,6 +73,18 @@ export function DskPage() {
       if (!res.ok) return;
       const data = await res.json();
       setImages(data.images || []);
+    } catch { /* non-fatal */ }
+  }
+
+  // ── Viewport dimensions ─────────────────────────────────
+  async function fetchViewportDimensions() {
+    if (!serverUrl || !apiKey || !viewportName) return;
+    try {
+      const res = await fetch(`${serverUrl}/dsk/${encodeURIComponent(apiKey)}/viewports/public`);
+      if (!res.ok) return;
+      const data = await res.json();
+      const vp = (data.viewports || []).find(v => v.name === viewportName);
+      if (vp) setVpDimensions({ width: vp.width, height: vp.height });
     } catch { /* non-fatal */ }
   }
 
@@ -80,9 +107,8 @@ export function DskPage() {
     es.addEventListener('graphics', (e) => {
       if (!mounted.current) return;
       try {
-        const { names } = JSON.parse(e.data);
-        // Preserve metacode order: index 0 = bottom layer, last = top layer
-        setActiveNames(Array.isArray(names) ? names : []);
+        const payload = JSON.parse(e.data);
+        setActiveNames(resolveActiveNames(payload, viewportName));
       } catch {}
     });
 
@@ -110,9 +136,23 @@ export function DskPage() {
     };
   }
 
+  // Recalculate scale whenever vpDimensions or window size changes
+  useEffect(() => {
+    if (!vpDimensions) return;
+    function updateScale() {
+      const sx = window.innerWidth  / vpDimensions.width;
+      const sy = window.innerHeight / vpDimensions.height;
+      setScale(Math.min(sx, sy));
+    }
+    updateScale();
+    window.addEventListener('resize', updateScale);
+    return () => window.removeEventListener('resize', updateScale);
+  }, [vpDimensions]);
+
   useEffect(() => {
     mounted.current = true;
     fetchImages();
+    fetchViewportDimensions();
     connect();
     return () => {
       mounted.current = false;
@@ -120,6 +160,11 @@ export function DskPage() {
       if (retryTimer.current) clearTimeout(retryTimer.current);
     };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ── Container sizing ────────────────────────────────────
+  // When a viewport with specific dimensions is set, scale the fixed-size container to fit
+  // the window (same approach as DskEditorPage canvas scaling).
+  const containerStyle = buildContainerStyle(vpDimensions, scale, bgColor);
 
   // ── Render ──────────────────────────────────────────────
   if (!serverUrl || !apiKey) {
@@ -131,7 +176,7 @@ export function DskPage() {
   }
 
   return (
-    <div style={{ position: 'relative', width: '100vw', height: '100vh', background: bgColor, overflow: 'hidden' }}>
+    <div style={containerStyle}>
       {/* All images pre-loaded (hidden) for zero-latency visibility toggle */}
       {images.map(img => (
         <img
@@ -143,25 +188,22 @@ export function DskPage() {
         />
       ))}
 
-      {/* Active images rendered in metacode order: first name = lowest z-index (bottom layer), last = highest (top layer) */}
+      {/* Active images rendered in metacode order: first name = lowest z-index (bottom layer), last = highest */}
       {activeNames.map((name, layerIdx) => {
         const img = images.find(i => i.shorthand === name);
         if (!img) return null;
+
+        // Per-viewport settings
+        const vpSettings = getViewportSettings(img.settingsJson, viewportName);
+        if (vpSettings.visible === false) return null;
+
         return (
           <img
             key={`active-${img.id}`}
             src={`${serverUrl}/images/${img.id}`}
             alt=""
             aria-hidden="true"
-            style={{
-              position: 'absolute',
-              top: 0,
-              left: 0,
-              width: '100%',
-              height: 'auto',
-              zIndex: layerIdx + 1,
-              pointerEvents: 'none',
-            }}
+            style={buildImageStyle(layerIdx, vpSettings, vpDimensions)}
             crossOrigin="anonymous"
           />
         );
@@ -187,7 +229,7 @@ export function DskPage() {
         </div>
       )}
 
-      {/* Status indicator — only visible when not connected and not on green bg */}
+      {/* Status indicator — only visible when not connected */}
       {status !== 'connected' && (
         <div style={{
           position: 'absolute',
@@ -205,4 +247,82 @@ export function DskPage() {
       )}
     </div>
   );
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Resolve which image names to show for this viewport given the SSE payload.
+ *
+ * Supports both the new format { default, viewports, ts } and the legacy format { names, ts }.
+ */
+function resolveActiveNames(payload, viewportName) {
+  // Legacy format: { names: [...] }
+  if (Array.isArray(payload.names)) return payload.names;
+
+  // New format: { default: [...], viewports: { name: [...] } }
+  const { default: defaultNames, viewports } = payload;
+  if (viewportName && viewports && viewports[viewportName] !== undefined) {
+    return viewports[viewportName];
+  }
+  return Array.isArray(defaultNames) ? defaultNames : [];
+}
+
+/**
+ * Get per-viewport settings for an image.
+ * Falls back to empty object (use all defaults) when no settings are defined.
+ */
+function getViewportSettings(settingsJson, viewportName) {
+  if (!viewportName || !settingsJson?.viewports) return {};
+  return settingsJson.viewports[viewportName] ?? {};
+}
+
+/**
+ * Build CSS style for the outer container.
+ * When vpDimensions is set: fixed pixel size + CSS scale to fit window (preserves aspect ratio).
+ * Otherwise: 100vw × 100vh (original behaviour for the landscape default).
+ */
+function buildContainerStyle(vpDimensions, scale, bgColor) {
+  if (!vpDimensions) {
+    return { position: 'relative', width: '100vw', height: '100vh', background: bgColor, overflow: 'hidden' };
+  }
+  const { width, height } = vpDimensions;
+  return {
+    position:        'relative',
+    width:           width,
+    height:          height,
+    background:      bgColor,
+    overflow:        'hidden',
+    transformOrigin: 'top left',
+    transform:       `scale(${scale})`,
+  };
+}
+
+/**
+ * Build CSS style for an active image element.
+ * Uses absolute positioning when viewport-specific x/y/width/height are set,
+ * otherwise falls back to full-width behaviour.
+ */
+function buildImageStyle(layerIdx, vpSettings, vpDimensions) {
+  const hasPosition = vpSettings.x != null || vpSettings.y != null;
+  const base = {
+    position:      'absolute',
+    zIndex:        layerIdx + 1,
+    pointerEvents: 'none',
+  };
+
+  if (vpSettings.animation) base.animation = vpSettings.animation;
+
+  if (hasPosition || vpSettings.width != null || vpSettings.height != null) {
+    return {
+      ...base,
+      left:   vpSettings.x      != null ? vpSettings.x      : 0,
+      top:    vpSettings.y      != null ? vpSettings.y      : 0,
+      width:  vpSettings.width  != null ? vpSettings.width  : (vpDimensions ? vpDimensions.width : '100%'),
+      height: vpSettings.height != null ? vpSettings.height : 'auto',
+    };
+  }
+
+  // Default: full-width (original landscape behaviour)
+  return { ...base, top: 0, left: 0, width: '100%', height: 'auto' };
 }

--- a/packages/lcyt-web/src/components/DskViewportsPage.jsx
+++ b/packages/lcyt-web/src/components/DskViewportsPage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useId } from 'react';
 
 /**
  * DSK Viewports Management Page
@@ -121,7 +121,7 @@ export function DskViewportsPage() {
 
   // ── Selected viewport data ───────────────────────────────────────────────
 
-  const LANDSCAPE = { name: 'landscape', label: 'Landscape (default)', viewportType: 'landscape', width: 1920, height: 1080, _builtin: true };
+  const LANDSCAPE = { name: 'landscape', label: 'Landscape (default)', viewportType: 'landscape', width: 1920, height: 1080, textLayers: [], _builtin: true };
 
   const allViewports = [LANDSCAPE, ...viewports];
   const selectedVp   = selected ? (allViewports.find(v => v.name === selected) ?? null) : null;
@@ -183,6 +183,44 @@ export function DskViewportsPage() {
       setSelected('landscape');
       await loadViewports();
       flash('Deleted');
+    } catch { flash('Network error'); }
+  }
+
+  // ── Text layers ──────────────────────────────────────────────────────────
+
+  // Local draft of text layers for the selected viewport
+  const [draftLayers, setDraftLayers] = useState([]);
+
+  useEffect(() => {
+    setDraftLayers(selectedVp?.textLayers ?? []);
+  }, [selected]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  function newLayer() {
+    return {
+      id:         `tl-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+      binding:    '',
+      x:          0,
+      y:          0,
+      width:      400,
+      height:     120,
+      fontSize:   48,
+      fontWeight: 'bold',
+      color:      '#ffffff',
+      textAlign:  'center',
+      textShadow: '0 2px 8px rgba(0,0,0,0.8)',
+    };
+  }
+
+  async function saveTextLayers(layers) {
+    if (!selectedVp || selectedVp._builtin) return;
+    try {
+      const res = await apiFetch(`/dsk/${encodeURIComponent(apiKey)}/viewports/${encodeURIComponent(selectedVp.name)}`, {
+        method: 'PUT',
+        body:   JSON.stringify({ textLayers: layers }),
+      });
+      if (!res.ok) { flash('Save failed'); return; }
+      await loadViewports();
+      flash('Text layers saved');
     } catch { flash('Network error'); }
   }
 
@@ -427,11 +465,17 @@ export function DskViewportsPage() {
               </Section>
 
               {/* Per-image settings */}
-              <Section title="Image Settings for this Viewport">
+              <Section title="Image Settings for this Viewport" style={{ marginBottom: 24 }}>
                 <div style={{ fontSize: 12, color: dark.muted, marginBottom: 12 }}>
                   Control visibility and position of each uploaded image on <strong>{selectedVp.label || selectedVp.name}</strong>.
                   Blank position fields = full-width default. Animation: CSS shorthand e.g. <code>lcyt-fadeIn 0.5s</code>.
                 </div>
+                {selectedVp._builtin && (
+                  <div style={{ fontSize: 12, color: dark.muted, marginBottom: 12 }}>
+                    Metacode aliases for this viewport: <code>landscape</code>, <code>default</code>, <code>main</code>.
+                    Use e.g. <code>{'<!-- graphics[landscape]:logo -->'}</code> to target only this display.
+                  </div>
+                )}
                 {images.length === 0 && (
                   <div style={{ color: dark.muted, fontSize: 13 }}>No images uploaded yet.</div>
                 )}
@@ -445,6 +489,37 @@ export function DskViewportsPage() {
                   />
                 )}
               </Section>
+
+              {/* Text layers — only for user-defined viewports */}
+              {!selectedVp._builtin && (
+                <Section title="Text Layers">
+                  <div style={{ fontSize: 12, color: dark.muted, marginBottom: 12 }}>
+                    Text layers display live values from caption <code>codes</code> (section, stanza, speaker, etc.)
+                    at fixed positions on this viewport. Use e.g. <code>section:Gospel</code> in a metacode
+                    and a text layer bound to <code>section</code> will show <em>Gospel</em>.
+                  </div>
+                  <TextLayersEditor
+                    layers={draftLayers}
+                    onChange={setDraftLayers}
+                    vpWidth={selectedVp.width}
+                    vpHeight={selectedVp.height}
+                  />
+                  <div style={{ marginTop: 12, display: 'flex', gap: 8 }}>
+                    <button
+                      style={btnPrimary}
+                      onClick={() => saveTextLayers(draftLayers)}
+                    >
+                      Save Text Layers
+                    </button>
+                    <button
+                      style={btnBase}
+                      onClick={() => setDraftLayers(d => [...d, newLayer()])}
+                    >
+                      + Add Layer
+                    </button>
+                  </div>
+                </Section>
+              )}
             </div>
           )}
         </div>
@@ -514,6 +589,167 @@ function ImageSettingsTable({ images, viewportName, getImgVpSettings, saveImgVpS
           />
         );
       })}
+    </div>
+  );
+}
+
+const COMMON_BINDINGS = ['section', 'stanza', 'speaker', 'song', 'lyrics'];
+
+function TextLayersEditor({ layers, onChange, vpWidth, vpHeight }) {
+  function updateLayer(idx, patch) {
+    onChange(ls => ls.map((l, i) => i === idx ? { ...l, ...patch } : l));
+  }
+  function removeLayer(idx) {
+    onChange(ls => ls.filter((_, i) => i !== idx));
+  }
+
+  if (layers.length === 0) {
+    return <div style={{ color: dark.muted, fontSize: 13 }}>No text layers. Click "+ Add Layer" to add one.</div>;
+  }
+
+  return (
+    <div>
+      {layers.map((layer, idx) => (
+        <div key={layer.id || idx} style={{ background: '#1a1a1a', border: `1px solid ${dark.border}`, borderRadius: 6, padding: 14, marginBottom: 10 }}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 }}>
+            <span style={{ fontSize: 13, fontWeight: 'bold', color: dark.text }}>
+              Layer {idx + 1}{layer.binding ? ` — bound to "${layer.binding}"` : ' — static text'}
+            </span>
+            <button style={{ ...btnDanger, padding: '3px 8px', fontSize: 11 }} onClick={() => removeLayer(idx)}>Remove</button>
+          </div>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10 }}>
+            {/* Binding */}
+            <div style={{ flex: '1 1 200px' }}>
+              <label style={labelStyle}>Binding (code key)</label>
+              <div style={{ display: 'flex', gap: 6 }}>
+                <input
+                  list={`bindings-list-${idx}`}
+                  style={{ ...inputStyle, flex: 1 }}
+                  placeholder="section, stanza, speaker…"
+                  value={layer.binding || ''}
+                  onChange={e => updateLayer(idx, { binding: e.target.value })}
+                />
+                <datalist id={`bindings-list-${idx}`}>
+                  {COMMON_BINDINGS.map(b => <option key={b} value={b} />)}
+                </datalist>
+              </div>
+            </div>
+            {/* Static text (fallback / non-bound) */}
+            <div style={{ flex: '1 1 200px' }}>
+              <label style={labelStyle}>Static text (shown when no binding value)</label>
+              <input
+                style={{ ...inputStyle, width: '100%' }}
+                placeholder="optional fallback"
+                value={layer.text || ''}
+                onChange={e => updateLayer(idx, { text: e.target.value })}
+              />
+            </div>
+          </div>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10, marginTop: 10 }}>
+            {[['x', 'X (px)'], ['y', 'Y (px)'], ['width', 'Width (px)'], ['height', 'Height (px)']].map(([key, lbl]) => (
+              <div key={key} style={{ flex: '0 0 100px' }}>
+                <label style={labelStyle}>{lbl}</label>
+                <input
+                  style={{ ...inputStyle, width: '100%' }}
+                  type="number"
+                  value={layer[key] ?? ''}
+                  onChange={e => updateLayer(idx, { [key]: parseInt(e.target.value, 10) || 0 })}
+                />
+              </div>
+            ))}
+            <div style={{ flex: '0 0 80px' }}>
+              <label style={labelStyle}>Font size</label>
+              <input
+                style={{ ...inputStyle, width: '100%' }}
+                type="number"
+                value={layer.fontSize ?? 48}
+                onChange={e => updateLayer(idx, { fontSize: parseInt(e.target.value, 10) || 48 })}
+              />
+            </div>
+            <div style={{ flex: '0 0 80px' }}>
+              <label style={labelStyle}>Font weight</label>
+              <select
+                style={{ ...inputStyle, width: '100%' }}
+                value={layer.fontWeight ?? 'bold'}
+                onChange={e => updateLayer(idx, { fontWeight: e.target.value })}
+              >
+                <option value="normal">Normal</option>
+                <option value="bold">Bold</option>
+                <option value="600">600</option>
+              </select>
+            </div>
+            <div style={{ flex: '0 0 80px' }}>
+              <label style={labelStyle}>Color</label>
+              <input
+                style={{ ...inputStyle, width: '100%', padding: '4px 6px' }}
+                type="color"
+                value={layer.color || '#ffffff'}
+                onChange={e => updateLayer(idx, { color: e.target.value })}
+              />
+            </div>
+            <div style={{ flex: '0 0 100px' }}>
+              <label style={labelStyle}>Align</label>
+              <select
+                style={{ ...inputStyle, width: '100%' }}
+                value={layer.textAlign ?? 'center'}
+                onChange={e => updateLayer(idx, { textAlign: e.target.value })}
+              >
+                <option value="left">Left</option>
+                <option value="center">Center</option>
+                <option value="right">Right</option>
+              </select>
+            </div>
+            <div style={{ flex: '1 1 180px' }}>
+              <label style={labelStyle}>Text shadow (CSS)</label>
+              <input
+                style={{ ...inputStyle, width: '100%' }}
+                placeholder="0 2px 8px rgba(0,0,0,0.8)"
+                value={layer.textShadow || ''}
+                onChange={e => updateLayer(idx, { textShadow: e.target.value })}
+              />
+            </div>
+          </div>
+          {/* Mini preview */}
+          {(vpWidth && vpHeight) && (
+            <div style={{ marginTop: 12 }}>
+              <TextLayerMiniPreview layer={layer} vpWidth={vpWidth} vpHeight={vpHeight} />
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function TextLayerMiniPreview({ layer, vpWidth, vpHeight }) {
+  const PREVIEW_W = 280;
+  const scale = PREVIEW_W / vpWidth;
+  const previewH = vpHeight * scale;
+  return (
+    <div style={{ position: 'relative', width: PREVIEW_W, height: previewH, background: '#181818', border: `1px solid ${dark.border}`, borderRadius: 4, overflow: 'hidden' }}>
+      {/* Grid lines */}
+      <div style={{ position: 'absolute', inset: 0, backgroundImage: 'linear-gradient(rgba(255,255,255,0.04) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,0.04) 1px, transparent 1px)', backgroundSize: `${PREVIEW_W/8}px ${previewH/8}px` }} />
+      {/* Text layer preview box */}
+      <div style={{
+        position: 'absolute',
+        left:       (layer.x || 0) * scale,
+        top:        (layer.y || 0) * scale,
+        width:      (layer.width || 400) * scale,
+        height:     (layer.height || 80) * scale,
+        border:     '1px dashed rgba(68,255,136,0.6)',
+        background: 'rgba(68,255,136,0.05)',
+        display:    'flex',
+        alignItems: 'center',
+        justifyContent: layer.textAlign === 'right' ? 'flex-end' : layer.textAlign === 'center' ? 'center' : 'flex-start',
+        fontSize:   Math.max(8, (layer.fontSize || 48) * scale),
+        fontWeight: layer.fontWeight || 'bold',
+        color:      layer.color || '#ffffff',
+        padding:    '0 4px',
+        overflow:   'hidden',
+        whiteSpace: 'nowrap',
+      }}>
+        {layer.binding || layer.text || <span style={{ opacity: 0.4, fontStyle: 'italic' }}>binding</span>}
+      </div>
     </div>
   );
 }

--- a/packages/lcyt-web/src/components/DskViewportsPage.jsx
+++ b/packages/lcyt-web/src/components/DskViewportsPage.jsx
@@ -1,0 +1,632 @@
+import { useEffect, useState, useCallback } from 'react';
+
+/**
+ * DSK Viewports Management Page
+ *
+ * URL: /dsk-viewports?server=<backendUrl>&apikey=<key>
+ *
+ * Manage named viewport targets for DSK graphics:
+ *   - Built-in "Landscape (default)" (1920×1080, not deletable — existing /dsk/:key behaviour)
+ *   - User-defined viewports: vertical screens, viewer, etc.
+ *
+ * For each viewport:
+ *   - Edit label, type, dimensions
+ *   - Get the display URL (open in OBS / HDMI output browser)
+ *   - "Present to screen" — open display URL on a specific connected monitor (Window Placement API)
+ *   - Per-image settings: visible toggle, x/y/width/height position override, animation
+ *
+ * Auth: X-API-Key header (same as DskControlPage — no live session required).
+ */
+
+// ── Shared styles ─────────────────────────────────────────────────────────────
+
+const dark = {
+  bg:       '#121212',
+  panel:    '#1a1a1a',
+  card:     '#222',
+  cardHover:'#2a2a2a',
+  border:   '#333',
+  text:     '#ddd',
+  muted:    '#888',
+  accent:   '#44ff88',
+  accentDim:'#2d8a52',
+  danger:   '#ff6666',
+};
+
+const btnBase = {
+  background: dark.card,
+  border: `1px solid ${dark.border}`,
+  color: dark.text,
+  borderRadius: 6,
+  padding: '7px 14px',
+  fontSize: 13,
+  cursor: 'pointer',
+  whiteSpace: 'nowrap',
+};
+const btnPrimary  = { ...btnBase, background: '#1a4a2e', border: `1px solid ${dark.accentDim}`, color: '#cfffdc' };
+const btnDanger   = { ...btnBase, background: '#3a0000', border: '1px solid #882222', color: '#ffaaaa' };
+const btnSmall    = { ...btnBase, padding: '4px 10px', fontSize: 12 };
+
+const inputStyle = {
+  background: '#1a1a1a',
+  border: `1px solid ${dark.border}`,
+  color: '#eee',
+  borderRadius: 4,
+  padding: '6px 10px',
+  fontSize: 13,
+  boxSizing: 'border-box',
+};
+
+const labelStyle = { display: 'block', marginBottom: 4, color: dark.muted, fontSize: 12 };
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export function DskViewportsPage() {
+  const params    = new URLSearchParams(window.location.search);
+  const serverUrl = (params.get('server') || '').replace(/\/$/, '');
+  const apiKey    = params.get('apikey') || '';
+
+  const [viewports, setViewports]       = useState([]);     // user-defined
+  const [selected, setSelected]         = useState(null);   // viewport name or 'landscape'
+  const [images, setImages]             = useState([]);     // all images for this key
+  const [msg, setMsg]                   = useState('');
+  const [screens, setScreens]           = useState(null);   // ScreenDetailed[] | null
+  const [screenApiSupported, setScreenApiSupported] = useState(null); // null=unknown
+
+  // ── API helpers ──────────────────────────────────────────────────────────
+
+  const apiFetch = useCallback((path, opts = {}) =>
+    fetch(`${serverUrl}${path}`, {
+      ...opts,
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-Key': apiKey,
+        ...(opts.headers || {}),
+      },
+    }),
+  [serverUrl, apiKey]);
+
+  function flash(text) {
+    setMsg(text);
+    setTimeout(() => setMsg(''), 3000);
+  }
+
+  // ── Load data ────────────────────────────────────────────────────────────
+
+  const loadViewports = useCallback(async () => {
+    if (!serverUrl || !apiKey) return;
+    try {
+      const res = await apiFetch(`/dsk/${encodeURIComponent(apiKey)}/viewports`);
+      if (!res.ok) return;
+      const data = await res.json();
+      setViewports(data.viewports || []);
+    } catch {}
+  }, [apiKey, serverUrl, apiFetch]);
+
+  const loadImages = useCallback(async () => {
+    if (!serverUrl || !apiKey) return;
+    try {
+      const res = await apiFetch('/images');
+      if (!res.ok) return;
+      const data = await res.json();
+      setImages(data.images || []);
+    } catch {}
+  }, [apiKey, serverUrl, apiFetch]);
+
+  useEffect(() => {
+    loadViewports();
+    loadImages();
+    setScreenApiSupported('getScreenDetails' in window);
+  }, [loadViewports, loadImages]);
+
+  // ── Selected viewport data ───────────────────────────────────────────────
+
+  const LANDSCAPE = { name: 'landscape', label: 'Landscape (default)', viewportType: 'landscape', width: 1920, height: 1080, _builtin: true };
+
+  const allViewports = [LANDSCAPE, ...viewports];
+  const selectedVp   = selected ? (allViewports.find(v => v.name === selected) ?? null) : null;
+
+  // ── Viewport creation ────────────────────────────────────────────────────
+
+  const [creating, setCreating] = useState(false);
+  const [newVp, setNewVp]       = useState({ name: '', label: '', viewportType: 'vertical', width: 1080, height: 1920 });
+
+  async function handleCreate(e) {
+    e.preventDefault();
+    try {
+      const res = await apiFetch(`/dsk/${encodeURIComponent(apiKey)}/viewports`, {
+        method: 'POST',
+        body:   JSON.stringify(newVp),
+      });
+      const data = await res.json();
+      if (!res.ok) { flash(data.error || 'Create failed'); return; }
+      await loadViewports();
+      setSelected(newVp.name);
+      setCreating(false);
+      setNewVp({ name: '', label: '', viewportType: 'vertical', width: 1080, height: 1920 });
+      flash('Viewport created');
+    } catch { flash('Network error'); }
+  }
+
+  // ── Viewport edit ────────────────────────────────────────────────────────
+
+  const [editVp, setEditVp] = useState(null); // draft for editing
+
+  useEffect(() => {
+    if (selectedVp && !selectedVp._builtin) {
+      setEditVp({ label: selectedVp.label ?? '', viewportType: selectedVp.viewportType, width: selectedVp.width, height: selectedVp.height });
+    } else {
+      setEditVp(null);
+    }
+  }, [selected]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  async function handleSaveVp() {
+    if (!selectedVp || selectedVp._builtin || !editVp) return;
+    try {
+      const res = await apiFetch(`/dsk/${encodeURIComponent(apiKey)}/viewports/${encodeURIComponent(selectedVp.name)}`, {
+        method: 'PUT',
+        body:   JSON.stringify(editVp),
+      });
+      const data = await res.json();
+      if (!res.ok) { flash(data.error || 'Save failed'); return; }
+      await loadViewports();
+      flash('Saved');
+    } catch { flash('Network error'); }
+  }
+
+  async function handleDeleteVp() {
+    if (!selectedVp || selectedVp._builtin) return;
+    if (!confirm(`Delete viewport "${selectedVp.name}"?`)) return;
+    try {
+      const res = await apiFetch(`/dsk/${encodeURIComponent(apiKey)}/viewports/${encodeURIComponent(selectedVp.name)}`, { method: 'DELETE' });
+      if (!res.ok) { flash('Delete failed'); return; }
+      setSelected('landscape');
+      await loadViewports();
+      flash('Deleted');
+    } catch { flash('Network error'); }
+  }
+
+  // ── Present to screen ────────────────────────────────────────────────────
+
+  async function handleRequestScreens() {
+    try {
+      const details = await window.getScreenDetails();
+      setScreens(details.screens);
+    } catch (err) {
+      flash(err.message || 'Screen access denied');
+    }
+  }
+
+  function getDisplayUrl(vp) {
+    const base = `${serverUrl}/dsk/${encodeURIComponent(apiKey)}`;
+    if (!vp || vp._builtin) return base;
+    const u = new URL(base, window.location.href);
+    u.searchParams.set('viewport', vp.name);
+    return u.toString();
+  }
+
+  function openOnScreen(screen, url) {
+    const popup = window.open(
+      url, '_blank',
+      `left=${screen.left},top=${screen.top},width=${screen.width},height=${screen.height}`
+    );
+    popup?.addEventListener('load', () => {
+      try { popup.document.documentElement.requestFullscreen(); } catch {}
+    });
+  }
+
+  // ── Image viewport settings ──────────────────────────────────────────────
+
+  function getImgVpSettings(img, vpName) {
+    if (!vpName || vpName === 'landscape') return img.settingsJson?.viewports?.landscape ?? {};
+    return img.settingsJson?.viewports?.[vpName] ?? {};
+  }
+
+  async function saveImgVpSettings(img, vpName, patch) {
+    const key = vpName === 'landscape' ? 'landscape' : vpName;
+    const existing = img.settingsJson ?? {};
+    const merged = {
+      ...existing,
+      viewports: {
+        ...(existing.viewports ?? {}),
+        [key]: { ...(getImgVpSettings(img, vpName)), ...patch },
+      },
+    };
+    try {
+      const res = await apiFetch(`/images/${img.id}`, {
+        method: 'PUT',
+        body:   JSON.stringify({ settingsJson: merged }),
+      });
+      if (!res.ok) { flash('Save failed'); return; }
+      // Update local state
+      setImages(imgs => imgs.map(i => i.id === img.id ? { ...i, settingsJson: merged } : i));
+    } catch { flash('Network error'); }
+  }
+
+  // ── Render ───────────────────────────────────────────────────────────────
+
+  if (!serverUrl || !apiKey) {
+    return (
+      <div style={{ background: dark.bg, minHeight: '100vh', color: dark.text, fontFamily: 'sans-serif', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24 }}>
+        <div>Missing <code>?server=</code> and <code>?apikey=</code> parameters.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ background: dark.bg, minHeight: '100vh', color: dark.text, fontFamily: 'sans-serif', display: 'flex', flexDirection: 'column' }}>
+      {/* Header */}
+      <div style={{ background: dark.panel, borderBottom: `1px solid ${dark.border}`, padding: '12px 20px', display: 'flex', alignItems: 'center', gap: 16 }}>
+        <span style={{ fontSize: 16, fontWeight: 'bold' }}>DSK Viewports</span>
+        <span style={{ color: dark.muted, fontSize: 13 }}>{serverUrl}</span>
+        {msg && <span style={{ marginLeft: 'auto', color: dark.accent, fontSize: 13 }}>{msg}</span>}
+      </div>
+
+      {/* Body */}
+      <div style={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
+
+        {/* Left panel — viewport list */}
+        <div style={{ width: 240, background: dark.panel, borderRight: `1px solid ${dark.border}`, overflowY: 'auto', padding: 12, flexShrink: 0 }}>
+          <div style={{ fontSize: 12, color: dark.muted, marginBottom: 8, textTransform: 'uppercase', letterSpacing: '0.05em' }}>Viewports</div>
+
+          {allViewports.map(vp => (
+            <div
+              key={vp.name}
+              onClick={() => { setSelected(vp.name); setCreating(false); }}
+              style={{
+                background:    selected === vp.name ? dark.cardHover : 'transparent',
+                border:        `1px solid ${selected === vp.name ? dark.accentDim : 'transparent'}`,
+                borderRadius:  6,
+                padding:       '8px 10px',
+                marginBottom:  4,
+                cursor:        'pointer',
+              }}
+            >
+              <div style={{ fontSize: 13, fontWeight: selected === vp.name ? 'bold' : 'normal' }}>
+                {vp.label || vp.name}
+              </div>
+              <div style={{ fontSize: 11, color: dark.muted, marginTop: 2 }}>
+                {vp._builtin ? 'built-in · ' : ''}{vp.width}×{vp.height} · {vp.viewportType}
+              </div>
+            </div>
+          ))}
+
+          <div style={{ marginTop: 12 }}>
+            {!creating
+              ? <button style={btnSmall} onClick={() => { setCreating(true); setSelected(null); }}>+ New Viewport</button>
+              : (
+                <form onSubmit={handleCreate} style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                  <div style={{ fontSize: 12, fontWeight: 'bold', color: dark.text }}>New Viewport</div>
+                  <div>
+                    <label style={labelStyle}>Name (slug)</label>
+                    <input
+                      style={{ ...inputStyle, width: '100%' }}
+                      placeholder="vertical-left"
+                      value={newVp.name}
+                      onChange={e => setNewVp(v => ({ ...v, name: e.target.value.toLowerCase().replace(/[^a-z0-9_-]/g, '-') }))}
+                      required
+                    />
+                  </div>
+                  <div>
+                    <label style={labelStyle}>Label</label>
+                    <input style={{ ...inputStyle, width: '100%' }} placeholder="Vertical Screen 1" value={newVp.label} onChange={e => setNewVp(v => ({ ...v, label: e.target.value }))} />
+                  </div>
+                  <div>
+                    <label style={labelStyle}>Type</label>
+                    <select style={{ ...inputStyle, width: '100%' }} value={newVp.viewportType} onChange={e => {
+                      const vt = e.target.value;
+                      setNewVp(v => ({ ...v, viewportType: vt, width: vt === 'vertical' ? 1080 : 1920, height: vt === 'vertical' ? 1920 : 1080 }));
+                    }}>
+                      <option value="landscape">Landscape</option>
+                      <option value="vertical">Vertical</option>
+                    </select>
+                  </div>
+                  <div style={{ display: 'flex', gap: 6 }}>
+                    <div style={{ flex: 1 }}>
+                      <label style={labelStyle}>Width</label>
+                      <input style={{ ...inputStyle, width: '100%' }} type="number" value={newVp.width} onChange={e => setNewVp(v => ({ ...v, width: parseInt(e.target.value, 10) || v.width }))} />
+                    </div>
+                    <div style={{ flex: 1 }}>
+                      <label style={labelStyle}>Height</label>
+                      <input style={{ ...inputStyle, width: '100%' }} type="number" value={newVp.height} onChange={e => setNewVp(v => ({ ...v, height: parseInt(e.target.value, 10) || v.height }))} />
+                    </div>
+                  </div>
+                  <div style={{ display: 'flex', gap: 6 }}>
+                    <button type="submit" style={btnPrimary}>Create</button>
+                    <button type="button" style={btnBase} onClick={() => setCreating(false)}>Cancel</button>
+                  </div>
+                </form>
+              )
+            }
+          </div>
+        </div>
+
+        {/* Right panel — viewport details */}
+        <div style={{ flex: 1, overflowY: 'auto', padding: 24 }}>
+          {!selectedVp && !creating && (
+            <div style={{ color: dark.muted }}>Select a viewport on the left to configure it.</div>
+          )}
+
+          {selectedVp && (
+            <div style={{ maxWidth: 820 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 20 }}>
+                <h2 style={{ margin: 0, fontSize: 18 }}>{selectedVp.label || selectedVp.name}</h2>
+                {selectedVp._builtin && <span style={{ fontSize: 11, background: '#333', color: dark.muted, borderRadius: 4, padding: '2px 7px' }}>built-in</span>}
+              </div>
+
+              {/* Edit form — only for user-defined viewports */}
+              {!selectedVp._builtin && editVp && (
+                <Section title="Settings" style={{ marginBottom: 24 }}>
+                  <div style={{ display: 'flex', flexWrap: 'wrap', gap: 16, marginBottom: 12 }}>
+                    <div style={{ flex: '1 1 180px' }}>
+                      <label style={labelStyle}>Label</label>
+                      <input style={{ ...inputStyle, width: '100%' }} value={editVp.label} onChange={e => setEditVp(v => ({ ...v, label: e.target.value }))} />
+                    </div>
+                    <div style={{ flex: '0 0 140px' }}>
+                      <label style={labelStyle}>Type</label>
+                      <select style={{ ...inputStyle, width: '100%' }} value={editVp.viewportType} onChange={e => setEditVp(v => ({ ...v, viewportType: e.target.value }))}>
+                        <option value="landscape">Landscape</option>
+                        <option value="vertical">Vertical</option>
+                      </select>
+                    </div>
+                    <div style={{ flex: '0 0 100px' }}>
+                      <label style={labelStyle}>Width</label>
+                      <input style={{ ...inputStyle, width: '100%' }} type="number" value={editVp.width} onChange={e => setEditVp(v => ({ ...v, width: parseInt(e.target.value, 10) || v.width }))} />
+                    </div>
+                    <div style={{ flex: '0 0 100px' }}>
+                      <label style={labelStyle}>Height</label>
+                      <input style={{ ...inputStyle, width: '100%' }} type="number" value={editVp.height} onChange={e => setEditVp(v => ({ ...v, height: parseInt(e.target.value, 10) || v.height }))} />
+                    </div>
+                  </div>
+                  <div style={{ display: 'flex', gap: 8 }}>
+                    <button style={btnPrimary} onClick={handleSaveVp}>Save</button>
+                    <button style={btnDanger}  onClick={handleDeleteVp}>Delete Viewport</button>
+                  </div>
+                </Section>
+              )}
+
+              {/* Display URL */}
+              <Section title="Display URL" style={{ marginBottom: 24 }}>
+                <div style={{ fontSize: 12, color: dark.muted, marginBottom: 8 }}>
+                  Open this URL in a browser and output via HDMI / OBS Browser Source.
+                  {selectedVp._builtin && ' (Existing landscape DSK behaviour — no change needed.)'}
+                </div>
+                <UrlBlock url={getDisplayUrl(selectedVp)} onCopy={() => flash('Copied')} />
+              </Section>
+
+              {/* Present to screen */}
+              <Section title="Present to Screen" style={{ marginBottom: 24 }}>
+                <div style={{ fontSize: 12, color: dark.muted, marginBottom: 10 }}>
+                  Open the display URL on a specific connected monitor in fullscreen.
+                  Requires browser permission to enumerate screens (Chrome/Chromium 100+).
+                </div>
+                {screenApiSupported === false && (
+                  <div style={{ color: dark.muted, fontSize: 12 }}>
+                    Window Placement API not available in this browser. Open the URL manually using the copy button above.
+                  </div>
+                )}
+                {screenApiSupported && !screens && (
+                  <button style={btnBase} onClick={handleRequestScreens}>List Connected Screens</button>
+                )}
+                {screens && (
+                  <div>
+                    {screens.length === 0 && <div style={{ color: dark.muted, fontSize: 12 }}>No screens found.</div>}
+                    {screens.map((sc, i) => (
+                      <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 6 }}>
+                        <span style={{ fontSize: 13, color: dark.text, minWidth: 180 }}>
+                          {sc.label || `Screen ${i + 1}`} ({sc.width}×{sc.height}){sc.isPrimary ? ' · primary' : ''}
+                        </span>
+                        <button style={btnSmall} onClick={() => openOnScreen(sc, getDisplayUrl(selectedVp))}>
+                          Open on this screen
+                        </button>
+                      </div>
+                    ))}
+                    <button style={{ ...btnSmall, marginTop: 6, color: dark.muted }} onClick={() => setScreens(null)}>Refresh screen list</button>
+                  </div>
+                )}
+              </Section>
+
+              {/* Per-image settings */}
+              <Section title="Image Settings for this Viewport">
+                <div style={{ fontSize: 12, color: dark.muted, marginBottom: 12 }}>
+                  Control visibility and position of each uploaded image on <strong>{selectedVp.label || selectedVp.name}</strong>.
+                  Blank position fields = full-width default. Animation: CSS shorthand e.g. <code>lcyt-fadeIn 0.5s</code>.
+                </div>
+                {images.length === 0 && (
+                  <div style={{ color: dark.muted, fontSize: 13 }}>No images uploaded yet.</div>
+                )}
+                {images.length > 0 && (
+                  <ImageSettingsTable
+                    images={images}
+                    viewportName={selectedVp._builtin ? 'landscape' : selectedVp.name}
+                    getImgVpSettings={getImgVpSettings}
+                    saveImgVpSettings={saveImgVpSettings}
+                    serverUrl={serverUrl}
+                  />
+                )}
+              </Section>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function Section({ title, children, style }) {
+  return (
+    <div style={{ background: dark.card, border: `1px solid ${dark.border}`, borderRadius: 8, padding: 16, ...style }}>
+      <div style={{ fontSize: 12, fontWeight: 'bold', color: dark.muted, textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 12 }}>{title}</div>
+      {children}
+    </div>
+  );
+}
+
+function UrlBlock({ url, onCopy }) {
+  async function copy() {
+    try { await navigator.clipboard.writeText(url); onCopy(); } catch {}
+  }
+  return (
+    <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+      <code style={{ flex: 1, background: '#111', border: `1px solid ${dark.border}`, borderRadius: 4, padding: '6px 10px', fontSize: 12, color: '#aef', wordBreak: 'break-all' }}>
+        {url}
+      </code>
+      <button style={btnSmall} onClick={copy}>Copy</button>
+      <button style={btnSmall} onClick={() => window.open(url, '_blank')}>Open</button>
+    </div>
+  );
+}
+
+function ImageSettingsTable({ images, viewportName, getImgVpSettings, saveImgVpSettings, serverUrl }) {
+  const [expanded, setExpanded] = useState(new Set());
+
+  function toggle(id) {
+    setExpanded(s => {
+      const n = new Set(s);
+      n.has(id) ? n.delete(id) : n.add(id);
+      return n;
+    });
+  }
+
+  return (
+    <div>
+      {/* Header row */}
+      <div style={{ display: 'grid', gridTemplateColumns: '48px 1fr 80px 80px', gap: 8, padding: '4px 8px', fontSize: 11, color: dark.muted, borderBottom: `1px solid ${dark.border}`, marginBottom: 4 }}>
+        <span />
+        <span>Shorthand</span>
+        <span>Visible</span>
+        <span>Position</span>
+      </div>
+      {images.map(img => {
+        const settings = getImgVpSettings(img, viewportName);
+        const isExpanded = expanded.has(img.id);
+        return (
+          <ImageRow
+            key={img.id}
+            img={img}
+            settings={settings}
+            isExpanded={isExpanded}
+            onToggleExpand={() => toggle(img.id)}
+            onSave={patch => saveImgVpSettings(img, viewportName, patch)}
+            serverUrl={serverUrl}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function ImageRow({ img, settings, isExpanded, onToggleExpand, onSave, serverUrl }) {
+  const visible   = settings.visible !== false;
+  const hasPos    = settings.x != null || settings.y != null || settings.width != null || settings.height != null;
+  const hasAnim   = !!settings.animation;
+
+  // Local draft for position editing
+  const [draft, setDraft] = useState({
+    x:         settings.x         != null ? String(settings.x)         : '',
+    y:         settings.y         != null ? String(settings.y)         : '',
+    width:     settings.width     != null ? String(settings.width)     : '',
+    height:    settings.height    != null ? String(settings.height)    : '',
+    animation: settings.animation ?? '',
+  });
+
+  // Sync draft when settings change (e.g. after save)
+  useEffect(() => {
+    setDraft({
+      x:         settings.x         != null ? String(settings.x)         : '',
+      y:         settings.y         != null ? String(settings.y)         : '',
+      width:     settings.width     != null ? String(settings.width)     : '',
+      height:    settings.height    != null ? String(settings.height)    : '',
+      animation: settings.animation ?? '',
+    });
+  }, [settings.x, settings.y, settings.width, settings.height, settings.animation]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  function parsePx(val) {
+    const n = parseInt(val, 10);
+    return isNaN(n) ? null : n;
+  }
+
+  function handleSave() {
+    onSave({
+      x:         parsePx(draft.x),
+      y:         parsePx(draft.y),
+      width:     parsePx(draft.width),
+      height:    parsePx(draft.height),
+      animation: draft.animation || null,
+    });
+  }
+
+  return (
+    <div style={{ borderBottom: `1px solid ${dark.border}` }}>
+      {/* Summary row */}
+      <div style={{ display: 'grid', gridTemplateColumns: '48px 1fr 80px 80px', gap: 8, padding: '6px 8px', alignItems: 'center' }}>
+        {/* Thumbnail */}
+        <img
+          src={`${serverUrl}/images/${img.id}`}
+          alt=""
+          style={{ width: 40, height: 40, objectFit: 'contain', background: '#111', borderRadius: 4, border: `1px solid ${dark.border}` }}
+          crossOrigin="anonymous"
+        />
+        {/* Shorthand */}
+        <div>
+          <code style={{ fontSize: 13, color: '#aef' }}>{img.shorthand}</code>
+          <span style={{ fontSize: 11, color: dark.muted, marginLeft: 8 }}>{img.mimeType?.split('/')[1]}</span>
+        </div>
+        {/* Visible toggle */}
+        <div>
+          <input
+            type="checkbox"
+            checked={visible}
+            onChange={e => onSave({ visible: e.target.checked })}
+            style={{ width: 16, height: 16, cursor: 'pointer' }}
+          />
+        </div>
+        {/* Expand button */}
+        <button
+          style={{ ...btnSmall, background: isExpanded ? dark.cardHover : 'transparent', border: `1px solid ${isExpanded ? dark.border : 'transparent'}` }}
+          onClick={onToggleExpand}
+          title="Position & animation overrides"
+        >
+          {hasPos || hasAnim ? '✎' : '+'} pos
+        </button>
+      </div>
+
+      {/* Expanded position row */}
+      {isExpanded && (
+        <div style={{ padding: '8px 56px 12px', background: '#1a1a1a', borderTop: `1px solid ${dark.border}` }}>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10, marginBottom: 10 }}>
+            {[['x', 'X (px)'], ['y', 'Y (px)'], ['width', 'Width (px)'], ['height', 'Height (px)']].map(([key, lbl]) => (
+              <div key={key} style={{ flex: '0 0 100px' }}>
+                <label style={labelStyle}>{lbl}</label>
+                <input
+                  style={{ ...inputStyle, width: '100%' }}
+                  type="number"
+                  placeholder="auto"
+                  value={draft[key]}
+                  onChange={e => setDraft(d => ({ ...d, [key]: e.target.value }))}
+                />
+              </div>
+            ))}
+            <div style={{ flex: '1 1 200px' }}>
+              <label style={labelStyle}>Animation</label>
+              <input
+                style={{ ...inputStyle, width: '100%' }}
+                placeholder="e.g. lcyt-fadeIn 0.5s"
+                value={draft.animation}
+                onChange={e => setDraft(d => ({ ...d, animation: e.target.value }))}
+              />
+            </div>
+          </div>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button style={btnPrimary} onClick={handleSave}>Save</button>
+            <button style={btnDanger} onClick={() => onSave({ x: null, y: null, width: null, height: null, animation: null })}>
+              Reset position
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/lcyt-web/src/components/ViewerPage.jsx
+++ b/packages/lcyt-web/src/components/ViewerPage.jsx
@@ -18,6 +18,11 @@
  *             'original' shows the raw original text,
  *             'all' splits the view into one column per language.
  *             Omit (or empty) to show the composed text (original + translation if configured).
+ *   apikey    DSK API key — when set, subscribes to /dsk/:apikey/events and renders
+ *             graphics overlays in addition to caption text. Useful when this viewer
+ *             page is configured as a named DSK viewport.
+ *   viewport  Viewport name — used to select per-viewport image settings and
+ *             metacode targeting. Requires apikey to be set.
  */
 
 import { useState, useEffect, useRef } from 'react';
@@ -59,6 +64,9 @@ export function ViewerPage() {
   const lang       = params.get('lang') || '';
   const showAll    = lang === 'all';
   const iconId     = params.get('icon') ? parseInt(params.get('icon'), 10) : null;
+  // DSK graphics overlay (optional)
+  const dskApiKey     = params.get('apikey')   || null;
+  const dskViewport   = params.get('viewport') || null;
 
   // Single-language display state
   const [text,      setText]      = useState('');
@@ -69,7 +77,13 @@ export function ViewerPage() {
   const [connected, setConnected] = useState(false);
   const [error,     setError]     = useState('');
 
+  // DSK graphics state (populated only when dskApiKey is set)
+  const [dskImages,      setDskImages]      = useState([]);  // [{ id, shorthand, mimeType, settingsJson }]
+  const [dskActiveNames, setDskActiveNames] = useState([]);  // string[]
+
   const esRef        = useRef(null);
+  const dskEsRef     = useRef(null);
+  const dskRetryRef  = useRef(null);
   const reconnectRef = useRef(null);
 
   useEffect(() => {
@@ -137,10 +151,90 @@ export function ViewerPage() {
     };
   }, [viewerKey, backendUrl, lang, showAll]);
 
+  // ── DSK graphics overlay ──────────────────────────────────────────────────
+  useEffect(() => {
+    if (!dskApiKey) return;
+
+    let cancelled = false;
+    let retryDelay = 1000;
+
+    // Fetch images (with settingsJson for per-viewport settings)
+    async function fetchDskImages() {
+      try {
+        const res = await fetch(`${backendUrl}/dsk/${encodeURIComponent(dskApiKey)}/images`);
+        if (!res.ok || cancelled) return;
+        const data = await res.json();
+        setDskImages(data.images || []);
+      } catch {}
+    }
+
+    function openDskEvents() {
+      if (cancelled) return;
+      const es = new EventSource(`${backendUrl}/dsk/${encodeURIComponent(dskApiKey)}/events`);
+      dskEsRef.current = es;
+
+      es.addEventListener('graphics', (e) => {
+        if (cancelled) return;
+        try {
+          const payload = JSON.parse(e.data);
+          setDskActiveNames(resolveDskNames(payload, dskViewport));
+        } catch {}
+      });
+
+      es.addEventListener('reload', () => { if (!cancelled) fetchDskImages(); });
+
+      es.onerror = () => {
+        es.close();
+        dskEsRef.current = null;
+        if (cancelled) return;
+        dskRetryRef.current = setTimeout(() => {
+          retryDelay = Math.min(retryDelay * 2, 30000);
+          openDskEvents();
+        }, retryDelay);
+      };
+    }
+
+    fetchDskImages();
+    openDskEvents();
+
+    return () => {
+      cancelled = true;
+      dskEsRef.current?.close();
+      clearTimeout(dskRetryRef.current);
+    };
+  }, [dskApiKey, dskViewport, backendUrl]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const langEntries = Object.entries(langTexts);
 
   return (
     <div style={rootStyle(theme)}>
+      {/* DSK graphics overlay (when apikey + viewport params are set) */}
+      {dskApiKey && dskActiveNames.map((name, layerIdx) => {
+        const img = dskImages.find(i => i.shorthand === name);
+        if (!img) return null;
+        const vpSettings = img.settingsJson?.viewports?.[dskViewport] ?? {};
+        if (vpSettings.visible === false) return null;
+        return (
+          <img
+            key={`dsk-${img.id}`}
+            src={`${backendUrl}/images/${img.id}`}
+            alt=""
+            aria-hidden="true"
+            crossOrigin="anonymous"
+            style={{
+              position:      'absolute',
+              zIndex:        layerIdx + 1,
+              pointerEvents: 'none',
+              left:          vpSettings.x      != null ? vpSettings.x      : 0,
+              top:           vpSettings.y      != null ? vpSettings.y      : 0,
+              width:         vpSettings.width  != null ? vpSettings.width  : '100%',
+              height:        vpSettings.height != null ? vpSettings.height : 'auto',
+              ...(vpSettings.animation ? { animation: vpSettings.animation } : {}),
+            }}
+          />
+        );
+      })}
+
       {/* Section badge — top left */}
       {section && (
         <div style={sectionBadgeStyle}>
@@ -195,6 +289,21 @@ export function ViewerPage() {
       )}
     </div>
   );
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Resolve active image names from a DSK 'graphics' SSE payload for a given viewport.
+ * Supports both the new format { default, viewports } and the legacy format { names }.
+ */
+function resolveDskNames(payload, viewportName) {
+  if (Array.isArray(payload.names)) return payload.names; // legacy
+  const { default: defaultNames, viewports } = payload;
+  if (viewportName && viewports && viewports[viewportName] !== undefined) {
+    return viewports[viewportName];
+  }
+  return Array.isArray(defaultNames) ? defaultNames : [];
 }
 
 // ─── Styles ───────────────────────────────────────────────────────────────────

--- a/packages/lcyt-web/src/main.jsx
+++ b/packages/lcyt-web/src/main.jsx
@@ -15,6 +15,7 @@ import { EmbedRtmpPage } from './components/EmbedRtmpPage';
 import { DskPage } from './components/DskPage';
 import { DskEditorPage } from './components/DskEditorPage';
 import { DskControlPage } from './components/DskControlPage';
+import { DskViewportsPage } from './components/DskViewportsPage';
 import { EmbedViewerPage } from './components/EmbedViewerPage';
 import { ViewerPage } from './components/ViewerPage';
 import { ProductionCamerasPage } from './components/ProductionCamerasPage';
@@ -39,6 +40,7 @@ function getPage() {
   if (path.startsWith('/embed/files'))     return <EmbedFilesPage />;
   if (path.startsWith('/embed/settings')) return <EmbedSettingsPage />;
   if (path.startsWith('/embed/rtmp'))     return <EmbedRtmpPage />;
+  if (path.startsWith('/dsk-viewports'))  return <DskViewportsPage />;
   if (path.startsWith('/dsk-editor'))     return <DskEditorPage />;
   if (path.startsWith('/dsk-control/'))   return <DskControlPage />;
   if (path.startsWith('/dsk/'))           return <DskPage />;

--- a/packages/plugins/lcyt-dsk/src/api.js
+++ b/packages/plugins/lcyt-dsk/src/api.js
@@ -28,6 +28,7 @@ import { startRenderer, stopRenderer } from './renderer.js';
 import { createDskCaptionProcessor } from './caption-processor.js';
 import { createDskRouter } from './routes/dsk.js';
 import { createDskTemplatesRouter } from './routes/dsk-templates.js';
+import { createDskViewportsRouter } from './routes/dsk-viewports.js';
 import { createImagesRouter } from './routes/images.js';
 import { createDskRtmpRouter } from './routes/dsk-rtmp.js';
 import { createEditorAuth, editorAuthOrBearer } from './middleware/editor-auth.js';
@@ -65,11 +66,13 @@ export async function initDskControl(db, store, relayManager) {
 export function createDskRouters(db, store, auth, relayManager) {
   const editorAuth = createEditorAuth(db);
   return {
-    /** Mount at /dsk  — public SSE + image list */
+    /** Mount at /dsk  — public SSE + image list + public viewports */
     dskRouter: createDskRouter(db, store),
     /** Mount at /dsk  — authenticated template CRUD + renderer control */
     dskTemplatesRouter: createDskTemplatesRouter(db, auth, editorAuth, relayManager),
-    /** Mount at /images — authenticated upload (JWT or X-API-Key); public serve */
+    /** Mount at /dsk  — authenticated viewport CRUD (JWT Bearer or X-API-Key editor auth) */
+    dskViewportsRouter: createDskViewportsRouter(db, editorAuthOrBearer(auth, editorAuth)),
+    /** Mount at /images — authenticated upload (JWT or X-API-Key); public serve; viewport settings */
     imagesRouter: createImagesRouter(db, editorAuthOrBearer(auth, editorAuth)),
     /** Mount at /dsk-rtmp — nginx-rtmp on_publish callbacks */
     dskRtmpRouter: createDskRtmpRouter(relayManager),

--- a/packages/plugins/lcyt-dsk/src/caption-processor.js
+++ b/packages/plugins/lcyt-dsk/src/caption-processor.js
@@ -1,8 +1,22 @@
 /**
  * DSK caption processor.
  *
- * Extracts the <!-- graphics:... --> metadata from caption text, emits DSK SSE
- * events to subscribed overlay pages, and updates the RTMP relay overlay.
+ * Extracts <!-- graphics:... --> and <!-- graphics[viewport,...]:... --> metadata from caption
+ * text, emits DSK SSE events to subscribed overlay pages, and updates the RTMP relay overlay.
+ *
+ * Metacode syntax:
+ *   <!-- graphics:logo,banner -->                         default: all viewports get logo + banner
+ *   <!-- graphics[vertical-left]:stanza,logo -->          vertical-left gets stanza+logo (overrides default)
+ *   <!-- graphics[v1,v2]:stanza -->                       v1 AND v2 both get stanza (overrides default for each)
+ *   <!-- graphics[vertical-right]: -->                    vertical-right gets nothing (cleared)
+ *
+ * Override rule: if a viewport-specific section exists for a viewport, it REPLACES the
+ * default for that viewport. Viewports not mentioned use the default section.
+ *
+ * SSE 'graphics' event payload:
+ *   { default: string[]|null, viewports: { [name]: string[] }, ts: number }
+ *   - default: null if no all-viewport section was found
+ *   - viewports: viewport-specific overrides (empty array = clear that viewport)
  *
  * Used by lcyt-backend's captions route via dependency injection:
  *   const { captionProcessor } = await initDskControl(db, store, relayManager);
@@ -12,44 +26,90 @@
 import { join, resolve, basename } from 'node:path';
 import { getImageByShorthand, safeApiKey } from './db/images.js';
 
-const GRAPHICS_CODE_RE = /<!--\s*graphics\s*:(.*?)-->/i;
+// Matches <!-- graphics[v1,v2]:name1, name2 --> (viewport-targeted section)
+const VP_CODE_RE = /<!--\s*graphics\[([^\]]+)\]\s*:\s*(.*?)-->/gi;
+// Matches <!-- graphics:name1, name2 --> (default / all-viewports section)
+const DEFAULT_CODE_RE = /<!--\s*graphics\s*:\s*(.*?)-->/i;
+
 const GRAPHICS_BASE_DIR = resolve(process.env.GRAPHICS_DIR || '/data/images');
+
+/**
+ * Parse all DSK metacodes from a caption string.
+ *
+ * @param {string} text
+ * @returns {{ defaultNames: string[]|null, viewportNames: Object<string,string[]>, cleanText: string }}
+ */
+function parseDskMetacodes(text) {
+  /** @type {Object<string,string[]>} */
+  const viewportNames = {};
+
+  // 1. Extract viewport-specific sections (<!-- graphics[v1,v2]:names -->)
+  let m;
+  VP_CODE_RE.lastIndex = 0;
+  while ((m = VP_CODE_RE.exec(text)) !== null) {
+    const vpList = m[1].split(',').map(v => v.trim()).filter(Boolean);
+    const names  = m[2].split(',').map(n => n.trim()).filter(Boolean);
+    for (const vp of vpList) {
+      viewportNames[vp] = names;
+    }
+  }
+
+  // 2. Remove viewport-specific sections before looking for the default section,
+  //    to prevent the default regex from matching inside them.
+  const textWithoutVpSections = text.replace(/<!--\s*graphics\[[^\]]+\][^>]*-->/gi, '');
+
+  // 3. Extract default (all-viewport) section
+  const defMatch = textWithoutVpSections.match(DEFAULT_CODE_RE);
+  const defaultNames = defMatch
+    ? defMatch[1].split(',').map(n => n.trim()).filter(Boolean)
+    : null;
+
+  // 4. Build clean text: remove ALL graphics metacodes
+  const cleanText = text
+    .replace(/<!--\s*graphics(?:\[[^\]]+\])?\s*:[^>]*-->/gi, '')
+    .trim();
+
+  return { defaultNames, viewportNames, cleanText };
+}
 
 /**
  * Create a DSK caption processor function.
  *
  * @param {{ db: import('better-sqlite3').Database, store: object, relayManager: object|null }} opts
  * @returns {(apiKey: string, text: string) => Promise<string>}
- *   Always returns the cleaned caption text (with the <!-- graphics:... --> code removed).
- *   If no graphics code is present the text is returned unchanged.
+ *   Always returns the cleaned caption text (with all <!-- graphics:... --> codes removed).
+ *   If no graphics codes are present the text is returned unchanged.
  */
 export function createDskCaptionProcessor({ db, store, relayManager }) {
   return async function processDskCaption(apiKey, text) {
-    const match = text.match(GRAPHICS_CODE_RE);
-    if (!match) return text; // no DSK code — fast path
+    // Quick check: does the text contain any DSK metacode at all?
+    if (!text.includes('<!--') || !/graphics/i.test(text)) return text;
 
-    const graphicsNames = match[1]
-      .split(',')
-      .map(n => n.trim())
-      .filter(Boolean);
+    const { defaultNames, viewportNames, cleanText } = parseDskMetacodes(text);
 
-    const cleanText = text.replace(GRAPHICS_CODE_RE, '').trim();
+    // If nothing was parsed (no default and no viewport sections), return unchanged
+    if (defaultNames === null && Object.keys(viewportNames).length === 0) return text;
 
-    // Emit SSE events to any open /dsk/:apikey/events subscribers (client-side overlay)
-    store.emitDskEvent(apiKey, 'graphics', { names: graphicsNames, ts: Date.now() });
+    // Emit SSE 'graphics' event to all open /dsk/:apikey/events subscribers
+    store.emitDskEvent(apiKey, 'graphics', {
+      default:   defaultNames,
+      viewports: viewportNames,
+      ts:        Date.now(),
+    });
+
     if (cleanText) {
       store.emitDskEvent(apiKey, 'text', { text: cleanText, ts: Date.now() });
     }
 
-    // Server-side DSK overlay: update the RTMP relay process with the new image files.
+    // Server-side DSK overlay (RTMP relay): use the default names for the landscape stream.
     // SVG is not supported by ffmpeg's overlay filter; only PNG/WebP are included.
-    if (relayManager) {
-      const imagePaths = graphicsNames.flatMap(name => {
+    if (relayManager && defaultNames !== null) {
+      const imagePaths = defaultNames.flatMap(name => {
         const row = getImageByShorthand(db, apiKey, name);
         if (!row || row.mime_type === 'image/svg+xml') return [];
         return [join(GRAPHICS_BASE_DIR, safeApiKey(apiKey), basename(row.filename))];
       });
-      relayManager.setDskOverlay(apiKey, graphicsNames, imagePaths).catch(() => {});
+      relayManager.setDskOverlay(apiKey, defaultNames, imagePaths).catch(() => {});
     }
 
     return cleanText;

--- a/packages/plugins/lcyt-dsk/src/caption-processor.js
+++ b/packages/plugins/lcyt-dsk/src/caption-processor.js
@@ -5,18 +5,34 @@
  * text, emits DSK SSE events to subscribed overlay pages, and updates the RTMP relay overlay.
  *
  * Metacode syntax:
- *   <!-- graphics:logo,banner -->                         default: all viewports get logo + banner
+ *   <!-- graphics:logo,banner -->                         default: all viewports get logo+banner (absolute)
  *   <!-- graphics[vertical-left]:stanza,logo -->          vertical-left gets stanza+logo (overrides default)
- *   <!-- graphics[v1,v2]:stanza -->                       v1 AND v2 both get stanza (overrides default for each)
+ *   <!-- graphics[v1,v2]:stanza -->                       v1 AND v2 both get stanza
  *   <!-- graphics[vertical-right]: -->                    vertical-right gets nothing (cleared)
+ *   <!-- graphics:+logo -->                               add logo to currently active set (delta mode)
+ *   <!-- graphics:-banner -->                             remove banner from active set (delta mode)
+ *   <!-- graphics:+logo,-banner -->                       add logo AND remove banner simultaneously
+ *   <!-- graphics[v1]:+stanza -->                         add stanza only to v1's current active set
  *
- * Override rule: if a viewport-specific section exists for a viewport, it REPLACES the
- * default for that viewport. Viewports not mentioned use the default section.
+ * Landscape aliases — the built-in landscape viewport (the /dsk/:key default display) can be
+ * targeted by any of these names: "landscape", "default", "main".
+ * All three resolve to the same "landscape" slot in the broadcast payload.
+ *
+ * Delta mode: triggered when ANY name in a section starts with + or -. Unprefixed names in a
+ * delta section are treated as additions (+). Server maintains current active state per apiKey
+ * so delta operations have something to work against. The broadcast payload always contains
+ * complete resolved name lists — display pages need no changes.
+ *
+ * Override rule (absolute sections): if a viewport-specific section exists for a viewport, it
+ * REPLACES the default for that viewport. Viewports not mentioned use the default section.
  *
  * SSE 'graphics' event payload:
  *   { default: string[]|null, viewports: { [name]: string[] }, ts: number }
- *   - default: null if no all-viewport section was found
+ *   - default: null if no all-viewport section was found AND no delta changed the default slot
  *   - viewports: viewport-specific overrides (empty array = clear that viewport)
+ *
+ * SSE 'bindings' event payload (when caption has non-empty codes):
+ *   { codes: { section?: string, stanza?: string, speaker?: string, ... }, ts: number }
  *
  * Used by lcyt-backend's captions route via dependency injection:
  *   const { captionProcessor } = await initDskControl(db, store, relayManager);
@@ -33,24 +49,73 @@ const DEFAULT_CODE_RE = /<!--\s*graphics\s*:\s*(.*?)-->/i;
 
 const GRAPHICS_BASE_DIR = resolve(process.env.GRAPHICS_DIR || '/data/images');
 
+// Names that target the built-in landscape / default viewport
+const LANDSCAPE_ALIASES = new Set(['landscape', 'default', 'main']);
+
+/**
+ * Parse a comma-separated names string, detecting delta mode.
+ * Returns { delta: false, names: string[] } or { delta: true, add: string[], remove: string[] }.
+ * Delta mode is triggered when any name starts with + or -.
+ * In delta mode, unprefixed names are treated as additions.
+ */
+function parseSection(rawNames) {
+  const items = rawNames.split(',').map(n => n.trim()).filter(Boolean);
+  const hasDelta = items.some(n => n[0] === '+' || n[0] === '-');
+
+  if (!hasDelta) {
+    return { delta: false, names: items };
+  }
+
+  const add    = [];
+  const remove = [];
+  for (const item of items) {
+    if (item[0] === '-') {
+      remove.push(item.slice(1).trim());
+    } else if (item[0] === '+') {
+      add.push(item.slice(1).trim());
+    } else {
+      add.push(item); // unprefixed in delta section → treat as add
+    }
+  }
+  return { delta: true, add, remove };
+}
+
+/**
+ * Apply a parsed section to a current names array.
+ * Returns the new complete names array.
+ */
+function applySection(current, parsed) {
+  if (!parsed.delta) return parsed.names;
+  const set = new Set(current);
+  for (const name of parsed.remove) set.delete(name);
+  for (const name of parsed.add)    set.add(name);
+  return [...set];
+}
+
 /**
  * Parse all DSK metacodes from a caption string.
  *
  * @param {string} text
- * @returns {{ defaultNames: string[]|null, viewportNames: Object<string,string[]>, cleanText: string }}
+ * @returns {{
+ *   defaultSection: ReturnType<parseSection>|null,
+ *   viewportSections: Object<string, ReturnType<parseSection>>,
+ *   cleanText: string,
+ * }}
  */
 function parseDskMetacodes(text) {
-  /** @type {Object<string,string[]>} */
-  const viewportNames = {};
+  /** @type {Object<string, ReturnType<parseSection>>} */
+  const viewportSections = {};
 
   // 1. Extract viewport-specific sections (<!-- graphics[v1,v2]:names -->)
   let m;
   VP_CODE_RE.lastIndex = 0;
   while ((m = VP_CODE_RE.exec(text)) !== null) {
-    const vpList = m[1].split(',').map(v => v.trim()).filter(Boolean);
-    const names  = m[2].split(',').map(n => n.trim()).filter(Boolean);
+    const vpList  = m[1].split(',').map(v => v.trim()).filter(Boolean);
+    const section = parseSection(m[2]);
     for (const vp of vpList) {
-      viewportNames[vp] = names;
+      // Normalize landscape aliases to a single key
+      const key = LANDSCAPE_ALIASES.has(vp) ? 'landscape' : vp;
+      viewportSections[key] = section;
     }
   }
 
@@ -60,40 +125,64 @@ function parseDskMetacodes(text) {
 
   // 3. Extract default (all-viewport) section
   const defMatch = textWithoutVpSections.match(DEFAULT_CODE_RE);
-  const defaultNames = defMatch
-    ? defMatch[1].split(',').map(n => n.trim()).filter(Boolean)
-    : null;
+  const defaultSection = defMatch ? parseSection(defMatch[1]) : null;
 
   // 4. Build clean text: remove ALL graphics metacodes
   const cleanText = text
     .replace(/<!--\s*graphics(?:\[[^\]]+\])?\s*:[^>]*-->/gi, '')
     .trim();
 
-  return { defaultNames, viewportNames, cleanText };
+  return { defaultSection, viewportSections, cleanText };
 }
 
 /**
  * Create a DSK caption processor function.
  *
  * @param {{ db: import('better-sqlite3').Database, store: object, relayManager: object|null }} opts
- * @returns {(apiKey: string, text: string) => Promise<string>}
+ * @returns {(apiKey: string, text: string, codes?: object) => Promise<string>}
  *   Always returns the cleaned caption text (with all <!-- graphics:... --> codes removed).
  *   If no graphics codes are present the text is returned unchanged.
  */
 export function createDskCaptionProcessor({ db, store, relayManager }) {
-  return async function processDskCaption(apiKey, text) {
-    // Quick check: does the text contain any DSK metacode at all?
+  return async function processDskCaption(apiKey, text, codes = {}) {
+    // Emit 'bindings' SSE event if codes are present (section, stanza, speaker, etc.)
+    if (codes && typeof codes === 'object' && Object.keys(codes).length > 0) {
+      store.emitDskEvent(apiKey, 'bindings', { codes, ts: Date.now() });
+    }
+
+    // Quick check: does the text contain any graphics metacode?
     if (!text.includes('<!--') || !/graphics/i.test(text)) return text;
 
-    const { defaultNames, viewportNames, cleanText } = parseDskMetacodes(text);
+    const { defaultSection, viewportSections, cleanText } = parseDskMetacodes(text);
 
     // If nothing was parsed (no default and no viewport sections), return unchanged
-    if (defaultNames === null && Object.keys(viewportNames).length === 0) return text;
+    if (defaultSection === null && Object.keys(viewportSections).length === 0) return text;
+
+    // ── Apply sections against current server-side state ────────────────────
+    const state = store.getDskGraphicsState(apiKey);
+
+    // Default slot
+    let newDefault = null;
+    if (defaultSection !== null) {
+      newDefault = applySection(state.default, defaultSection);
+      state.default = newDefault;
+    }
+
+    // Viewport-specific slots
+    const newViewports = {};
+    for (const [vpName, section] of Object.entries(viewportSections)) {
+      const current = state.viewports[vpName] ?? state.default ?? [];
+      const resolved = applySection(current, section);
+      state.viewports[vpName] = resolved;
+      newViewports[vpName] = resolved;
+    }
+
+    store.setDskGraphicsState(apiKey, state);
 
     // Emit SSE 'graphics' event to all open /dsk/:apikey/events subscribers
     store.emitDskEvent(apiKey, 'graphics', {
-      default:   defaultNames,
-      viewports: viewportNames,
+      default:   newDefault,         // null if no default section touched this time
+      viewports: newViewports,
       ts:        Date.now(),
     });
 
@@ -101,15 +190,15 @@ export function createDskCaptionProcessor({ db, store, relayManager }) {
       store.emitDskEvent(apiKey, 'text', { text: cleanText, ts: Date.now() });
     }
 
-    // Server-side DSK overlay (RTMP relay): use the default names for the landscape stream.
+    // Server-side DSK overlay (RTMP relay): use the resolved default for the landscape stream.
     // SVG is not supported by ffmpeg's overlay filter; only PNG/WebP are included.
-    if (relayManager && defaultNames !== null) {
-      const imagePaths = defaultNames.flatMap(name => {
+    if (relayManager && newDefault !== null) {
+      const imagePaths = newDefault.flatMap(name => {
         const row = getImageByShorthand(db, apiKey, name);
         if (!row || row.mime_type === 'image/svg+xml') return [];
         return [join(GRAPHICS_BASE_DIR, safeApiKey(apiKey), basename(row.filename))];
       });
-      relayManager.setDskOverlay(apiKey, defaultNames, imagePaths).catch(() => {});
+      relayManager.setDskOverlay(apiKey, newDefault, imagePaths).catch(() => {});
     }
 
     return cleanText;

--- a/packages/plugins/lcyt-dsk/src/db.js
+++ b/packages/plugins/lcyt-dsk/src/db.js
@@ -27,10 +27,28 @@ export function runMigrations(db) {
     )
   `);
 
+  // dsk_viewports: named display targets (landscape, vertical-left, viewer, etc.)
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS dsk_viewports (
+      id             INTEGER PRIMARY KEY AUTOINCREMENT,
+      api_key        TEXT    NOT NULL,
+      name           TEXT    NOT NULL,
+      label          TEXT,
+      viewport_type  TEXT    NOT NULL DEFAULT 'landscape',
+      width          INTEGER NOT NULL DEFAULT 1920,
+      height         INTEGER NOT NULL DEFAULT 1080,
+      created_at     TEXT    NOT NULL DEFAULT (datetime('now')),
+      updated_at     TEXT    NOT NULL DEFAULT (datetime('now')),
+      UNIQUE (api_key, name)
+    )
+  `);
+
   // Additive columns on caption_files for image metadata (DSK images are stored there)
   const filesCols = new Set(
     db.prepare('PRAGMA table_info(caption_files)').all().map(c => c.name)
   );
-  if (!filesCols.has('shorthand')) db.exec('ALTER TABLE caption_files ADD COLUMN shorthand TEXT');
-  if (!filesCols.has('mime_type')) db.exec('ALTER TABLE caption_files ADD COLUMN mime_type TEXT');
+  if (!filesCols.has('shorthand'))     db.exec('ALTER TABLE caption_files ADD COLUMN shorthand TEXT');
+  if (!filesCols.has('mime_type'))     db.exec('ALTER TABLE caption_files ADD COLUMN mime_type TEXT');
+  // settings_json: per-viewport visibility, position, animation overrides for each image
+  if (!filesCols.has('settings_json')) db.exec('ALTER TABLE caption_files ADD COLUMN settings_json TEXT');
 }

--- a/packages/plugins/lcyt-dsk/src/db.js
+++ b/packages/plugins/lcyt-dsk/src/db.js
@@ -51,4 +51,10 @@ export function runMigrations(db) {
   if (!filesCols.has('mime_type'))     db.exec('ALTER TABLE caption_files ADD COLUMN mime_type TEXT');
   // settings_json: per-viewport visibility, position, animation overrides for each image
   if (!filesCols.has('settings_json')) db.exec('ALTER TABLE caption_files ADD COLUMN settings_json TEXT');
+
+  // Additive column on dsk_viewports for text layers (bound to caption codes)
+  const vpCols = new Set(
+    db.prepare('PRAGMA table_info(dsk_viewports)').all().map(c => c.name)
+  );
+  if (!vpCols.has('text_layers_json')) db.exec('ALTER TABLE dsk_viewports ADD COLUMN text_layers_json TEXT');
 }

--- a/packages/plugins/lcyt-dsk/src/db/images.js
+++ b/packages/plugins/lcyt-dsk/src/db/images.js
@@ -106,6 +106,21 @@ export function deleteImage(db, id, apiKey) {
 }
 
 /**
+ * Update the settings_json column for an image scoped to an API key.
+ * @param {import('better-sqlite3').Database} db
+ * @param {number} id
+ * @param {string} apiKey
+ * @param {object} settingsJson  parsed JS object — will be JSON-stringified
+ * @returns {boolean} true if a row was updated
+ */
+export function updateImageSettings(db, id, apiKey, settingsJson) {
+  const result = db.prepare(
+    "UPDATE caption_files SET settings_json = ? WHERE id = ? AND api_key = ? AND type = 'image'"
+  ).run(JSON.stringify(settingsJson), id, apiKey);
+  return result.changes > 0;
+}
+
+/**
  * Delete all image rows for an API key (for hard-delete cascade).
  * @param {import('better-sqlite3').Database} db
  * @param {string} apiKey

--- a/packages/plugins/lcyt-dsk/src/db/viewports.js
+++ b/packages/plugins/lcyt-dsk/src/db/viewports.js
@@ -1,0 +1,68 @@
+// ─── Viewport helpers ─────────────────────────────────────────────────────────
+
+/**
+ * List all user-defined viewports for an API key.
+ * @param {import('better-sqlite3').Database} db
+ * @param {string} apiKey
+ * @returns {Array}
+ */
+export function listViewports(db, apiKey) {
+  return db.prepare(
+    'SELECT * FROM dsk_viewports WHERE api_key = ? ORDER BY created_at ASC'
+  ).all(apiKey);
+}
+
+/**
+ * Get a single viewport by name for an API key.
+ * @param {import('better-sqlite3').Database} db
+ * @param {string} apiKey
+ * @param {string} name
+ * @returns {object|null}
+ */
+export function getViewport(db, apiKey, name) {
+  return db.prepare(
+    'SELECT * FROM dsk_viewports WHERE api_key = ? AND name = ?'
+  ).get(apiKey, name) ?? null;
+}
+
+/**
+ * Create or update a viewport. Name is immutable once set (use delete + create to rename).
+ * @param {import('better-sqlite3').Database} db
+ * @param {string} apiKey
+ * @param {{ name: string, label?: string, viewportType?: string, width?: number, height?: number }} data
+ * @returns {object} the upserted row
+ */
+export function upsertViewport(db, apiKey, { name, label, viewportType, width, height }) {
+  db.prepare(`
+    INSERT INTO dsk_viewports (api_key, name, label, viewport_type, width, height, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, datetime('now'))
+    ON CONFLICT (api_key, name) DO UPDATE SET
+      label         = excluded.label,
+      viewport_type = excluded.viewport_type,
+      width         = excluded.width,
+      height        = excluded.height,
+      updated_at    = excluded.updated_at
+  `).run(
+    apiKey,
+    name,
+    label ?? null,
+    viewportType ?? 'landscape',
+    width ?? 1920,
+    height ?? 1080,
+  );
+  return getViewport(db, apiKey, name);
+}
+
+/**
+ * Delete a viewport by name.
+ * @param {import('better-sqlite3').Database} db
+ * @param {string} apiKey
+ * @param {string} name
+ * @returns {boolean} true if a row was deleted
+ */
+export function deleteViewport(db, apiKey, name) {
+  const result = db.prepare(
+    'DELETE FROM dsk_viewports WHERE api_key = ? AND name = ?'
+  ).run(apiKey, name);
+  return result.changes > 0;
+}

--- a/packages/plugins/lcyt-dsk/src/db/viewports.js
+++ b/packages/plugins/lcyt-dsk/src/db/viewports.js
@@ -29,19 +29,20 @@ export function getViewport(db, apiKey, name) {
  * Create or update a viewport. Name is immutable once set (use delete + create to rename).
  * @param {import('better-sqlite3').Database} db
  * @param {string} apiKey
- * @param {{ name: string, label?: string, viewportType?: string, width?: number, height?: number }} data
+ * @param {{ name: string, label?: string, viewportType?: string, width?: number, height?: number, textLayersJson?: string }} data
  * @returns {object} the upserted row
  */
-export function upsertViewport(db, apiKey, { name, label, viewportType, width, height }) {
+export function upsertViewport(db, apiKey, { name, label, viewportType, width, height, textLayersJson }) {
   db.prepare(`
-    INSERT INTO dsk_viewports (api_key, name, label, viewport_type, width, height, updated_at)
-    VALUES (?, ?, ?, ?, ?, ?, datetime('now'))
+    INSERT INTO dsk_viewports (api_key, name, label, viewport_type, width, height, text_layers_json, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))
     ON CONFLICT (api_key, name) DO UPDATE SET
-      label         = excluded.label,
-      viewport_type = excluded.viewport_type,
-      width         = excluded.width,
-      height        = excluded.height,
-      updated_at    = excluded.updated_at
+      label             = excluded.label,
+      viewport_type     = excluded.viewport_type,
+      width             = excluded.width,
+      height            = excluded.height,
+      text_layers_json  = excluded.text_layers_json,
+      updated_at        = excluded.updated_at
   `).run(
     apiKey,
     name,
@@ -49,6 +50,7 @@ export function upsertViewport(db, apiKey, { name, label, viewportType, width, h
     viewportType ?? 'landscape',
     width ?? 1920,
     height ?? 1080,
+    textLayersJson ?? null,
   );
   return getViewport(db, apiKey, name);
 }

--- a/packages/plugins/lcyt-dsk/src/renderer.js
+++ b/packages/plugins/lcyt-dsk/src/renderer.js
@@ -60,15 +60,20 @@ const _keys = new Map();
  *       type: "text" | "rect" | "image",
  *       x: number, y: number,    // px from top-left
  *       width: number, height: number,
- *       text: string,            // for type=text
+ *       text: string,            // for type=text (static content; overridden by binding)
+ *       binding: string,         // for type=text: code key (section, stanza, speaker…)
+ *                                //   element gets data-binding attr + auto-updates via SSE
  *       src: string,             // for type=image (URL or data-URI)
  *       style: { ...cssProps },  // arbitrary inline CSS
  *       animation: string,       // CSS animation shorthand
  *     }
  *   ]
  * }
+ *
+ * @param {object} templateJson
+ * @param {{ apiKey?: string, serverUrl?: string }} [opts]
  */
-export function renderTemplateToHtml(templateJson) {
+export function renderTemplateToHtml(templateJson, opts = {}) {
   const t = templateJson || {};
   const bg = t.background ?? 'transparent';
   const w  = t.width  ?? 1920;
@@ -93,7 +98,10 @@ export function renderTemplateToHtml(templateJson) {
     const style = [baseStyle, extraStyle].filter(Boolean).join(';');
 
     if (layer.type === 'text') {
-      return `<div${id} style="${style}">${escHtml(layer.text ?? '')}</div>`;
+      // When binding is set, add data-binding attr so the SSE subscriber can update the text.
+      const bindingAttr = layer.binding ? ` data-binding="${escHtml(layer.binding)}"` : '';
+      const content = layer.binding ? '' : escHtml(layer.text ?? '');
+      return `<div${id}${bindingAttr} style="${style}">${content}</div>`;
     } else if (layer.type === 'rect') {
       return `<div${id} style="${style}"></div>`;
     } else if (layer.type === 'ellipse') {
@@ -105,6 +113,13 @@ export function renderTemplateToHtml(templateJson) {
     }
     return '';
   }).join('\n    ');
+
+  // Inject SSE bindings subscriber when apiKey is provided and at least one bound text layer exists.
+  const hasBoundLayers = layers.some(l => l.type === 'text' && l.binding);
+  const { apiKey, serverUrl } = opts;
+  const sseScript = (hasBoundLayers && apiKey && serverUrl)
+    ? buildSseBindingsScript(serverUrl, apiKey)
+    : '';
 
   return `<!DOCTYPE html>
 <html>
@@ -139,9 +154,46 @@ export function renderTemplateToHtml(templateJson) {
 <div id="root">
   ${layerHtml}
 </div>
+${sseScript}
 </body>
 </html>`;
 }
+
+/**
+ * Build an inline SSE subscriber <script> that listens for 'bindings' events
+ * from GET {serverUrl}/dsk/{apiKey}/events and updates [data-binding] elements.
+ * Includes exponential-backoff reconnect (1 s → 30 s).
+ */
+function buildSseBindingsScript(serverUrl, apiKey) {
+  const url = `${serverUrl}/dsk/${encodeURIComponent(apiKey)}/events`;
+  return `<script>
+(function() {
+  var url = ${JSON.stringify(url)};
+  var delay = 1000;
+  function connect() {
+    var es = new EventSource(url);
+    es.addEventListener('bindings', function(e) {
+      try {
+        var codes = JSON.parse(e.data).codes;
+        if (!codes) return;
+        for (var key in codes) {
+          var els = document.querySelectorAll('[data-binding="' + key + '"]');
+          for (var i = 0; i < els.length; i++) {
+            els[i].textContent = codes[key] != null ? codes[key] : '';
+          }
+        }
+      } catch(ex) {}
+    });
+    es.onerror = function() {
+      es.close();
+      setTimeout(connect, delay);
+      delay = Math.min(delay * 2, 30000);
+    };
+    es.addEventListener('connected', function() { delay = 1000; });
+  }
+  connect();
+})();
+</script>`;
 
 function escHtml(s) {
   return String(s)
@@ -265,6 +317,11 @@ async function _getOrCreatePage(apiKey) {
 // Template management
 // ---------------------------------------------------------------------------
 
+// Local backend server URL for SSE bindings subscriber injected into Playwright pages.
+// Defaults to http://localhost:<PORT> so the headless page can reach the DSK events endpoint.
+const DSK_LOCAL_SERVER = process.env.DSK_LOCAL_SERVER
+  || `http://localhost:${process.env.PORT || 3000}`;
+
 /**
  * Render a new template for an API key.  Replaces the page content fully.
  * Any ongoing capture loop will pick up the new visuals automatically.
@@ -273,7 +330,7 @@ export async function updateTemplate(apiKey, templateJson) {
   _ensureBrowser();
   const state = await _getOrCreatePage(apiKey);
   state.templateJson = templateJson;
-  const html = renderTemplateToHtml(templateJson);
+  const html = renderTemplateToHtml(templateJson, { apiKey, serverUrl: DSK_LOCAL_SERVER });
   await state.page.setContent(html, { waitUntil: 'load' });
 }
 

--- a/packages/plugins/lcyt-dsk/src/routes/dsk-viewports.js
+++ b/packages/plugins/lcyt-dsk/src/routes/dsk-viewports.js
@@ -39,7 +39,7 @@ export function createDskViewportsRouter(db, auth) {
   // POST /dsk/:apikey/viewports
   router.post('/:apikey/viewports', auth, (req, res) => {
     if (!checkOwner(req, res, req.params.apikey)) return;
-    const { name, label, viewportType, width, height } = req.body ?? {};
+    const { name, label, viewportType, width, height, textLayers } = req.body ?? {};
 
     if (!name || !SLUG_RE.test(name)) {
       return res.status(400).json({ error: 'name must be a lowercase slug (letters, digits, hyphens, underscores)' });
@@ -59,7 +59,8 @@ export function createDskViewportsRouter(db, auth) {
       return res.status(409).json({ error: 'Viewport with this name already exists' });
     }
 
-    const row = upsertViewport(db, req.params.apikey, { name, label, viewportType: vt, width: w, height: h });
+    const textLayersJson = Array.isArray(textLayers) ? JSON.stringify(textLayers) : null;
+    const row = upsertViewport(db, req.params.apikey, { name, label, viewportType: vt, width: w, height: h, textLayersJson });
     res.status(201).json({ viewport: formatViewport(row) });
   });
 
@@ -70,18 +71,23 @@ export function createDskViewportsRouter(db, auth) {
     const existing = getViewport(db, req.params.apikey, name);
     if (!existing) return res.status(404).json({ error: 'Viewport not found' });
 
-    const { label, viewportType, width, height } = req.body ?? {};
+    const { label, viewportType, width, height, textLayers } = req.body ?? {};
     const vt = viewportType ?? existing.viewport_type;
     if (!['landscape', 'vertical'].includes(vt)) {
       return res.status(400).json({ error: 'viewportType must be landscape or vertical' });
     }
 
+    const textLayersJson = Array.isArray(textLayers)
+      ? JSON.stringify(textLayers)
+      : (textLayers === null ? null : existing.text_layers_json ?? null);
+
     const row = upsertViewport(db, req.params.apikey, {
       name,
-      label:        label        !== undefined ? label        : existing.label,
-      viewportType: vt,
-      width:        width        !== undefined ? (parseInt(width, 10)  || existing.width)  : existing.width,
-      height:       height       !== undefined ? (parseInt(height, 10) || existing.height) : existing.height,
+      label:           label        !== undefined ? label        : existing.label,
+      viewportType:    vt,
+      width:           width        !== undefined ? (parseInt(width, 10)  || existing.width)  : existing.width,
+      height:          height       !== undefined ? (parseInt(height, 10) || existing.height) : existing.height,
+      textLayersJson,
     });
     res.json({ viewport: formatViewport(row) });
   });
@@ -105,7 +111,13 @@ function formatViewport(row) {
     viewportType: row.viewport_type,
     width:        row.width,
     height:       row.height,
+    textLayers:   parseJsonArray(row.text_layers_json),
     createdAt:    row.created_at,
     updatedAt:    row.updated_at,
   };
+}
+
+function parseJsonArray(str) {
+  if (!str) return [];
+  try { return JSON.parse(str); } catch { return []; }
 }

--- a/packages/plugins/lcyt-dsk/src/routes/dsk-viewports.js
+++ b/packages/plugins/lcyt-dsk/src/routes/dsk-viewports.js
@@ -1,0 +1,111 @@
+/**
+ * Authenticated viewport management endpoints.
+ *
+ * All routes require a valid JWT Bearer token.
+ * The API key comes from req.session.apiKey set by the auth middleware.
+ *
+ * GET    /dsk/:apikey/viewports           — list user-defined viewports
+ * POST   /dsk/:apikey/viewports           — create viewport
+ * PUT    /dsk/:apikey/viewports/:name     — update viewport label/type/dimensions
+ * DELETE /dsk/:apikey/viewports/:name     — delete viewport
+ *
+ * @param {import('better-sqlite3').Database} db
+ * @param {import('express').RequestHandler} auth
+ */
+import { Router } from 'express';
+import { listViewports, getViewport, upsertViewport, deleteViewport } from '../db/viewports.js';
+
+// Viewport name must be a lowercase slug (letters, digits, hyphens, underscores)
+const SLUG_RE = /^[a-z0-9][a-z0-9_-]{0,62}$/;
+
+export function createDskViewportsRouter(db, auth) {
+  const router = Router();
+
+  function checkOwner(req, res, paramKey) {
+    if (req.session.apiKey !== paramKey) {
+      res.status(403).json({ error: 'Forbidden' });
+      return false;
+    }
+    return true;
+  }
+
+  // GET /dsk/:apikey/viewports
+  router.get('/:apikey/viewports', auth, (req, res) => {
+    if (!checkOwner(req, res, req.params.apikey)) return;
+    const rows = listViewports(db, req.params.apikey);
+    res.json({ viewports: rows.map(formatViewport) });
+  });
+
+  // POST /dsk/:apikey/viewports
+  router.post('/:apikey/viewports', auth, (req, res) => {
+    if (!checkOwner(req, res, req.params.apikey)) return;
+    const { name, label, viewportType, width, height } = req.body ?? {};
+
+    if (!name || !SLUG_RE.test(name)) {
+      return res.status(400).json({ error: 'name must be a lowercase slug (letters, digits, hyphens, underscores)' });
+    }
+    if (name === 'public') {
+      return res.status(400).json({ error: 'Reserved viewport name' });
+    }
+    const vt = viewportType ?? 'landscape';
+    if (!['landscape', 'vertical'].includes(vt)) {
+      return res.status(400).json({ error: 'viewportType must be landscape or vertical' });
+    }
+    const w = parseInt(width, 10) || (vt === 'vertical' ? 1080 : 1920);
+    const h = parseInt(height, 10) || (vt === 'vertical' ? 1920 : 1080);
+
+    const existing = getViewport(db, req.params.apikey, name);
+    if (existing) {
+      return res.status(409).json({ error: 'Viewport with this name already exists' });
+    }
+
+    const row = upsertViewport(db, req.params.apikey, { name, label, viewportType: vt, width: w, height: h });
+    res.status(201).json({ viewport: formatViewport(row) });
+  });
+
+  // PUT /dsk/:apikey/viewports/:name
+  router.put('/:apikey/viewports/:name', auth, (req, res) => {
+    if (!checkOwner(req, res, req.params.apikey)) return;
+    const { name } = req.params;
+    const existing = getViewport(db, req.params.apikey, name);
+    if (!existing) return res.status(404).json({ error: 'Viewport not found' });
+
+    const { label, viewportType, width, height } = req.body ?? {};
+    const vt = viewportType ?? existing.viewport_type;
+    if (!['landscape', 'vertical'].includes(vt)) {
+      return res.status(400).json({ error: 'viewportType must be landscape or vertical' });
+    }
+
+    const row = upsertViewport(db, req.params.apikey, {
+      name,
+      label:        label        !== undefined ? label        : existing.label,
+      viewportType: vt,
+      width:        width        !== undefined ? (parseInt(width, 10)  || existing.width)  : existing.width,
+      height:       height       !== undefined ? (parseInt(height, 10) || existing.height) : existing.height,
+    });
+    res.json({ viewport: formatViewport(row) });
+  });
+
+  // DELETE /dsk/:apikey/viewports/:name
+  router.delete('/:apikey/viewports/:name', auth, (req, res) => {
+    if (!checkOwner(req, res, req.params.apikey)) return;
+    const deleted = deleteViewport(db, req.params.apikey, req.params.name);
+    if (!deleted) return res.status(404).json({ error: 'Viewport not found' });
+    res.json({ ok: true });
+  });
+
+  return router;
+}
+
+function formatViewport(row) {
+  return {
+    id:           row.id,
+    name:         row.name,
+    label:        row.label ?? null,
+    viewportType: row.viewport_type,
+    width:        row.width,
+    height:       row.height,
+    createdAt:    row.created_at,
+    updatedAt:    row.updated_at,
+  };
+}

--- a/packages/plugins/lcyt-dsk/src/routes/dsk.js
+++ b/packages/plugins/lcyt-dsk/src/routes/dsk.js
@@ -64,6 +64,7 @@ export function createDskRouter(db, store) {
         viewportType: r.viewport_type,
         width:        r.width,
         height:       r.height,
+        textLayers:   parseJson(r.text_layers_json, []),
       })),
     });
   });
@@ -101,7 +102,7 @@ export function createDskRouter(db, store) {
   return router;
 }
 
-function parseJson(str) {
-  if (!str) return {};
-  try { return JSON.parse(str); } catch { return {}; }
+function parseJson(str, fallback = {}) {
+  if (!str) return fallback;
+  try { return JSON.parse(str); } catch { return fallback; }
 }

--- a/packages/plugins/lcyt-dsk/src/routes/dsk.js
+++ b/packages/plugins/lcyt-dsk/src/routes/dsk.js
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { listImages } from '../db/images.js';
+import { listViewports } from '../db/viewports.js';
 
 /**
  * Factory for the /dsk router.
@@ -28,20 +29,43 @@ export function createDskRouter(db, store) {
   }
 
   // GET /dsk/:apikey/images — list images for pre-loading (public)
+  // Includes settingsJson (per-viewport visibility/position/animation) so the
+  // display page has everything it needs in a single fetch.
   router.get('/:apikey/images', (req, res) => {
     const { apikey } = req.params;
     if (!resolveKey(apikey, res)) return;
 
     const rows = listImages(db, apikey);
     const images = rows.map(r => ({
-      id: r.id,
-      shorthand: r.shorthand,
-      mimeType: r.mime_type,
+      id:           r.id,
+      shorthand:    r.shorthand,
+      mimeType:     r.mime_type,
+      settingsJson: parseJson(r.settings_json),
       // The DSK page fetches image bytes from /images/:id (public endpoint)
       url: `/images/${r.id}`,
     }));
     res.set('Cache-Control', 'no-store');
     res.json({ images });
+  });
+
+  // GET /dsk/:apikey/viewports/public — list user-defined viewports without auth (public)
+  // Used by display pages to fetch viewport dimensions on load.
+  // NOTE: this route must be declared before the /:apikey/events route so Express
+  // doesn't interpret "viewports" as an apikey.
+  router.get('/:apikey/viewports/public', (req, res) => {
+    const { apikey } = req.params;
+    if (!resolveKey(apikey, res)) return;
+    const rows = listViewports(db, apikey);
+    res.set('Cache-Control', 'no-store');
+    res.json({
+      viewports: rows.map(r => ({
+        name:         r.name,
+        label:        r.label ?? null,
+        viewportType: r.viewport_type,
+        width:        r.width,
+        height:       r.height,
+      })),
+    });
   });
 
   // GET /dsk/:apikey/events — SSE stream (public)
@@ -75,4 +99,9 @@ export function createDskRouter(db, store) {
   });
 
   return router;
+}
+
+function parseJson(str) {
+  if (!str) return {};
+  try { return JSON.parse(str); } catch { return {}; }
 }

--- a/packages/plugins/lcyt-dsk/src/routes/images.js
+++ b/packages/plugins/lcyt-dsk/src/routes/images.js
@@ -13,6 +13,7 @@ import {
   getTotalImageStorageBytes,
   isShorthandTaken,
   safeApiKey,
+  updateImageSettings,
 } from '../db/images.js';
 
 const GRAPHICS_BASE_DIR = resolve(process.env.GRAPHICS_DIR || '/data/images');
@@ -225,14 +226,37 @@ export function createImagesRouter(db, auth) {
 
     const rows = listImages(db, apiKey);
     const images = rows.map(r => ({
-      id: r.id,
-      shorthand: r.shorthand,
-      filename: r.filename,
-      mimeType: r.mime_type,
-      sizeBytes: r.size_bytes,
-      createdAt: r.created_at,
+      id:          r.id,
+      shorthand:   r.shorthand,
+      filename:    r.filename,
+      mimeType:    r.mime_type,
+      sizeBytes:   r.size_bytes,
+      settingsJson: parseSettingsJson(r.settings_json),
+      createdAt:   r.created_at,
     }));
     return res.json({ images });
+  });
+
+  // PUT /images/:id — update per-viewport settings (auth required)
+  router.put('/:id', auth, (req, res) => {
+    const apiKey = req.session.apiKey;
+    if (!apiKey) return res.status(401).json({ error: 'Unauthorized' });
+
+    const id = parseInt(req.params.id, 10);
+    if (isNaN(id)) return res.status(400).json({ error: 'Invalid image id' });
+
+    const { settingsJson } = req.body ?? {};
+    if (settingsJson === undefined) {
+      return res.status(400).json({ error: 'settingsJson is required' });
+    }
+    if (typeof settingsJson !== 'object' || settingsJson === null) {
+      return res.status(400).json({ error: 'settingsJson must be an object' });
+    }
+
+    const updated = updateImageSettings(db, id, apiKey, settingsJson);
+    if (!updated) return res.status(404).json({ error: 'Image not found' });
+
+    return res.json({ ok: true, settingsJson });
   });
 
   // GET /images/:id — serve image publicly (no auth — for DSK page pre-loading)
@@ -283,4 +307,9 @@ export function createImagesRouter(db, auth) {
   });
 
   return router;
+}
+
+function parseSettingsJson(str) {
+  if (!str) return {};
+  try { return JSON.parse(str); } catch { return {}; }
 }


### PR DESCRIPTION
feat(dsk): landscape aliases, delta graphics, and metacode text containers

## Feature 1: Landscape viewport aliases
- caption-processor.js: normalize landscape/default/main metacode targets to 'landscape' key
- DskPage.jsx: resolveActiveNames() checks viewports.landscape/default/main before payload.default
- DskViewportsPage.jsx: show alias note in built-in landscape card

## Feature 2: Additive/subtractive graphics (+/- prefix)
- caption-processor.js: parseSection() detects delta mode (+/-), applySection() applies add/remove
- store.js: _dskGraphicsState Map + getDskGraphicsState/setDskGraphicsState methods
- captions.js: pass caption.codes to dskProcessor call

## Feature 3: Metacode text containers (bindings)
- db.js: additive text_layers_json TEXT column on dsk_viewports
- db/viewports.js: upsertViewport includes textLayersJson in INSERT/UPDATE
- routes/dsk-viewports.js: POST/PUT accept textLayers[], GET returns textLayers; formatViewport includes textLayers
- routes/dsk.js: public viewports endpoint includes textLayers; parseJson() accepts default value
- DskPage.jsx: subscribe to 'bindings' SSE event, render text layer divs with live bindings values
- DskViewportsPage.jsx: TextLayersEditor with add/remove/configure layers, mini-canvas preview, save via PUT
- DskEditorPage.jsx: binding field in text layer properties panel; canvas shows ⟳binding placeholder
- renderer.js: data-binding attr on bound text layers; inject SSE subscriber <script> for Playwright pages

https://claude.ai/code/session_01HprXfiabCer4SczQj65n8R