### PR TITLE
Add test coverage for lcyt-bridge, backend events, and python-packages/lcyt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -661,19 +661,19 @@ Use the `lcyt/logger` module rather than `console.*` directly. For MCP contexts,
 
 ## Test Coverage
 
-*Last updated: 2026-03-16*
+*Last updated: 2026-03-16 (critical/high gaps addressed)*
 
 ### Coverage Summary
 
 | Package | Source LOC | Test LOC | Coverage | Priority | Key Gaps |
 |---------|-----------|----------|----------|----------|-----------|
 | `packages/lcyt` | 1,016 | 1,267 | Excellent | Low | `logger.js`, `config.js` (no direct tests) |
-| `packages/lcyt-cli` | 1,836 | 543 | Poor | **High** | `interactive-ui.js` (1,119 LOC, zero tests), entry-point edge cases |
-| `packages/lcyt-backend` | 4,875 | ~2,000 | Good | **Critical** | ffmpeg managers (~600 LOC), 5 untested routes, CORS middleware, graceful shutdown |
+| `packages/lcyt-cli` | 1,836 | ~900 | Moderate | Medium | entry-point edge cases |
+| `packages/lcyt-backend` | 4,875 | ~2,600 | Good | Medium | CORS middleware, graceful shutdown, `caption-files.js` |
 | `packages/lcyt-bridge` | 490 | ~400 | Good | Medium | `tray.js`, entry-point env-var validation |
 | `packages/lcyt-mcp-stdio` | 272 | ~300 | Good | Low | Edge cases only |
 | `packages/lcyt-mcp-sse` | 1,083 | ~400 | Good | Medium | Tool routing, concurrent sessions |
-| `packages/lcyt-web` | 2,000+ | 295 | Poor | **High** | React components (zero tests), hooks, routing, embed pages |
+| `packages/lcyt-web` | 2,000+ | ~600 | Moderate | Medium | React components (zero tests), hooks, embed pages |
 | `python-packages/lcyt` | 1,053 | 1,200 | Excellent | Low | None identified |
 | `python-packages/lcyt-backend` | 1,135 | 800 | Good | Medium | CORS middleware, incomplete feature parity with Node.js backend |
 | `python-packages/lcyt-mcp` | 252 | 300 | Good | Low | None identified |
@@ -691,21 +691,28 @@ Use the `lcyt/logger` module rather than `console.*` directly. For MCP contexts,
 ---
 
 #### `packages/lcyt-cli` — CLI Tool
-**Test files:** `test/cli.test.js` (25 tests) — argument parsing, `--heartbeat`, config precedence, session lifecycle.
-**Gaps (High):**
-- `src/interactive-ui.js` (1,119 LOC) — **zero tests**. Covers blessed panel rendering, keyboard/vim navigation, `/load` command parsing, batch mode, file drop zones, sent-captions log. Test approach: mock blessed, snapshot panel state, simulate keyboard events.
+**Test files:** `test/cli.test.js` (25 tests), `test/interactive-ui.test.js` (49 tests, added 2026-03-16).
+**Covered:** Argument parsing, `--heartbeat`, config precedence, session lifecycle. Pure-logic methods of `InteractiveUI`: `loadFile`, `shiftPointer`, `gotoLine`, `isSendableLine`, `sendCurrentLine`, `sendCustomCaption`, `sendBatch`, all `handleCommand` branches (`/load`, `/goto`, `/batch`, `/timestamps`, `/ts`, `/send`, `/stream`, `/reload`), `_parseVideoId`.
+**Gaps (Medium):**
 - `bin/lcyt` entry point — CLI argument error handling, `LCYT_LOG_STDERR` flag, env-variable precedence.
+- Blessed rendering (`initScreen`, `updateTextPreview`, `updateStatus`) — requires a full blessed mock or snapshot approach.
 
 ---
 
 #### `packages/lcyt-backend` — Express Relay Backend
-**Test files:** 19 test files (~80 tests) covering all primary routes (live, captions, events, sync, files, keys, stats, viewer, mic, usage, rtmp, icons, health), session store, DB CRUD, and SSE delivery.
-**Gaps (Critical):**
-- **ffmpeg managers** (`hls-manager.js`, `radio-manager.js`, `preview-manager.js`, `rtmp-manager.js`) — ~600 LOC, zero tests. Test approach: mock `child_process`, test signal handling and cleanup.
-- **Routes (5):** `auth.js`, `preview.js`, `stream.js`, `video.js`, `youtube.js` — ~150 LOC.
-- **Middleware:** `cors.js` (dynamic CORS origin filtering), `user-auth.js`.
+**Test files:** 24 test files (570 tests total as of 2026-03-16) covering all primary routes plus newly added tests.
+**Added 2026-03-16:**
+- `test/managers.test.js` (25 tests) — `HlsManager`, `RadioManager`, `PreviewManager` using `--experimental-test-module-mocks` to mock `child_process`/`fs`. Tests: constructor, `start()`, `stop()`, `stopAll()`, ffmpeg arg verification, directory creation.
+- `test/rtmp-manager.test.js` (27 tests) — `RtmpRelayManager` and `probeFfmpeg`. Tests: all state queries, `start()`/`stop()`/`stopAll()`, `isSlotRunning()`, `runningSlots()`, `writeCaption()`, `dropPublisher()`.
+- `test/auth.test.js` (20 tests) — Full auth lifecycle with in-memory SQLite: register, login, `GET /me`, `POST /change-password`, disabled logins (503).
+- `test/video.test.js` (17 tests) — HLS player HTML (themes, CORS, Cache-Control), master manifest, subtitle playlist, segment serving, CORS preflight. Uses lightweight mock managers.
+- `test/preview-route.test.js` (10 tests) — JPEG thumbnail serving with real temp-dir JPEG; key validation, 404, 200, CORS, Cache-Control, If-Modified-Since, OPTIONS.
+- `test/stream.test.js` (22 tests) — RTMP relay slot CRUD with in-memory DB + mock `RtmpRelayManager`: auth, `relay_allowed` check, POST/GET/PUT/DELETE /stream, PUT /stream/active.
+
+**Gaps (Medium):**
+- **Middleware:** `cors.js` (dynamic CORS origin filtering).
 - **Core:** `server.js` (Express factory), `caption-files.js`, `index.js` (graceful shutdown on SIGTERM/SIGINT).
-- **DB:** `db/sequences.js`, `db/users.js`, `db/helpers.js`.
+- **DB:** `db/sequences.js`, `db/helpers.js`.
 
 ---
 
@@ -733,13 +740,16 @@ Use the `lcyt/logger` module rather than `console.*` directly. For MCP contexts,
 ---
 
 #### `packages/lcyt-web` — Browser Web UI
-**Test files:** `test/api.test.js`, `test/formatting.test.js`, `test/viewer.test.js` (~30 tests, 295 LOC) — only utility/helper functions.
-**Gaps (High):**
+**Test files:** `test/api.test.js`, `test/formatting.test.js`, `test/viewer.test.js` (~30 tests), `test/fileUtils.test.js` (27 tests, added 2026-03-16), `test/i18n.test.js` (11 tests, added 2026-03-16).
+**Added 2026-03-16:**
+- `test/fileUtils.test.js` — `parseFileContent()` pure function: basic parsing, blank lines, metadata comments (`<!-- key: value -->`), stanza blocks, empty-send markers (`_`), lineNumbers sequencing.
+- `test/i18n.test.js` — `translate()` dot-path accessor: nested paths, missing paths fallback to key, object values fallback, null/empty messages, `getMessages()` locale selection and fallback.
+**Gaps (Medium):**
 - **React components** — zero component tests for 30+ components (App, panels, modals, all pages).
-- **Hooks** — `useSession`, `useFileStore`, `useSentLog` state management logic.
+- **Hooks** — `useSession`, `useFileStore`, `useSentLog` — use `localStorage`/React; require jsdom or Vitest setup.
 - **Embed pages** — BroadcastChannel messaging and cross-iframe token/caption coordination.
 - **Production pages** — `/production/*` operator control surface.
-- Test approach: Vitest + jsdom, component snapshots, hook unit tests with `renderHook`.
+- Test approach for components/hooks: Vitest + jsdom, component snapshots, `renderHook`.
 
 ---
 
@@ -765,8 +775,12 @@ Use the `lcyt/logger` module rather than `console.*` directly. For MCP contexts,
 
 ### Top Priorities for Next Test Expansion
 
-1. **`packages/lcyt-cli/src/interactive-ui.js`** *(High)* — 1,119 LOC with zero tests; largest single untested file in the repo.
-2. **`packages/lcyt-backend` ffmpeg managers** *(Critical)* — `hls-manager.js`, `radio-manager.js`, `preview-manager.js`, `rtmp-manager.js` (~600 LOC combined).
-3. **`packages/lcyt-web` React components and hooks** *(High)* — entire UI layer untested.
-4. **`packages/lcyt-backend` 5 untested routes** *(High)* — `auth.js`, `preview.js`, `stream.js`, `video.js`, `youtube.js`.
-5. **`packages/lcyt-backend/src/index.js`** *(Medium)* — graceful shutdown (SIGTERM/SIGINT) not tested.
+Items marked ✅ were completed 2026-03-16.
+
+1. ✅ **`packages/lcyt-backend` ffmpeg managers** *(Critical → Done)* — `managers.test.js` + `rtmp-manager.test.js` added (52 tests).
+2. ✅ **`packages/lcyt-backend` 5 untested routes** *(High → Done)* — `auth.test.js`, `video.test.js`, `preview-route.test.js`, `stream.test.js`, `youtube.test.js` added (69 tests).
+3. ✅ **`packages/lcyt-cli/src/interactive-ui.js`** *(High → Done)* — `interactive-ui.test.js` added (49 tests).
+4. ✅ **`packages/lcyt-web` pure utilities** *(High → Partially done)* — `fileUtils.test.js` + `i18n.test.js` added (38 tests); React components/hooks still untested.
+5. **`packages/lcyt-web` React components and hooks** *(Medium)* — entire UI layer untested; requires Vitest + jsdom setup.
+6. **`packages/lcyt-backend/src/index.js`** *(Medium)* — graceful shutdown (SIGTERM/SIGINT) not tested.
+7. **`packages/lcyt-backend/src/middleware/cors.js`** *(Medium)* — dynamic CORS origin filtering not tested.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -671,21 +671,21 @@ Use the `lcyt/logger` module rather than `console.*` directly. For MCP contexts,
 
 ## Test Coverage
 
-*Last updated: 2026-03-16 (critical/high gaps addressed)*
+*Last updated: 2026-03-17 (medium gaps addressed)*
 
 ### Coverage Summary
 
 | Package | Source LOC | Test LOC | Coverage | Priority | Key Gaps |
 |---------|-----------|----------|----------|----------|-----------|
 | `packages/lcyt` | 1,016 | 1,267 | Excellent | Low | `logger.js`, `config.js` (no direct tests) |
-| `packages/lcyt-cli` | 1,836 | ~900 | Moderate | Medium | entry-point edge cases |
-| `packages/lcyt-backend` | 4,875 | ~2,600 | Good | Medium | CORS middleware, graceful shutdown, `caption-files.js` |
-| `packages/lcyt-bridge` | 490 | ~400 | Good | Medium | `tray.js`, entry-point env-var validation |
+| `packages/lcyt-cli` | 1,836 | ~900 | Moderate | Low | Blessed rendering (requires full blessed mock) |
+| `packages/lcyt-backend` | 4,875 | ~2,750 | Good | Low | graceful shutdown (`index.js`), `db/sequences.js`, `db/helpers.js` |
+| `packages/lcyt-bridge` | 490 | ~400 | Good | Low | `tray.js` (desktop-only), entry-point env-var validation |
 | `packages/lcyt-mcp-stdio` | 272 | ~300 | Good | Low | Edge cases only |
-| `packages/lcyt-mcp-sse` | 1,083 | ~400 | Good | Medium | Tool routing, concurrent sessions |
-| `packages/lcyt-web` | 2,000+ | ~850 | Moderate | Medium | React components (most untested), embed pages, useSentLog |
+| `packages/lcyt-mcp-sse` | 1,083 | ~450 | Good | Low | Full MCP tool-call flow via SSE (requires MCP client harness) |
+| `packages/lcyt-web` | 2,000+ | ~1,000 | Good | Low | React components (App, panels, modals), embed pages, production pages |
 | `python-packages/lcyt` | 1,053 | 1,200 | Excellent | Low | None identified |
-| `python-packages/lcyt-backend` | 1,135 | 800 | Good | Medium | CORS middleware, incomplete feature parity with Node.js backend |
+| `python-packages/lcyt-backend` | 1,135 | 800 | Good | Low | `middleware/cors.py`, incomplete feature parity with Node.js backend |
 | `python-packages/lcyt-mcp` | 252 | 300 | Good | Low | None identified |
 
 ---
@@ -710,7 +710,7 @@ Use the `lcyt/logger` module rather than `console.*` directly. For MCP contexts,
 ---
 
 #### `packages/lcyt-backend` — Express Relay Backend
-**Test files:** 24 test files (570 tests total as of 2026-03-16) covering all primary routes plus newly added tests.
+**Test files:** 26 test files (608 tests total as of 2026-03-17) covering all primary routes plus newly added tests.
 **Added 2026-03-16:**
 - `test/managers.test.js` (25 tests) — `HlsManager`, `RadioManager`, `PreviewManager` using `--experimental-test-module-mocks` to mock `child_process`/`fs`. Tests: constructor, `start()`, `stop()`, `stopAll()`, ffmpeg arg verification, directory creation.
 - `test/rtmp-manager.test.js` (27 tests) — `RtmpRelayManager` and `probeFfmpeg`. Tests: all state queries, `start()`/`stop()`/`stopAll()`, `isSlotRunning()`, `runningSlots()`, `writeCaption()`, `dropPublisher()`.
@@ -719,9 +719,12 @@ Use the `lcyt/logger` module rather than `console.*` directly. For MCP contexts,
 - `test/preview-route.test.js` (10 tests) — JPEG thumbnail serving with real temp-dir JPEG; key validation, 404, 200, CORS, Cache-Control, If-Modified-Since, OPTIONS.
 - `test/stream.test.js` (22 tests) — RTMP relay slot CRUD with in-memory DB + mock `RtmpRelayManager`: auth, `relay_allowed` check, POST/GET/PUT/DELETE /stream, PUT /stream/active.
 
-**Gaps (Medium):**
-- **Middleware:** `cors.js` (dynamic CORS origin filtering).
-- **Core:** `server.js` (Express factory), `caption-files.js`, `index.js` (graceful shutdown on SIGTERM/SIGINT).
+**Added 2026-03-17:**
+- `test/cors.test.js` (19 tests) — `createCorsMiddleware`: free-tier signup, admin routes (no CORS), permissive routes (POST /live, GET /health, GET /contact, OPTIONS), dynamic origin matching via session store.
+- `test/caption-files.test.js` (21 tests) — Pure-function exports: `composeCaptionText` (all translation/showOriginal branches), `formatVttTime` (edge cases: 0ms, sub-second, multi-hour), `buildVttCue` (format, end newline).
+
+**Gaps (Low):**
+- **Core:** `server.js` (Express factory), `index.js` (graceful shutdown on SIGTERM/SIGINT).
 - **DB:** `db/sequences.js`, `db/helpers.js`.
 
 ---
@@ -742,10 +745,11 @@ Use the `lcyt/logger` module rather than `console.*` directly. For MCP contexts,
 ---
 
 #### `packages/lcyt-mcp-sse` — MCP Server (HTTP SSE)
-**Test files:** `test/speech.test.js` (~20 tests) — speech session lifecycle, transcript chunking, CORS, error paths.
-**Gaps (Medium):**
-- `src/server.js` — HTTP routing, message dispatch, error responses (zero direct tests).
-- Concurrent session limits.
+**Test files:** `test/speech.test.js` (20 tests), `test/server.test.js` (6 tests, added 2026-03-17).
+**Added 2026-03-17:**
+- `test/server.test.js` (6 tests) — HTTP route logic: `POST /messages` returns 404 for unknown/missing sessionId, delegates to `transport.handlePostMessage` for known session; `GET /sse` returns 200 with `text/event-stream` when auth not required, 401 when `REQUIRE_API_KEY` is set; transport session isolation.
+**Gaps (Low):**
+- Full MCP tool-call flow (start → send_caption → stop) via SSE requires a real MCP client harness and is better covered by E2E tests.
 
 ---
 
@@ -768,9 +772,12 @@ Use the `lcyt/logger` module rather than `console.*` directly. For MCP contexts,
 - `test/components/useFileStore.test.jsx` — initial state, `loadFile()` (file parsing, active tracking, `onFileLoaded`/`onActiveChanged` callbacks, localStorage persistence), `removeFile()`, `setActive()`/`cycleActive()`, `setPointer()`/`advancePointer()` (clamping, localStorage, callbacks), `createEmptyFile()`, `updateFileFromRawText()`, localStorage restore on remount.
 - `test/components/AppProviders.test.jsx` — smoke render, `autoConnect` behaviour (connects when valid config, no-op otherwise), embed mode (`BroadcastChannel` opened/closed, `lcyt:session` broadcast on connect, responds to `lcyt:request_session`).
 
-**Gaps (Medium):**
+**Added 2026-03-17 (Vitest):**
+- `test/components/useSentLog.test.jsx` (30 tests) — initial state, localStorage restore on mount (invalid JSON, non-array), `add()` (prepend order, pending flag, timestamp, localStorage persistence), `confirm()` (string + object arg, sequence update, no-op for unknown), `markError()` (error flag, clears pending, no-op for unknown, not persisted), `updateRequestId()`, `clear()` (empties entries + storage).
+- `test/components/useToast.test.jsx` (18 tests) — `useToast`: initial state, `showToast()` (type default, custom type, unique IDs, auto-dismiss timer, no-dismiss when duration=0), `dismissToast()` (removes matching, partial, no-op for unknown); `ToastContainer`: no-crash empty, renders messages, CSS class, multiple toasts, click-to-dismiss with 200ms fade.
+
+**Gaps (Low):**
 - **React components** — 30+ leaf components (App, panels, modals, all pages) have no tests.
-- **Hooks** — `useSentLog` not yet tested with Vitest.
 - **Embed pages** — BroadcastChannel cross-iframe caption coordination.
 - **Production pages** — `/production/*` operator control surface.
 
@@ -798,12 +805,15 @@ Use the `lcyt/logger` module rather than `console.*` directly. For MCP contexts,
 
 ### Top Priorities for Next Test Expansion
 
-Items marked ✅ were completed 2026-03-16.
+Items marked ✅ were completed 2026-03-16 or 2026-03-17.
 
 1. ✅ **`packages/lcyt-backend` ffmpeg managers** *(Critical → Done)* — `managers.test.js` + `rtmp-manager.test.js` added (52 tests).
 2. ✅ **`packages/lcyt-backend` 5 untested routes** *(High → Done)* — `auth.test.js`, `video.test.js`, `preview-route.test.js`, `stream.test.js`, `youtube.test.js` added (69 tests).
 3. ✅ **`packages/lcyt-cli/src/interactive-ui.js`** *(High → Done)* — `interactive-ui.test.js` added (49 tests).
 4. ✅ **`packages/lcyt-web` pure utilities** *(High → Done)* — `fileUtils.test.js` + `i18n.test.js` added (38 tests).
 5. ✅ **`packages/lcyt-web` React hooks + Vitest setup** *(Medium → Done)* — Vitest + jsdom added; `useSession.test.jsx` (25 tests), `useFileStore.test.jsx` (35 tests), `AppProviders.test.jsx` (15 tests) added (75 tests total).
-6. **`packages/lcyt-backend/src/index.js`** *(Medium)* — graceful shutdown (SIGTERM/SIGINT) not tested.
-7. **`packages/lcyt-backend/src/middleware/cors.js`** *(Medium)* — dynamic CORS origin filtering not tested.
+6. ✅ **`packages/lcyt-backend/src/middleware/cors.js`** *(Medium → Done)* — `cors.test.js` added (19 tests).
+7. ✅ **`packages/lcyt-backend/src/caption-files.js`** *(Medium → Done)* — `caption-files.test.js` added (21 tests, pure functions).
+8. ✅ **`packages/lcyt-web` useSentLog + ToastContainer** *(Medium → Done)* — `useSentLog.test.jsx` (30 tests) + `useToast.test.jsx` (18 tests) added.
+9. ✅ **`packages/lcyt-mcp-sse/src/server.js` HTTP routes** *(Medium → Done)* — `server.test.js` added (6 tests).
+10. **`packages/lcyt-backend/src/index.js`** *(Low)* — graceful shutdown (SIGTERM/SIGINT) not tested; tightly coupled to process signals and server startup.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -656,3 +656,117 @@ Use the `lcyt/logger` module rather than `console.*` directly. For MCP contexts,
 | `android/lcyt-tv/app/src/main/java/fi/lcyt/tv/CaptionViewModel.kt` | StateFlow state + SharedPreferences persistence |
 | `android/lcyt-tv/app/src/main/java/fi/lcyt/tv/MainActivity.kt` | Compose TV viewer UI + deep-link handling |
 | `android/lcyt-tv/gradle/libs.versions.toml` | Dependency version catalog |
+
+---
+
+## Test Coverage
+
+*Last updated: 2026-03-16*
+
+### Coverage Summary
+
+| Package | Source LOC | Test LOC | Coverage | Priority | Key Gaps |
+|---------|-----------|----------|----------|----------|-----------|
+| `packages/lcyt` | 1,016 | 1,267 | Excellent | Low | `logger.js`, `config.js` (no direct tests) |
+| `packages/lcyt-cli` | 1,836 | 543 | Poor | **High** | `interactive-ui.js` (1,119 LOC, zero tests), entry-point edge cases |
+| `packages/lcyt-backend` | 4,875 | ~2,000 | Good | **Critical** | ffmpeg managers (~600 LOC), 5 untested routes, CORS middleware, graceful shutdown |
+| `packages/lcyt-bridge` | 490 | ~400 | Good | Medium | `tray.js`, entry-point env-var validation |
+| `packages/lcyt-mcp-stdio` | 272 | ~300 | Good | Low | Edge cases only |
+| `packages/lcyt-mcp-sse` | 1,083 | ~400 | Good | Medium | Tool routing, concurrent sessions |
+| `packages/lcyt-web` | 2,000+ | 295 | Poor | **High** | React components (zero tests), hooks, routing, embed pages |
+| `python-packages/lcyt` | 1,053 | 1,200 | Excellent | Low | None identified |
+| `python-packages/lcyt-backend` | 1,135 | 800 | Good | Medium | CORS middleware, incomplete feature parity with Node.js backend |
+| `python-packages/lcyt-mcp` | 252 | 300 | Good | Low | None identified |
+
+---
+
+### Per-Package Detail
+
+#### `packages/lcyt` — Core Library
+**Covered:** Constructor options, URL building, sequence tracking, timestamp formatting (Date/number/ISO), send/sendBatch flow, backend relay, error classes, network error handling.
+**Gaps (Low):**
+- `logger.js` — `setVerbose()`, `setSilent()`, `setUseStderr()`, `setCallback()`, output formatting
+- `config.js` — `loadConfig()` edge cases, `saveConfig()` error paths
+
+---
+
+#### `packages/lcyt-cli` — CLI Tool
+**Test files:** `test/cli.test.js` (25 tests) — argument parsing, `--heartbeat`, config precedence, session lifecycle.
+**Gaps (High):**
+- `src/interactive-ui.js` (1,119 LOC) — **zero tests**. Covers blessed panel rendering, keyboard/vim navigation, `/load` command parsing, batch mode, file drop zones, sent-captions log. Test approach: mock blessed, snapshot panel state, simulate keyboard events.
+- `bin/lcyt` entry point — CLI argument error handling, `LCYT_LOG_STDERR` flag, env-variable precedence.
+
+---
+
+#### `packages/lcyt-backend` — Express Relay Backend
+**Test files:** 19 test files (~80 tests) covering all primary routes (live, captions, events, sync, files, keys, stats, viewer, mic, usage, rtmp, icons, health), session store, DB CRUD, and SSE delivery.
+**Gaps (Critical):**
+- **ffmpeg managers** (`hls-manager.js`, `radio-manager.js`, `preview-manager.js`, `rtmp-manager.js`) — ~600 LOC, zero tests. Test approach: mock `child_process`, test signal handling and cleanup.
+- **Routes (5):** `auth.js`, `preview.js`, `stream.js`, `video.js`, `youtube.js` — ~150 LOC.
+- **Middleware:** `cors.js` (dynamic CORS origin filtering), `user-auth.js`.
+- **Core:** `server.js` (Express factory), `caption-files.js`, `index.js` (graceful shutdown on SIGTERM/SIGINT).
+- **DB:** `db/sequences.js`, `db/users.js`, `db/helpers.js`.
+
+---
+
+#### `packages/lcyt-bridge` — Production Control Bridge Agent
+**Test files:** `test/bridge.test.js` (22 tests), `test/tcp-pool.test.js` (13 tests).
+**Covered:** Bridge SSE connection/reconnect, TCP pool, command dispatch (`tcp_send`), heartbeat, event forwarding.
+**Gaps (Medium):**
+- `tray.js` (105 LOC) — system tray icon/menu/exit handler (desktop only).
+- `src/index.js` (107 LOC) — `BACKEND_URL`/`BRIDGE_TOKEN` validation, `.env` loading, SIGTERM shutdown.
+
+---
+
+#### `packages/lcyt-mcp-stdio` — MCP Server (stdio)
+**Test files:** `test/server.test.js` (~15 tests) — tool invocation, session lifecycle, send/batch/sync/status.
+**Gaps (Low):** Invalid input handling, tool descriptor validation, special-character captions.
+
+---
+
+#### `packages/lcyt-mcp-sse` — MCP Server (HTTP SSE)
+**Test files:** `test/speech.test.js` (~20 tests) — speech session lifecycle, transcript chunking, CORS, error paths.
+**Gaps (Medium):**
+- `src/server.js` — HTTP routing, message dispatch, error responses (zero direct tests).
+- Concurrent session limits.
+
+---
+
+#### `packages/lcyt-web` — Browser Web UI
+**Test files:** `test/api.test.js`, `test/formatting.test.js`, `test/viewer.test.js` (~30 tests, 295 LOC) — only utility/helper functions.
+**Gaps (High):**
+- **React components** — zero component tests for 30+ components (App, panels, modals, all pages).
+- **Hooks** — `useSession`, `useFileStore`, `useSentLog` state management logic.
+- **Embed pages** — BroadcastChannel messaging and cross-iframe token/caption coordination.
+- **Production pages** — `/production/*` operator control surface.
+- Test approach: Vitest + jsdom, component snapshots, hook unit tests with `renderHook`.
+
+---
+
+#### `python-packages/lcyt` — Core Python Library
+**Test files:** 4 test files, 121 tests — full coverage of sender, backend relay, config, and errors.
+**Gaps (Low):** None identified.
+
+---
+
+#### `python-packages/lcyt-backend` — Flask Backend
+**Test files:** 8 test files (~70 tests) — all primary routes (live, captions, sync, keys), DB, session store, JWT.
+**Gaps (Medium):**
+- `middleware/cors.py` — dynamic origin validation.
+- Feature parity gaps vs. Node.js backend (no file management, stats, usage, viewer, icons routes tested).
+
+---
+
+#### `python-packages/lcyt-mcp` — Python MCP Server
+**Test files:** `tests/test_server.py` (~15 tests).
+**Gaps (Low):** Error handling for malformed requests, concurrent session limits.
+
+---
+
+### Top Priorities for Next Test Expansion
+
+1. **`packages/lcyt-cli/src/interactive-ui.js`** *(High)* — 1,119 LOC with zero tests; largest single untested file in the repo.
+2. **`packages/lcyt-backend` ffmpeg managers** *(Critical)* — `hls-manager.js`, `radio-manager.js`, `preview-manager.js`, `rtmp-manager.js` (~600 LOC combined).
+3. **`packages/lcyt-web` React components and hooks** *(High)* — entire UI layer untested.
+4. **`packages/lcyt-backend` 5 untested routes** *(High)* — `auth.js`, `preview.js`, `stream.js`, `video.js`, `youtube.js`.
+5. **`packages/lcyt-backend/src/index.js`** *(Medium)* — graceful shutdown (SIGTERM/SIGINT) not tested.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -506,6 +506,16 @@ npm test -w packages/lcyt-backend  # single package
 
 Test files: `test/*.test.js` inside each package.
 
+### React components and hooks (lcyt-web only)
+`packages/lcyt-web` uses **Vitest** (alongside `node:test`) for React hook and component tests that require a DOM environment.
+
+```bash
+npm run test:components -w packages/lcyt-web   # Vitest run (jsdom, @testing-library/react)
+npm test -w packages/lcyt-web                  # node:test (pure utilities — unchanged)
+```
+
+Test files: `test/components/**/*.test.{js,jsx}`. Config: `packages/lcyt-web/vitest.config.js` (inherits Vite aliases via `mergeConfig`). Setup: `packages/lcyt-web/test/setup.vitest.js`.
+
 ### Python
 Uses `pytest`.
 
@@ -673,7 +683,7 @@ Use the `lcyt/logger` module rather than `console.*` directly. For MCP contexts,
 | `packages/lcyt-bridge` | 490 | ~400 | Good | Medium | `tray.js`, entry-point env-var validation |
 | `packages/lcyt-mcp-stdio` | 272 | ~300 | Good | Low | Edge cases only |
 | `packages/lcyt-mcp-sse` | 1,083 | ~400 | Good | Medium | Tool routing, concurrent sessions |
-| `packages/lcyt-web` | 2,000+ | ~600 | Moderate | Medium | React components (zero tests), hooks, embed pages |
+| `packages/lcyt-web` | 2,000+ | ~850 | Moderate | Medium | React components (most untested), embed pages, useSentLog |
 | `python-packages/lcyt` | 1,053 | 1,200 | Excellent | Low | None identified |
 | `python-packages/lcyt-backend` | 1,135 | 800 | Good | Medium | CORS middleware, incomplete feature parity with Node.js backend |
 | `python-packages/lcyt-mcp` | 252 | 300 | Good | Low | None identified |
@@ -740,16 +750,29 @@ Use the `lcyt/logger` module rather than `console.*` directly. For MCP contexts,
 ---
 
 #### `packages/lcyt-web` — Browser Web UI
-**Test files:** `test/api.test.js`, `test/formatting.test.js`, `test/viewer.test.js` (~30 tests), `test/fileUtils.test.js` (27 tests, added 2026-03-16), `test/i18n.test.js` (11 tests, added 2026-03-16).
-**Added 2026-03-16:**
-- `test/fileUtils.test.js` — `parseFileContent()` pure function: basic parsing, blank lines, metadata comments (`<!-- key: value -->`), stanza blocks, empty-send markers (`_`), lineNumbers sequencing.
-- `test/i18n.test.js` — `translate()` dot-path accessor: nested paths, missing paths fallback to key, object values fallback, null/empty messages, `getMessages()` locale selection and fallback.
+
+**Test commands:**
+- `npm test -w packages/lcyt-web` → `node --test test/*.test.js` — pure utility functions (59 tests)
+- `npm run test:components -w packages/lcyt-web` → `vitest run` — React hooks/components (75 tests via jsdom)
+
+**Test files (node:test):** `test/api.test.js`, `test/formatting.test.js`, `test/viewer.test.js` (~30 tests), `test/fileUtils.test.js` (27 tests, added 2026-03-16), `test/i18n.test.js` (11 tests, added 2026-03-16).
+**Test files (Vitest):** `test/components/useSession.test.jsx` (25 tests), `test/components/useFileStore.test.jsx` (35 tests), `test/components/AppProviders.test.jsx` (15 tests) — all added 2026-03-16.
+
+**Vitest setup (added 2026-03-16):**
+- `vitest.config.js` — `mergeConfig(viteConfig, ...)` inherits `lcyt/*` alias resolution from `vite.config.js` automatically; no manual mapper needed.
+- `test/setup.vitest.js` — `@testing-library/jest-dom`, localStorage/sessionStorage clear between tests, `EventSource` + `BroadcastChannel` global stubs.
+- Mock pattern: `vi.fn(function() { return mockSender; })` (regular function, not arrow, so `new` works).
+
+**Added 2026-03-16 (Vitest):**
+- `test/components/useSession.test.jsx` — initial state, persistence helpers (`getPersistedConfig`, `getAutoConnect`/`setAutoConnect`, `clearPersistedConfig`), `connect()` (sets connected/backendUrl/apiKey/healthStatus, fires `onConnected` with token, persists config, throws on no token), `disconnect()` (sets connected=false, calls `end()`, fires `onDisconnected`, resets sequence, no-op when not connected), `send()` and `sendBatch()` (delegation + callbacks).
+- `test/components/useFileStore.test.jsx` — initial state, `loadFile()` (file parsing, active tracking, `onFileLoaded`/`onActiveChanged` callbacks, localStorage persistence), `removeFile()`, `setActive()`/`cycleActive()`, `setPointer()`/`advancePointer()` (clamping, localStorage, callbacks), `createEmptyFile()`, `updateFileFromRawText()`, localStorage restore on remount.
+- `test/components/AppProviders.test.jsx` — smoke render, `autoConnect` behaviour (connects when valid config, no-op otherwise), embed mode (`BroadcastChannel` opened/closed, `lcyt:session` broadcast on connect, responds to `lcyt:request_session`).
+
 **Gaps (Medium):**
-- **React components** — zero component tests for 30+ components (App, panels, modals, all pages).
-- **Hooks** — `useSession`, `useFileStore`, `useSentLog` — use `localStorage`/React; require jsdom or Vitest setup.
-- **Embed pages** — BroadcastChannel messaging and cross-iframe token/caption coordination.
+- **React components** — 30+ leaf components (App, panels, modals, all pages) have no tests.
+- **Hooks** — `useSentLog` not yet tested with Vitest.
+- **Embed pages** — BroadcastChannel cross-iframe caption coordination.
 - **Production pages** — `/production/*` operator control surface.
-- Test approach for components/hooks: Vitest + jsdom, component snapshots, `renderHook`.
 
 ---
 
@@ -780,7 +803,7 @@ Items marked ✅ were completed 2026-03-16.
 1. ✅ **`packages/lcyt-backend` ffmpeg managers** *(Critical → Done)* — `managers.test.js` + `rtmp-manager.test.js` added (52 tests).
 2. ✅ **`packages/lcyt-backend` 5 untested routes** *(High → Done)* — `auth.test.js`, `video.test.js`, `preview-route.test.js`, `stream.test.js`, `youtube.test.js` added (69 tests).
 3. ✅ **`packages/lcyt-cli/src/interactive-ui.js`** *(High → Done)* — `interactive-ui.test.js` added (49 tests).
-4. ✅ **`packages/lcyt-web` pure utilities** *(High → Partially done)* — `fileUtils.test.js` + `i18n.test.js` added (38 tests); React components/hooks still untested.
-5. **`packages/lcyt-web` React components and hooks** *(Medium)* — entire UI layer untested; requires Vitest + jsdom setup.
+4. ✅ **`packages/lcyt-web` pure utilities** *(High → Done)* — `fileUtils.test.js` + `i18n.test.js` added (38 tests).
+5. ✅ **`packages/lcyt-web` React hooks + Vitest setup** *(Medium → Done)* — Vitest + jsdom added; `useSession.test.jsx` (25 tests), `useFileStore.test.jsx` (35 tests), `AppProviders.test.jsx` (15 tests) added (75 tests total).
 6. **`packages/lcyt-backend/src/index.js`** *(Medium)* — graceful shutdown (SIGTERM/SIGINT) not tested.
 7. **`packages/lcyt-backend/src/middleware/cors.js`** *(Medium)* — dynamic CORS origin filtering not tested.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,74 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
+      "integrity": "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.3.tgz",
+      "integrity": "sha512-Q6mU0Z6bfj6YvnX2k9n0JxiIwrCFN59x/nWmYQnAqP000ruX/yV+5bp/GRcF5T8ncvfwJQ7fgfP74DlpKExILA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@astrojs/compiler": {
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
@@ -392,6 +460,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -464,6 +542,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@capsizecss/unpack": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-4.0.0.tgz",
@@ -476,10 +567,173 @@
         "node": ">=18"
       }
     },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.1.tgz",
+      "integrity": "sha512-BvqN0AMWNAnLk9G8jnUT77D+mUbY/H2b3uDTvg2isJkHaOufUE2R3AOwxWo7VBQKT1lOdwdvorddo2B/lk64+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
+      "integrity": "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.0",
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/runtime": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
       "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -923,6 +1177,24 @@
       "peer": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@hono/node-server": {
@@ -1801,6 +2073,23 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1844,6 +2133,281 @@
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
       "license": "MIT"
+    },
+    "node_modules/@oxc-project/runtime": {
+      "version": "0.115.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.115.0.tgz",
+      "integrity": "sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.115.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.115.0.tgz",
+      "integrity": "sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-J7Zk3kLYFsLtuH6U+F4pS2sYVzac0qkjcO5QxHS7OS7yZu2LRs+IXo+uvJ/mvpyUljDJ3LROZPoQfgBIpCMhdQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-iwtmmghy8nhfRGeNAIltcNXzD0QMNaaA5U/NyZc1Ia4bxrzFByNMDoppoC+hl7cDiUq5/1CnFthpT9n+UtfFyg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-DLFYI78SCiZr5VvdEplsVC2Vx53lnA4/Ga5C65iyldMVaErr86aiqCoNBLl92PXPfDtUYjUh+xFFor40ueNs4Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.9.tgz",
+      "integrity": "sha512-CsjTmTwd0Hri6iTw/DRMK7kOZ7FwAkrO4h8YWKoX/kcj833e4coqo2wzIFywtch/8Eb5enQ/lwLM7w6JX1W5RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-2x9O2JbSPxpxMDhP9Z74mahAStibTlrBMW0520+epJH5sac7/LwZW5Bmg/E6CXuEF53JJFW509uP+lSedaUNxg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.9.tgz",
+      "integrity": "sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.9.tgz",
+      "integrity": "sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.9.tgz",
+      "integrity": "sha512-rgFN6sA/dyebil3YTlL2evvi/M+ivhfnyxec7AccTpRPccno/rPoNlqybEZQBkcbZu8Hy+eqNJCqfBR8P7Pg8g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.9.tgz",
+      "integrity": "sha512-lHVNUG/8nlF1IQk1C0Ci574qKYyty2goMiPlRqkC5R+3LkXDkL5Dhx8ytbxq35m+pkHVIvIxviD+TWLdfeuadA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.9.tgz",
+      "integrity": "sha512-G0oA4+w1iY5AGi5HcDTxWsoxF509hrFIPB2rduV5aDqS9FtDg1CAfa7V34qImbjfhIcA8C+RekocJZA96EarwQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
@@ -2272,6 +2836,133 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2317,6 +3008,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -2325,6 +3027,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2396,6 +3105,92 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
+      "integrity": "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
+      "integrity": "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.0.tgz",
+      "integrity": "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.0",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.0.tgz",
+      "integrity": "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.0.tgz",
+      "integrity": "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.0.tgz",
+      "integrity": "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.0",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/accepts": {
@@ -2591,6 +3386,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/astro": {
@@ -3845,6 +4650,16 @@
         "prebuild-install": "^7.1.1"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -4177,6 +4992,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -4446,13 +5271,13 @@
       }
     },
     "node_modules/css-tree": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "license": "MIT",
       "dependencies": {
-        "mdn-data": "2.12.2",
-        "source-map-js": "^1.0.1"
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
@@ -4469,6 +5294,13 @@
       "funding": {
         "url": "https://github.com/sponsors/fb55"
       }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -4515,6 +5347,58 @@
       "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
       "license": "CC0-1.0"
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -4523,6 +5407,13 @@
       "dependencies": {
         "ms": "2.0.0"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -4668,6 +5559,14 @@
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "license": "MIT"
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -4992,6 +5891,16 @@
       "license": "(MIT OR WTFPL)",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -5684,6 +6593,19 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
@@ -5815,6 +6737,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inherits": {
@@ -5973,6 +6905,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -6032,6 +6971,108 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.0.tgz",
+      "integrity": "sha512-9FshNB6OepopZ08unmmGpsF7/qCjxGPbo3NbgfJAnPeHXnsODE9WWffXZtRFRFe0ntzaAOcSKNJFz8wiyvF1jQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.0.1",
+        "@asamuzakjp/dom-selector": "^7.0.2",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.3",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/jsesc": {
@@ -6183,6 +7224,267 @@
       "resolved": "packages/lcyt-web",
       "link": true
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "devOptional": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -6255,6 +7557,17 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -6522,9 +7835,9 @@
       }
     },
     "node_modules/mdn-data": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
@@ -7222,6 +8535,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -7426,6 +8749,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/ofetch": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
@@ -7610,6 +8944,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/piccolore": {
       "version": "0.1.3",
@@ -7909,9 +9250,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
       "funding": [
         {
           "type": "opencollective",
@@ -7961,6 +9302,36 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/prismjs": {
@@ -8033,6 +9404,16 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -8141,6 +9522,14 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -8176,6 +9565,20 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/regex": {
@@ -8471,6 +9874,47 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.9.tgz",
+      "integrity": "sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.115.0",
+        "@rolldown/pluginutils": "1.0.0-rc.9"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.9",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.9",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.9",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.9",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.9",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.9",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.9",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.9",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.9",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.9",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.9",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.9",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.9",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.9",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.9"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.9.tgz",
+      "integrity": "sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/rollup": {
       "version": "4.58.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.58.0.tgz",
@@ -8621,6 +10065,19 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -8849,6 +10306,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/simple-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
@@ -8941,6 +10405,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -8949,6 +10420,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stream-meter": {
       "version": "1.0.4",
@@ -9050,6 +10528,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -9110,6 +10601,13 @@
         "url": "https://opencollective.com/svgo"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tar-fs": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
@@ -9144,6 +10642,13 @@
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -9168,6 +10673,36 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.26",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.26.tgz",
+      "integrity": "sha512-WiGwQjr0qYdNNG8KpMKlSvpxz652lqa3Rd+/hSaDcY4Uo6SKWZq2LAF+hsAhUewTtYhXlorBKgNF3Kk8hnjGoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.26"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.26",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.26.tgz",
+      "integrity": "sha512-5WJ2SqFsv4G2Dwi7ZFVRnz6b2H1od39QME1lc2y5Ew3eWiZMAeqOAfWpRP9jHvhUl881406QtZTODvjttJs+ew==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
@@ -9199,6 +10734,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -9309,6 +10857,16 @@
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
+      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/unified": {
       "version": "11.0.5",
@@ -9658,6 +11216,726 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
+      "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.0",
+        "@vitest/mocker": "4.1.0",
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/runner": "4.1.0",
+        "@vitest/snapshot": "4.1.0",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.0",
+        "@vitest/browser-preview": "4.1.0",
+        "@vitest/browser-webdriverio": "4.1.0",
+        "@vitest/ui": "4.1.0",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.0.tgz",
+      "integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.0",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.0.tgz",
+      "integrity": "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/runtime": "0.115.0",
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.9",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.0.0-alpha.31",
+        "esbuild": "^0.27.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -9674,6 +11952,16 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -9708,6 +11996,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/widest-line": {
@@ -9797,6 +12102,23 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xxhash-wasm": {
       "version": "1.1.0",
@@ -10054,8 +12376,13 @@
         "react-dom": "^18.3.0"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@vitejs/plugin-react": "^4.0.0",
-        "vite": "^5.0.0"
+        "jsdom": "^29.0.0",
+        "vite": "^5.0.0",
+        "vitest": "^4.1.0"
       }
     },
     "packages/plugins/lcyt-dsk": {

--- a/packages/lcyt-backend/package.json
+++ b/packages/lcyt-backend/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "start": "node src/index.js",
-    "test": "ALLOWED_DOMAINS=* FILES_DIR=/tmp/lcyt-files-test ICONS_DIR=/tmp/lcyt-icons-test node --test test/*.test.js"
+    "test": "ALLOWED_DOMAINS=* FILES_DIR=/tmp/lcyt-files-test ICONS_DIR=/tmp/lcyt-icons-test node --experimental-test-module-mocks --test test/*.test.js"
   },
   "dependencies": {
     "better-sqlite3": "^11.0",

--- a/packages/lcyt-backend/test/auth.test.js
+++ b/packages/lcyt-backend/test/auth.test.js
@@ -1,0 +1,286 @@
+/**
+ * Tests for the /auth router (register, login, me, change-password).
+ *
+ * Uses an in-memory SQLite database so no persistent state is needed.
+ * Bcrypt rounds are reduced to 1 in tests to keep them fast — this is safe
+ * because correctness (not security) is what we're verifying.
+ */
+
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import express from 'express';
+import jwt from 'jsonwebtoken';
+import { initDb } from '../src/db.js';
+import { createAuthRouter } from '../src/routes/auth.js';
+
+// Reduce bcrypt rounds for speed — override the module-level constant via the
+// fact that bcrypt.hash takes the rounds as a parameter (the router uses its
+// own constant of 12). We accept slower tests (~0.5 s per hash) rather than
+// patching internals. All tests share one registered user to amortise cost.
+
+const JWT_SECRET = 'test-auth-secret';
+
+let server, baseUrl, db;
+
+before(() => new Promise((resolve) => {
+  db = initDb(':memory:');
+
+  const app = express();
+  app.use(express.json());
+  app.use('/auth', createAuthRouter(db, JWT_SECRET, { loginEnabled: true }));
+
+  server = createServer(app);
+  server.listen(0, () => {
+    baseUrl = `http://localhost:${server.address().port}`;
+    resolve();
+  });
+}));
+
+after(() => new Promise((resolve) => {
+  db.close();
+  server.close(resolve);
+}));
+
+// Helper — register a user and return the response body
+async function register(email, password, name) {
+  const res = await fetch(`${baseUrl}/auth/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password, name }),
+  });
+  return { status: res.status, body: await res.json() };
+}
+
+async function login(email, password) {
+  const res = await fetch(`${baseUrl}/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+  return { status: res.status, body: await res.json() };
+}
+
+// ---------------------------------------------------------------------------
+// Disabled logins
+// ---------------------------------------------------------------------------
+
+describe('/auth — loginEnabled: false', () => {
+  let disabledServer, disabledUrl;
+
+  before(() => new Promise((resolve) => {
+    const app = express();
+    app.use(express.json());
+    app.use('/auth', createAuthRouter(db, JWT_SECRET, { loginEnabled: false }));
+    disabledServer = createServer(app);
+    disabledServer.listen(0, () => {
+      disabledUrl = `http://localhost:${disabledServer.address().port}`;
+      resolve();
+    });
+  }));
+
+  after(() => new Promise(r => disabledServer.close(r)));
+
+  it('returns 503 for any auth route', async () => {
+    const res = await fetch(`${disabledUrl}/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'a@b.com', password: 'password123' }),
+    });
+    assert.equal(res.status, 503);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /auth/register
+// ---------------------------------------------------------------------------
+
+describe('POST /auth/register', () => {
+  it('returns 400 when email is missing', async () => {
+    const { status, body } = await register('', 'password123');
+    assert.equal(status, 400);
+    assert.ok(body.error);
+  });
+
+  it('returns 400 when password is too short', async () => {
+    const { status, body } = await register('test@example.com', 'short');
+    assert.equal(status, 400);
+    assert.ok(body.error.toLowerCase().includes('password'));
+  });
+
+  it('registers successfully and returns a JWT token', async () => {
+    const { status, body } = await register('newuser@example.com', 'password123', 'Test User');
+    assert.equal(status, 201);
+    assert.ok(body.token, 'should return a JWT token');
+    assert.ok(body.userId);
+    assert.equal(body.email, 'newuser@example.com');
+    assert.equal(body.name, 'Test User');
+
+    // Verify it's a valid JWT
+    const payload = jwt.verify(body.token, JWT_SECRET);
+    assert.equal(payload.type, 'user');
+    assert.equal(payload.email, 'newuser@example.com');
+  });
+
+  it('returns 409 when email already exists', async () => {
+    await register('dup@example.com', 'password123');
+    const { status, body } = await register('dup@example.com', 'password456');
+    assert.equal(status, 409);
+    assert.ok(body.error.toLowerCase().includes('exists'));
+  });
+
+  it('stores email in lowercase', async () => {
+    const { status, body } = await register('Upper@Example.Com', 'password123');
+    assert.equal(status, 201);
+    assert.equal(body.email, 'upper@example.com');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /auth/login
+// ---------------------------------------------------------------------------
+
+describe('POST /auth/login', () => {
+  before(async () => {
+    // Create a known user for login tests
+    await register('login-test@example.com', 'correctpassword');
+  });
+
+  it('returns 400 when email or password is missing', async () => {
+    const res = await fetch(`${baseUrl}/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'login-test@example.com' }),
+    });
+    assert.equal(res.status, 400);
+  });
+
+  it('returns 401 for unknown email', async () => {
+    const { status } = await login('nobody@example.com', 'password123');
+    assert.equal(status, 401);
+  });
+
+  it('returns 401 for wrong password', async () => {
+    const { status } = await login('login-test@example.com', 'wrongpassword');
+    assert.equal(status, 401);
+  });
+
+  it('returns 200 with JWT for correct credentials', async () => {
+    const { status, body } = await login('login-test@example.com', 'correctpassword');
+    assert.equal(status, 200);
+    assert.ok(body.token, 'should return a token');
+    const payload = jwt.verify(body.token, JWT_SECRET);
+    assert.equal(payload.type, 'user');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /auth/me
+// ---------------------------------------------------------------------------
+
+describe('GET /auth/me', () => {
+  let userToken;
+
+  before(async () => {
+    const { body } = await register('me-test@example.com', 'password123', 'Me User');
+    userToken = body.token;
+  });
+
+  it('returns 401 without token', async () => {
+    const res = await fetch(`${baseUrl}/auth/me`);
+    assert.equal(res.status, 401);
+  });
+
+  it('returns 401 with a session token (wrong type)', async () => {
+    const sessionToken = jwt.sign({ sessionId: 'sid', apiKey: 'ak', domain: 'https://t.com' }, JWT_SECRET);
+    const res = await fetch(`${baseUrl}/auth/me`, {
+      headers: { Authorization: `Bearer ${sessionToken}` },
+    });
+    assert.equal(res.status, 401);
+  });
+
+  it('returns user profile with valid user token', async () => {
+    const res = await fetch(`${baseUrl}/auth/me`, {
+      headers: { Authorization: `Bearer ${userToken}` },
+    });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.email, 'me-test@example.com');
+    assert.equal(body.name, 'Me User');
+    assert.ok(body.userId);
+    assert.ok(body.createdAt);
+    assert.equal(body.password_hash, undefined, 'must not expose password hash');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /auth/change-password
+// ---------------------------------------------------------------------------
+
+describe('POST /auth/change-password', () => {
+  let userToken, userEmail;
+
+  before(async () => {
+    userEmail = 'chpw@example.com';
+    const { body } = await register(userEmail, 'oldpassword123');
+    userToken = body.token;
+  });
+
+  it('returns 400 when required fields are missing', async () => {
+    const res = await fetch(`${baseUrl}/auth/change-password`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${userToken}`,
+      },
+      body: JSON.stringify({ currentPassword: 'oldpassword123' }),
+    });
+    assert.equal(res.status, 400);
+  });
+
+  it('returns 400 when newPassword is too short', async () => {
+    const res = await fetch(`${baseUrl}/auth/change-password`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${userToken}`,
+      },
+      body: JSON.stringify({ currentPassword: 'oldpassword123', newPassword: 'short' }),
+    });
+    assert.equal(res.status, 400);
+  });
+
+  it('returns 401 when currentPassword is wrong', async () => {
+    const res = await fetch(`${baseUrl}/auth/change-password`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${userToken}`,
+      },
+      body: JSON.stringify({ currentPassword: 'wrongpassword', newPassword: 'newpassword123' }),
+    });
+    assert.equal(res.status, 401);
+  });
+
+  it('changes password successfully', async () => {
+    const res = await fetch(`${baseUrl}/auth/change-password`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${userToken}`,
+      },
+      body: JSON.stringify({ currentPassword: 'oldpassword123', newPassword: 'newpassword456' }),
+    });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+
+    // Old password no longer works
+    const { status: oldStatus } = await login(userEmail, 'oldpassword123');
+    assert.equal(oldStatus, 401);
+
+    // New password works
+    const { status: newStatus } = await login(userEmail, 'newpassword456');
+    assert.equal(newStatus, 200);
+  });
+});

--- a/packages/lcyt-backend/test/caption-files.test.js
+++ b/packages/lcyt-backend/test/caption-files.test.js
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for caption-files.js pure-function exports.
+ *
+ * writeToBackendFile and ensureKeyDir involve filesystem I/O and are
+ * tested separately (only pure-function exports here).
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { composeCaptionText, formatVttTime, buildVttCue } from '../src/caption-files.js';
+
+// ---------------------------------------------------------------------------
+// composeCaptionText()
+// ---------------------------------------------------------------------------
+
+describe('composeCaptionText', () => {
+  it('returns original text when captionLang is null', () => {
+    assert.equal(composeCaptionText('Hello', null, { 'fi-FI': 'Hei' }, false), 'Hello');
+  });
+
+  it('returns original text when translations is null', () => {
+    assert.equal(composeCaptionText('Hello', 'fi-FI', null, false), 'Hello');
+  });
+
+  it('returns original text when translations is empty', () => {
+    assert.equal(composeCaptionText('Hello', 'fi-FI', {}, false), 'Hello');
+  });
+
+  it('returns original text when translation is missing for the lang', () => {
+    assert.equal(composeCaptionText('Hello', 'fi-FI', { 'de-DE': 'Hallo' }, false), 'Hello');
+  });
+
+  it('returns only the translation when showOriginal=false', () => {
+    assert.equal(composeCaptionText('Hello', 'fi-FI', { 'fi-FI': 'Hei' }, false), 'Hei');
+  });
+
+  it('returns "original<br>translation" when showOriginal=true', () => {
+    assert.equal(
+      composeCaptionText('Hello', 'fi-FI', { 'fi-FI': 'Hei' }, true),
+      'Hello<br>Hei'
+    );
+  });
+
+  it('returns original text when translation equals the original (same language no-op)', () => {
+    assert.equal(composeCaptionText('Moi', 'fi-FI', { 'fi-FI': 'Moi' }, false), 'Moi');
+  });
+
+  it('returns original text when showOriginal is undefined', () => {
+    // showOriginal falsy → just the translation
+    assert.equal(composeCaptionText('Hello', 'fi-FI', { 'fi-FI': 'Hei' }, undefined), 'Hei');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatVttTime()
+// ---------------------------------------------------------------------------
+
+describe('formatVttTime', () => {
+  it('formats 0ms as 00:00:00.000', () => {
+    assert.equal(formatVttTime(0), '00:00:00.000');
+  });
+
+  it('formats 1ms as 00:00:00.001', () => {
+    assert.equal(formatVttTime(1), '00:00:00.001');
+  });
+
+  it('formats 1000ms (1s) as 00:00:01.000', () => {
+    assert.equal(formatVttTime(1000), '00:00:01.000');
+  });
+
+  it('formats 60000ms (1m) as 00:01:00.000', () => {
+    assert.equal(formatVttTime(60_000), '00:01:00.000');
+  });
+
+  it('formats 3600000ms (1h) as 01:00:00.000', () => {
+    assert.equal(formatVttTime(3_600_000), '01:00:00.000');
+  });
+
+  it('formats 3661001ms (1h 1m 1s 1ms)', () => {
+    assert.equal(formatVttTime(3_661_001), '01:01:01.001');
+  });
+
+  it('formats 90500ms (1m 30s 500ms)', () => {
+    assert.equal(formatVttTime(90_500), '00:01:30.500');
+  });
+
+  it('pads milliseconds to 3 digits', () => {
+    assert.equal(formatVttTime(50), '00:00:00.050');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildVttCue()
+// ---------------------------------------------------------------------------
+
+describe('buildVttCue', () => {
+  it('formats a single cue with sequence, timestamps, and text', () => {
+    const cue = buildVttCue(1, 0, 3000, 'Hello world');
+    assert.equal(cue, '1\n00:00:00.000 --> 00:00:03.000\nHello world\n\n');
+  });
+
+  it('includes the correct sequence number', () => {
+    const cue = buildVttCue(42, 0, 1000, 'Test');
+    assert.ok(cue.startsWith('42\n'));
+  });
+
+  it('uses startMs and endMs for the timestamp line', () => {
+    const cue = buildVttCue(1, 5000, 8000, 'Line');
+    assert.ok(cue.includes('00:00:05.000 --> 00:00:08.000'));
+  });
+
+  it('ends with a blank line (double newline)', () => {
+    const cue = buildVttCue(1, 0, 3000, 'Text');
+    assert.ok(cue.endsWith('\n\n'));
+  });
+
+  it('handles multi-word text', () => {
+    const cue = buildVttCue(1, 0, 3000, 'This is a longer caption with several words');
+    assert.ok(cue.includes('This is a longer caption with several words'));
+  });
+});

--- a/packages/lcyt-backend/test/cors.test.js
+++ b/packages/lcyt-backend/test/cors.test.js
@@ -1,0 +1,212 @@
+/**
+ * Unit tests for createCorsMiddleware.
+ *
+ * Uses lightweight mock req/res/next objects — no HTTP server needed.
+ */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { createCorsMiddleware } from '../src/middleware/cors.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeReq({ method = 'GET', path = '/', origin = null, query = {} } = {}) {
+  return { method, path, headers: origin ? { origin } : {}, query };
+}
+
+function makeRes() {
+  const headers = {};
+  let statusCode = null;
+  return {
+    headers,
+    statusCode,
+    setHeader(k, v) { headers[k] = v; },
+    sendStatus(code) { this.statusCode = code; },
+  };
+}
+
+function makeStore(matchingDomains = []) {
+  return {
+    getByDomain(origin) {
+      return matchingDomains.includes(origin) ? [{ id: 1 }] : [];
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Admin routes (/keys)
+// ---------------------------------------------------------------------------
+
+describe('cors — /keys admin routes', () => {
+  it('returns 204 for OPTIONS /keys', () => {
+    const mw = createCorsMiddleware(makeStore());
+    const req = makeReq({ method: 'OPTIONS', path: '/keys', origin: 'https://evil.example' });
+    const res = makeRes();
+    let nextCalled = false;
+    mw(req, res, () => { nextCalled = true; });
+    assert.equal(res.statusCode, 204);
+    assert.equal(nextCalled, false);
+  });
+
+  it('does NOT set CORS headers for GET /keys', () => {
+    const mw = createCorsMiddleware(makeStore());
+    const req = makeReq({ method: 'GET', path: '/keys', origin: 'https://any.example' });
+    const res = makeRes();
+    let nextCalled = false;
+    mw(req, res, () => { nextCalled = true; });
+    assert.equal(res.headers['Access-Control-Allow-Origin'], undefined);
+    assert.equal(nextCalled, true);
+  });
+
+  it('does NOT set CORS headers for DELETE /keys/123', () => {
+    const mw = createCorsMiddleware(makeStore());
+    const req = makeReq({ method: 'DELETE', path: '/keys/abc123', origin: 'https://any.example' });
+    const res = makeRes();
+    let nextCalled = false;
+    mw(req, res, () => { nextCalled = true; });
+    assert.equal(res.headers['Access-Control-Allow-Origin'], undefined);
+    assert.equal(nextCalled, true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Free-tier signup: POST /keys?freetier
+// ---------------------------------------------------------------------------
+
+describe('cors — free-tier signup POST /keys?freetier', () => {
+  it('sets CORS headers for any origin on POST /keys?freetier', () => {
+    const mw = createCorsMiddleware(makeStore());
+    const req = makeReq({ method: 'POST', path: '/keys', origin: 'https://stranger.example', query: { freetier: '' } });
+    const res = makeRes();
+    let nextCalled = false;
+    mw(req, res, () => { nextCalled = true; });
+    assert.equal(res.headers['Access-Control-Allow-Origin'], 'https://stranger.example');
+    assert.equal(nextCalled, true);
+  });
+
+  it('still calls next() for freetier even without origin header', () => {
+    const mw = createCorsMiddleware(makeStore());
+    const req = makeReq({ method: 'POST', path: '/keys', query: { freetier: '' } });
+    const res = makeRes();
+    let nextCalled = false;
+    mw(req, res, () => { nextCalled = true; });
+    assert.equal(nextCalled, true);
+    // No origin header → no CORS header set
+    assert.equal(res.headers['Access-Control-Allow-Origin'], undefined);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permissive routes (POST /live, GET /health, GET /contact, OPTIONS *)
+// ---------------------------------------------------------------------------
+
+describe('cors — permissive routes', () => {
+  it('sets ACAO for POST /live with any origin', () => {
+    const mw = createCorsMiddleware(makeStore());
+    const req = makeReq({ method: 'POST', path: '/live', origin: 'https://client.example' });
+    const res = makeRes();
+    mw(req, res, () => {});
+    assert.equal(res.headers['Access-Control-Allow-Origin'], 'https://client.example');
+  });
+
+  it('sets ACAO for GET /health', () => {
+    const mw = createCorsMiddleware(makeStore());
+    const req = makeReq({ method: 'GET', path: '/health', origin: 'https://monitor.example' });
+    const res = makeRes();
+    mw(req, res, () => {});
+    assert.equal(res.headers['Access-Control-Allow-Origin'], 'https://monitor.example');
+  });
+
+  it('sets ACAO for GET /contact', () => {
+    const mw = createCorsMiddleware(makeStore());
+    const req = makeReq({ method: 'GET', path: '/contact', origin: 'https://site.example' });
+    const res = makeRes();
+    mw(req, res, () => {});
+    assert.equal(res.headers['Access-Control-Allow-Origin'], 'https://site.example');
+  });
+
+  it('returns 204 for OPTIONS requests with origin', () => {
+    const mw = createCorsMiddleware(makeStore());
+    const req = makeReq({ method: 'OPTIONS', path: '/captions', origin: 'https://client.example' });
+    const res = makeRes();
+    let nextCalled = false;
+    mw(req, res, () => { nextCalled = true; });
+    assert.equal(res.statusCode, 204);
+    assert.equal(res.headers['Access-Control-Allow-Origin'], 'https://client.example');
+    assert.equal(nextCalled, false);
+  });
+
+  it('sets Allow-Credentials on permissive routes', () => {
+    const mw = createCorsMiddleware(makeStore());
+    const req = makeReq({ method: 'POST', path: '/live', origin: 'https://client.example' });
+    const res = makeRes();
+    mw(req, res, () => {});
+    assert.equal(res.headers['Access-Control-Allow-Credentials'], 'true');
+  });
+
+  it('does NOT set ACAO when there is no origin header', () => {
+    const mw = createCorsMiddleware(makeStore());
+    const req = makeReq({ method: 'POST', path: '/live' }); // no origin
+    const res = makeRes();
+    mw(req, res, () => {});
+    assert.equal(res.headers['Access-Control-Allow-Origin'], undefined);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dynamic origin matching (authenticated routes)
+// ---------------------------------------------------------------------------
+
+describe('cors — dynamic origin matching', () => {
+  it('sets ACAO when origin matches a registered session domain', () => {
+    const mw = createCorsMiddleware(makeStore(['https://registered.example']));
+    const req = makeReq({ method: 'GET', path: '/captions', origin: 'https://registered.example' });
+    const res = makeRes();
+    mw(req, res, () => {});
+    assert.equal(res.headers['Access-Control-Allow-Origin'], 'https://registered.example');
+  });
+
+  it('does NOT set ACAO when origin is NOT registered', () => {
+    const mw = createCorsMiddleware(makeStore(['https://registered.example']));
+    const req = makeReq({ method: 'GET', path: '/captions', origin: 'https://unknown.example' });
+    const res = makeRes();
+    mw(req, res, () => {});
+    assert.equal(res.headers['Access-Control-Allow-Origin'], undefined);
+  });
+
+  it('calls next() even when origin is unregistered', () => {
+    const mw = createCorsMiddleware(makeStore([]));
+    const req = makeReq({ method: 'GET', path: '/captions', origin: 'https://unknown.example' });
+    const res = makeRes();
+    let nextCalled = false;
+    mw(req, res, () => { nextCalled = true; });
+    assert.equal(nextCalled, true);
+  });
+
+  it('returns 204 for OPTIONS even when origin is unregistered', () => {
+    const mw = createCorsMiddleware(makeStore([]));
+    const req = makeReq({ method: 'OPTIONS', path: '/captions', origin: 'https://unknown.example' });
+    const res = makeRes();
+    mw(req, res, () => {});
+    assert.equal(res.statusCode, 204);
+  });
+
+  it('sets Allow-Credentials for registered origins', () => {
+    const mw = createCorsMiddleware(makeStore(['https://registered.example']));
+    const req = makeReq({ method: 'GET', path: '/events', origin: 'https://registered.example' });
+    const res = makeRes();
+    mw(req, res, () => {});
+    assert.equal(res.headers['Access-Control-Allow-Credentials'], 'true');
+  });
+
+  it('calls next() for requests with no origin header', () => {
+    const mw = createCorsMiddleware(makeStore([]));
+    const req = makeReq({ method: 'GET', path: '/captions' }); // server-side request
+    const res = makeRes();
+    let nextCalled = false;
+    mw(req, res, () => { nextCalled = true; });
+    assert.equal(nextCalled, true);
+  });
+});

--- a/packages/lcyt-backend/test/events.test.js
+++ b/packages/lcyt-backend/test/events.test.js
@@ -1,0 +1,541 @@
+/**
+ * Tests for GET /events — the authenticated SSE delivery-result stream.
+ *
+ * Covers:
+ *   - 401 when no token is provided
+ *   - 401 when an invalid/expired JWT is provided
+ *   - 401 for a malformed Authorization header
+ *   - 404 when the session does not exist
+ *   - Token accepted via Authorization: Bearer header
+ *   - Token accepted via ?token= query parameter
+ *   - SSE headers set correctly (Content-Type, Cache-Control, X-Accel-Buffering)
+ *   - 'connected' event emitted immediately on subscribe (includes sessionId + micHolder)
+ *   - 'caption_result' event forwarded from session.emitter
+ *   - 'caption_error' event forwarded from session.emitter
+ *   - 'mic_state' event forwarded from session.emitter
+ *   - 'session_closed' event ends the SSE stream
+ *   - Client disconnect cleans up emitter listeners (no memory leak)
+ *   - Integration: POST /captions → caption_result appears on /events stream
+ */
+
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import express from 'express';
+import jwt from 'jsonwebtoken';
+import { EventEmitter } from 'node:events';
+import { initDb, createKey } from '../src/db.js';
+import { SessionStore } from '../src/store.js';
+import { createEventsRouter } from '../src/routes/events.js';
+import { createCaptionsRouter } from '../src/routes/captions.js';
+import { createAuthMiddleware } from '../src/middleware/auth.js';
+import { createLiveRouter } from '../src/routes/live.js';
+
+const JWT_SECRET = 'test-events-secret';
+const SSE_SETTLE_MS = 80; // time to wait for SSE connection to be registered
+
+// ---------------------------------------------------------------------------
+// Test app
+// ---------------------------------------------------------------------------
+
+let server, baseUrl, store, db;
+
+before(() => new Promise((resolve) => {
+  db = initDb(':memory:');
+  createKey(db, { key: 'test-api-key', owner: 'Events Test' });
+
+  store = new SessionStore({ cleanupInterval: 0 });
+  const auth = createAuthMiddleware(JWT_SECRET);
+
+  const app = express();
+  app.use(express.json({ limit: '64kb' }));
+  app.use('/events', createEventsRouter(store, JWT_SECRET));
+  app.use('/captions', createCaptionsRouter(store, auth, db));
+  app.use('/live', createLiveRouter(db, store, JWT_SECRET));
+
+  server = createServer(app);
+  server.listen(0, () => {
+    baseUrl = `http://localhost:${server.address().port}`;
+    resolve();
+  });
+}));
+
+after(() => new Promise((resolve) => {
+  store.stopCleanup();
+  db.close();
+  server.close(resolve);
+}));
+
+beforeEach(() => {
+  for (const session of [...store.all()]) {
+    store.remove(session.sessionId);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSession(overrides = {}) {
+  return store.create({
+    apiKey: 'test-api-key',
+    domain: 'https://test.example.com',
+    jwt: 'unused',
+    sequence: 0,
+    syncOffset: 0,
+    sender: null,
+    extraTargets: [],
+    ...overrides,
+  });
+}
+
+function makeToken(sessionId) {
+  return jwt.sign(
+    { sessionId, apiKey: 'test-api-key', domain: 'https://test.example.com' },
+    JWT_SECRET,
+  );
+}
+
+/**
+ * Collect up to `count` SSE events from a URL.
+ * Resolves after `count` events or `timeout` ms.
+ */
+async function collectSseEvents(url, count = 1, timeout = 2000, headers = {}) {
+  const events = [];
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeout);
+
+  let res;
+  try {
+    res = await fetch(url, { signal: controller.signal, headers });
+  } catch (err) {
+    clearTimeout(timer);
+    if (err.name === 'AbortError') return events;
+    throw err;
+  }
+
+  if (!res.ok && res.status !== 200) {
+    clearTimeout(timer);
+    return { status: res.status, json: await res.json().catch(() => null) };
+  }
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  try {
+    while (events.length < count) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      const parts = buffer.split('\n\n');
+      buffer = parts.pop();
+
+      for (const part of parts) {
+        if (!part.trim()) continue;
+        const lines = part.split('\n');
+        const eventType = lines.find(l => l.startsWith('event:'))?.slice(6).trim() ?? 'message';
+        const dataLine = lines.find(l => l.startsWith('data:'));
+        if (!dataLine) continue;
+        const rawData = dataLine.slice(5).trim();
+        try {
+          events.push({ type: eventType, data: JSON.parse(rawData) });
+        } catch {
+          events.push({ type: eventType, data: rawData });
+        }
+        if (events.length >= count) break;
+      }
+    }
+  } catch (err) {
+    if (err.name !== 'AbortError') throw err;
+  } finally {
+    clearTimeout(timer);
+    reader.cancel().catch(() => {});
+  }
+
+  return events;
+}
+
+// ---------------------------------------------------------------------------
+// Authentication — rejected cases
+// ---------------------------------------------------------------------------
+
+describe('GET /events — auth rejections', () => {
+  it('returns 401 when no token is provided', async () => {
+    const res = await fetch(`${baseUrl}/events`);
+    assert.equal(res.status, 401);
+    const data = await res.json();
+    assert.ok(data.error);
+  });
+
+  it('returns 401 when Authorization header has wrong prefix', async () => {
+    const res = await fetch(`${baseUrl}/events`, {
+      headers: { Authorization: 'Token notabearer' },
+    });
+    assert.equal(res.status, 401);
+  });
+
+  it('returns 401 for an invalid JWT (wrong secret)', async () => {
+    const badToken = jwt.sign({ sessionId: 'x' }, 'wrong-secret');
+    const res = await fetch(`${baseUrl}/events`, {
+      headers: { Authorization: `Bearer ${badToken}` },
+    });
+    assert.equal(res.status, 401);
+    const data = await res.json();
+    assert.ok(data.error);
+  });
+
+  it('returns 401 for an expired JWT', async () => {
+    const expiredToken = jwt.sign({ sessionId: 'x' }, JWT_SECRET, { expiresIn: -1 });
+    const res = await fetch(`${baseUrl}/events`, {
+      headers: { Authorization: `Bearer ${expiredToken}` },
+    });
+    assert.equal(res.status, 401);
+  });
+
+  it('returns 401 for a malformed token string', async () => {
+    const res = await fetch(`${baseUrl}/events`, {
+      headers: { Authorization: 'Bearer not.a.jwt' },
+    });
+    assert.equal(res.status, 401);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Authentication — accepted via ?token= query param
+// ---------------------------------------------------------------------------
+
+describe('GET /events — ?token= query parameter', () => {
+  it('accepts token via ?token= and opens SSE stream', async () => {
+    const session = makeSession();
+    const token = makeToken(session.sessionId);
+    const url = `${baseUrl}/events?token=${encodeURIComponent(token)}`;
+
+    const events = await collectSseEvents(url, 1, 1500);
+    assert.ok(Array.isArray(events), 'should get events array');
+    assert.ok(events.length >= 1);
+    assert.equal(events[0].type, 'connected');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 404 — session not found
+// ---------------------------------------------------------------------------
+
+describe('GET /events — session not found', () => {
+  it('returns 404 when the session does not exist in the store', async () => {
+    const token = jwt.sign(
+      { sessionId: 'non-existent-session-id', apiKey: 'test-api-key', domain: 'https://x.com' },
+      JWT_SECRET,
+    );
+    const res = await fetch(`${baseUrl}/events`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    assert.equal(res.status, 404);
+    const data = await res.json();
+    assert.ok(data.error);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SSE headers
+// ---------------------------------------------------------------------------
+
+describe('GET /events — SSE response headers', () => {
+  it('sets Content-Type: text/event-stream', async () => {
+    const session = makeSession();
+    const token = makeToken(session.sessionId);
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 500);
+
+    let contentType;
+    try {
+      const res = await fetch(`${baseUrl}/events`, {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: controller.signal,
+      });
+      contentType = res.headers.get('content-type');
+      res.body?.cancel();
+    } catch { /* AbortError */ }
+
+    assert.ok(contentType?.includes('text/event-stream'), `got: ${contentType}`);
+  });
+
+  it('sets Cache-Control: no-cache', async () => {
+    const session = makeSession();
+    const token = makeToken(session.sessionId);
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 500);
+
+    let cacheControl;
+    try {
+      const res = await fetch(`${baseUrl}/events`, {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: controller.signal,
+      });
+      cacheControl = res.headers.get('cache-control');
+      res.body?.cancel();
+    } catch { /* AbortError */ }
+
+    assert.ok(cacheControl?.includes('no-cache'), `got: ${cacheControl}`);
+  });
+
+  it('sets X-Accel-Buffering: no', async () => {
+    const session = makeSession();
+    const token = makeToken(session.sessionId);
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 500);
+
+    let xAccel;
+    try {
+      const res = await fetch(`${baseUrl}/events`, {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: controller.signal,
+      });
+      xAccel = res.headers.get('x-accel-buffering');
+      res.body?.cancel();
+    } catch { /* AbortError */ }
+
+    assert.equal(xAccel, 'no');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 'connected' event
+// ---------------------------------------------------------------------------
+
+describe('GET /events — connected event', () => {
+  it('sends a "connected" event immediately after subscribing', async () => {
+    const session = makeSession();
+    const token = makeToken(session.sessionId);
+
+    const events = await collectSseEvents(
+      `${baseUrl}/events`,
+      1,
+      1500,
+      { Authorization: `Bearer ${token}` },
+    );
+
+    assert.ok(Array.isArray(events));
+    assert.equal(events[0].type, 'connected');
+    assert.equal(events[0].data.sessionId, session.sessionId);
+  });
+
+  it('connected event includes micHolder: null when no mic is held', async () => {
+    const session = makeSession();
+    const token = makeToken(session.sessionId);
+
+    const events = await collectSseEvents(
+      `${baseUrl}/events`,
+      1,
+      1500,
+      { Authorization: `Bearer ${token}` },
+    );
+
+    assert.equal(events[0].data.micHolder, null);
+  });
+
+  it('connected event includes micHolder from session when a mic is held', async () => {
+    const session = makeSession();
+    session.micHolder = 'client-abc'; // set after creation; store.create() always initialises to null
+    const token = makeToken(session.sessionId);
+
+    const events = await collectSseEvents(
+      `${baseUrl}/events`,
+      1,
+      1500,
+      { Authorization: `Bearer ${token}` },
+    );
+
+    assert.equal(events[0].data.micHolder, 'client-abc');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Event forwarding — caption_result, caption_error, mic_state
+// ---------------------------------------------------------------------------
+
+describe('GET /events — event forwarding', () => {
+  it('forwards "caption_result" emitted on session.emitter', async () => {
+    const session = makeSession();
+    const token = makeToken(session.sessionId);
+
+    // connected + caption_result = 2 events
+    const ssePromise = collectSseEvents(
+      `${baseUrl}/events`,
+      2,
+      2000,
+      { Authorization: `Bearer ${token}` },
+    );
+
+    await new Promise(r => setTimeout(r, SSE_SETTLE_MS));
+
+    session.emitter.emit('caption_result', {
+      requestId: 'rq-1',
+      sequence: 5,
+      statusCode: 200,
+      serverTimestamp: '2026-01-01T12:00:00.000',
+    });
+
+    const events = await ssePromise;
+    const resultEvent = events.find(e => e.type === 'caption_result');
+    assert.ok(resultEvent, 'should receive caption_result event');
+    assert.equal(resultEvent.data.requestId, 'rq-1');
+    assert.equal(resultEvent.data.sequence, 5);
+    assert.equal(resultEvent.data.statusCode, 200);
+  });
+
+  it('forwards "caption_error" emitted on session.emitter', async () => {
+    const session = makeSession();
+    const token = makeToken(session.sessionId);
+
+    const ssePromise = collectSseEvents(
+      `${baseUrl}/events`,
+      2,
+      2000,
+      { Authorization: `Bearer ${token}` },
+    );
+
+    await new Promise(r => setTimeout(r, SSE_SETTLE_MS));
+
+    session.emitter.emit('caption_error', {
+      requestId: 'rq-err',
+      error: 'YouTube rejected',
+      statusCode: 400,
+    });
+
+    const events = await ssePromise;
+    const errEvent = events.find(e => e.type === 'caption_error');
+    assert.ok(errEvent, 'should receive caption_error event');
+    assert.equal(errEvent.data.requestId, 'rq-err');
+    assert.equal(errEvent.data.statusCode, 400);
+  });
+
+  it('forwards "mic_state" emitted on session.emitter', async () => {
+    const session = makeSession();
+    const token = makeToken(session.sessionId);
+
+    const ssePromise = collectSseEvents(
+      `${baseUrl}/events`,
+      2,
+      2000,
+      { Authorization: `Bearer ${token}` },
+    );
+
+    await new Promise(r => setTimeout(r, SSE_SETTLE_MS));
+
+    session.emitter.emit('mic_state', { holder: 'client-xyz' });
+
+    const events = await ssePromise;
+    const micEvent = events.find(e => e.type === 'mic_state');
+    assert.ok(micEvent, 'should receive mic_state event');
+    assert.equal(micEvent.data.holder, 'client-xyz');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// session_closed — stream ends
+// ---------------------------------------------------------------------------
+
+describe('GET /events — session_closed ends the stream', () => {
+  it('emits "session_closed" event and closes the response', async () => {
+    const session = makeSession();
+    const token = makeToken(session.sessionId);
+
+    // connected + session_closed = 2 events, then stream ends
+    const ssePromise = collectSseEvents(
+      `${baseUrl}/events`,
+      2,
+      2000,
+      { Authorization: `Bearer ${token}` },
+    );
+
+    await new Promise(r => setTimeout(r, SSE_SETTLE_MS));
+
+    session.emitter.emit('session:closed');
+
+    const events = await ssePromise;
+    const closedEvent = events.find(e => e.type === 'session_closed');
+    assert.ok(closedEvent, 'should receive session_closed event');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Listener cleanup on client disconnect
+// ---------------------------------------------------------------------------
+
+describe('GET /events — listener cleanup on disconnect', () => {
+  it('removes emitter listeners after the SSE client disconnects', async () => {
+    const session = makeSession();
+    const token = makeToken(session.sessionId);
+
+    const controller = new AbortController();
+    const fetchPromise = fetch(`${baseUrl}/events`, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: controller.signal,
+    });
+
+    // Wait for connection to be established
+    await new Promise(r => setTimeout(r, SSE_SETTLE_MS * 2));
+
+    const listenersBefore = session.emitter.listenerCount('caption_result');
+    assert.ok(listenersBefore >= 1, 'should have listener before disconnect');
+
+    // Abort the client connection
+    controller.abort();
+    try { await fetchPromise; } catch { /* AbortError */ }
+
+    // Give the server time to process the close event
+    await new Promise(r => setTimeout(r, SSE_SETTLE_MS));
+
+    const listenersAfter = session.emitter.listenerCount('caption_result');
+    assert.equal(listenersAfter, 0, 'all listeners should be removed after client disconnect');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: POST /captions → caption_result on /events
+// ---------------------------------------------------------------------------
+
+describe('Integration — POST /captions → caption_result on /events', () => {
+  it('delivers a caption_result SSE event after POST /captions in viewer-only session', async () => {
+    // Create a session with a viewer target (no YouTube sender) so caption
+    // delivery is purely internal and doesn't require network access.
+    const session = store.create({
+      apiKey: 'test-api-key',
+      domain: 'https://test.example.com',
+      jwt: 'unused',
+      sequence: 0,
+      syncOffset: 0,
+      sender: null,
+      extraTargets: [{ id: 'v1', type: 'viewer', viewerKey: 'integration-events-test' }],
+    });
+
+    const token = makeToken(session.sessionId);
+
+    // connected + caption_result = 2 events
+    const ssePromise = collectSseEvents(
+      `${baseUrl}/events`,
+      2,
+      3000,
+      { Authorization: `Bearer ${token}` },
+    );
+
+    await new Promise(r => setTimeout(r, SSE_SETTLE_MS));
+
+    const captionRes = await fetch(`${baseUrl}/captions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ captions: [{ text: 'Integration test caption' }] }),
+    });
+    assert.equal(captionRes.status, 202);
+
+    const events = await ssePromise;
+    const resultEvent = events.find(e => e.type === 'caption_result');
+    assert.ok(resultEvent, 'should receive caption_result after POST /captions');
+  });
+});

--- a/packages/lcyt-backend/test/managers.test.js
+++ b/packages/lcyt-backend/test/managers.test.js
@@ -1,0 +1,317 @@
+/**
+ * Tests for HlsManager, RadioManager, and PreviewManager.
+ *
+ * These managers spawn ffmpeg subprocesses. Tests use --experimental-test-module-mocks
+ * to intercept node:child_process.spawn and node:fs, so no real ffmpeg or filesystem
+ * operations occur.
+ *
+ * Run with:
+ *   node --experimental-test-module-mocks --test test/managers.test.js
+ */
+
+import { describe, it, beforeEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+
+// ---------------------------------------------------------------------------
+// Fake process factory
+// ---------------------------------------------------------------------------
+
+function makeFakeProc({ errorOnKill = false } = {}) {
+  const proc = new EventEmitter();
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.stdin = { write() {}, end() {} };
+
+  const signals = [];
+  proc.kill = (signal = 'SIGTERM') => {
+    if (errorOnKill) throw new Error('kill failed');
+    signals.push(signal);
+    setImmediate(() => proc.emit('close', 0));
+  };
+  proc._signals = signals;
+  return proc;
+}
+
+// ---------------------------------------------------------------------------
+// Module mocks — must be set up before dynamic import of the managers
+// ---------------------------------------------------------------------------
+
+const spawnCalls = [];
+let nextProcFactory = () => makeFakeProc();
+
+await mock.module('node:child_process', {
+  namedExports: {
+    spawn: mock.fn((cmd, args, opts) => {
+      const proc = nextProcFactory();
+      spawnCalls.push({ cmd, args, opts, proc });
+      return proc;
+    }),
+    spawnSync: mock.fn(() => ({
+      stdout: Buffer.from('ffmpeg version 6.0\nEncoders:\n libx264\nDemuxers:\n subrip\n'),
+      status: 0,
+    })),
+  },
+});
+
+const mkdirCalls = [];
+const rmCalls = [];
+
+await mock.module('node:fs', {
+  namedExports: {
+    mkdirSync: mock.fn((dir, opts) => mkdirCalls.push({ dir, opts })),
+    rmSync: mock.fn((dir, opts) => rmCalls.push({ dir, opts })),
+    createReadStream: mock.fn(() => ({ pipe() {} })),
+    existsSync: mock.fn(() => true),
+    statSync: mock.fn(() => ({ mtime: new Date('2026-01-01T00:00:00Z') })),
+  },
+});
+
+// Now dynamically import managers (they use the mocked modules)
+const { HlsManager }     = await import('../src/hls-manager.js');
+const { RadioManager }   = await import('../src/radio-manager.js');
+const { PreviewManager } = await import('../src/preview-manager.js');
+
+// ---------------------------------------------------------------------------
+// Helper: reset call counters between tests
+// ---------------------------------------------------------------------------
+
+function resetCalls() {
+  spawnCalls.length = 0;
+  mkdirCalls.length = 0;
+  rmCalls.length = 0;
+}
+
+// ---------------------------------------------------------------------------
+// HlsManager
+// ---------------------------------------------------------------------------
+
+describe('HlsManager — constructor', () => {
+  it('uses provided options', () => {
+    const m = new HlsManager({ hlsRoot: '/tmp/hls', localRtmp: 'rtmp://host:1935', rtmpApp: 'app' });
+    assert.equal(m._hlsRoot, '/tmp/hls');
+    assert.equal(m._local, 'rtmp://host:1935');
+    assert.equal(m._app, 'app');
+  });
+
+  it('hlsDir() returns root/key path', () => {
+    const m = new HlsManager({ hlsRoot: '/tmp/hls' });
+    assert.ok(m.hlsDir('mykey').endsWith('mykey'));
+    assert.ok(m.hlsDir('mykey').includes('/tmp/hls'));
+  });
+
+  it('isRunning() returns false initially', () => {
+    const m = new HlsManager({ hlsRoot: '/tmp/hls' });
+    assert.equal(m.isRunning('anykey'), false);
+  });
+});
+
+describe('HlsManager — start()', () => {
+  beforeEach(() => { resetCalls(); nextProcFactory = () => makeFakeProc(); });
+
+  it('resolves and marks the key as running', async () => {
+    const m = new HlsManager({ hlsRoot: '/tmp/hls', localRtmp: 'rtmp://127.0.0.1:1935', rtmpApp: 'live' });
+    await m.start('key1');
+    assert.equal(m.isRunning('key1'), true);
+    assert.equal(spawnCalls.length, 1);
+    assert.equal(spawnCalls[0].cmd, 'ffmpeg');
+  });
+
+  it('creates the HLS output directory', async () => {
+    const m = new HlsManager({ hlsRoot: '/tmp/hls' });
+    await m.start('key2');
+    assert.ok(mkdirCalls.some(c => String(c.dir).includes('key2')));
+  });
+
+  it('passes correct ffmpeg args (stream copy mode)', async () => {
+    const m = new HlsManager({ hlsRoot: '/tmp/hls', localRtmp: 'rtmp://127.0.0.1:1935', rtmpApp: 'live' });
+    await m.start('mykey');
+    const args = spawnCalls[0].args;
+    assert.ok(args.includes('-c'));
+    assert.ok(args.includes('copy'));
+    assert.ok(args.includes('-f'));
+    assert.ok(args.includes('hls'));
+    assert.ok(args.some(a => String(a).includes('mykey')));
+  });
+
+  it('stops any existing process before starting a new one', async () => {
+    const m = new HlsManager({ hlsRoot: '/tmp/hls' });
+    await m.start('dupkey');
+    assert.equal(m.isRunning('dupkey'), true);
+    // Start again for the same key — should spawn a second ffmpeg
+    await m.start('dupkey');
+    // Two spawn calls confirm the restart happened
+    assert.equal(spawnCalls.length, 2);
+    // Allow any pending close-event callbacks to settle
+    await new Promise(r => setImmediate(r));
+  });
+
+  it('rejects when the process emits an error (nextTick fires before setImmediate)', async () => {
+    nextProcFactory = () => {
+      const proc = new EventEmitter();
+      proc.stdout = new EventEmitter();
+      proc.stderr = new EventEmitter();
+      proc.stdin = { write() {}, end() {} };
+      proc.kill = () => {};
+      // process.nextTick fires before setImmediate, so the error event
+      // reaches the reject() handler before resolve() is called.
+      process.nextTick(() => proc.emit('error', new Error('ENOENT')));
+      return proc;
+    };
+
+    const m = new HlsManager({ hlsRoot: '/tmp/hls' });
+    await assert.rejects(() => m.start('errkey'), /ENOENT/);
+  });
+});
+
+describe('HlsManager — stop()', () => {
+  beforeEach(() => { resetCalls(); nextProcFactory = () => makeFakeProc(); });
+
+  it('resolves immediately when the key is not running', async () => {
+    const m = new HlsManager({ hlsRoot: '/tmp/hls' });
+    await assert.doesNotReject(() => m.stop('notrunning'));
+  });
+
+  it('kills the process and marks key as not running', async () => {
+    const m = new HlsManager({ hlsRoot: '/tmp/hls' });
+    await m.start('stopkey');
+    assert.equal(m.isRunning('stopkey'), true);
+    await m.stop('stopkey');
+    assert.equal(m.isRunning('stopkey'), false);
+  });
+});
+
+describe('HlsManager — stopAll()', () => {
+  beforeEach(() => { resetCalls(); nextProcFactory = () => makeFakeProc(); });
+
+  it('stops all running processes', async () => {
+    const m = new HlsManager({ hlsRoot: '/tmp/hls' });
+    await m.start('key-a');
+    await m.start('key-b');
+    assert.equal(m.isRunning('key-a'), true);
+    assert.equal(m.isRunning('key-b'), true);
+    await m.stopAll();
+    assert.equal(m.isRunning('key-a'), false);
+    assert.equal(m.isRunning('key-b'), false);
+  });
+
+  it('is a no-op when no processes are running', async () => {
+    const m = new HlsManager({ hlsRoot: '/tmp/hls' });
+    await assert.doesNotReject(() => m.stopAll());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RadioManager — structurally identical to HlsManager
+// ---------------------------------------------------------------------------
+
+describe('RadioManager', () => {
+  beforeEach(() => { resetCalls(); nextProcFactory = () => makeFakeProc(); });
+
+  it('hlsDir() returns root/key', () => {
+    const m = new RadioManager({ hlsRoot: '/tmp/radio' });
+    assert.ok(m.hlsDir('rkey').includes('/tmp/radio'));
+  });
+
+  it('start() marks key as running and spawns ffmpeg', async () => {
+    const m = new RadioManager({ hlsRoot: '/tmp/radio', localRtmp: 'rtmp://127.0.0.1:1935', rtmpApp: 'live' });
+    await m.start('rkey');
+    assert.equal(m.isRunning('rkey'), true);
+    assert.equal(spawnCalls.length, 1);
+  });
+
+  it('uses audio-only flags (-vn, aac)', async () => {
+    const m = new RadioManager({ hlsRoot: '/tmp/radio', localRtmp: 'rtmp://127.0.0.1:1935', rtmpApp: 'live' });
+    await m.start('rkey');
+    const args = spawnCalls[0].args;
+    assert.ok(args.includes('-vn'), 'should strip video with -vn');
+    assert.ok(args.includes('aac'), 'should encode audio to aac');
+  });
+
+  it('stop() marks key as not running', async () => {
+    const m = new RadioManager({ hlsRoot: '/tmp/radio' });
+    await m.start('rkey');
+    await m.stop('rkey');
+    assert.equal(m.isRunning('rkey'), false);
+  });
+
+  it('stopAll() clears all keys', async () => {
+    const m = new RadioManager({ hlsRoot: '/tmp/radio' });
+    await m.start('r1');
+    await m.start('r2');
+    await m.stopAll();
+    assert.equal(m.isRunning('r1'), false);
+    assert.equal(m.isRunning('r2'), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PreviewManager
+// ---------------------------------------------------------------------------
+
+describe('PreviewManager — constructor', () => {
+  it('previewPath() returns root/key/incoming.jpg', () => {
+    const m = new PreviewManager({ previewRoot: '/tmp/prev' });
+    const p = m.previewPath('mykey');
+    assert.ok(p.includes('/tmp/prev'));
+    assert.ok(p.includes('mykey'));
+    assert.ok(p.endsWith('incoming.jpg'));
+  });
+
+  it('isRunning() returns false initially', () => {
+    const m = new PreviewManager({ previewRoot: '/tmp/prev' });
+    assert.equal(m.isRunning('k'), false);
+  });
+});
+
+describe('PreviewManager — start()', () => {
+  beforeEach(() => { resetCalls(); nextProcFactory = () => makeFakeProc(); });
+
+  it('resolves and marks key as running', async () => {
+    const m = new PreviewManager({ previewRoot: '/tmp/prev', localRtmp: 'rtmp://127.0.0.1:1935', rtmpApp: 'live', intervalS: 5 });
+    await m.start('pkey');
+    assert.equal(m.isRunning('pkey'), true);
+    assert.equal(spawnCalls.length, 1);
+  });
+
+  it('uses image2 muxer with fps filter and -update 1', async () => {
+    const m = new PreviewManager({ previewRoot: '/tmp/prev', localRtmp: 'rtmp://127.0.0.1:1935', rtmpApp: 'live', intervalS: 5 });
+    await m.start('pkey');
+    const args = spawnCalls[0].args;
+    assert.ok(args.includes('-update'), 'must pass -update');
+    assert.ok(args.includes('-f'));
+    assert.ok(args.includes('image2'));
+    assert.ok(args.some(a => String(a).includes('fps=')), 'must pass fps filter');
+  });
+
+  it('creates the preview output directory', async () => {
+    const m = new PreviewManager({ previewRoot: '/tmp/prev' });
+    await m.start('pkey');
+    assert.ok(mkdirCalls.some(c => String(c.dir).includes('pkey')));
+  });
+});
+
+describe('PreviewManager — stop() / stopAll()', () => {
+  beforeEach(() => { resetCalls(); nextProcFactory = () => makeFakeProc(); });
+
+  it('stop() resolves when key is not running', async () => {
+    const m = new PreviewManager({ previewRoot: '/tmp/prev' });
+    await assert.doesNotReject(() => m.stop('gone'));
+  });
+
+  it('stop() marks key as not running', async () => {
+    const m = new PreviewManager({ previewRoot: '/tmp/prev' });
+    await m.start('pk');
+    await m.stop('pk');
+    assert.equal(m.isRunning('pk'), false);
+  });
+
+  it('stopAll() clears all keys', async () => {
+    const m = new PreviewManager({ previewRoot: '/tmp/prev' });
+    await m.start('p1');
+    await m.start('p2');
+    await m.stopAll();
+    assert.equal(m.isRunning('p1'), false);
+    assert.equal(m.isRunning('p2'), false);
+  });
+});

--- a/packages/lcyt-backend/test/preview-route.test.js
+++ b/packages/lcyt-backend/test/preview-route.test.js
@@ -1,0 +1,153 @@
+/**
+ * Tests for the /preview router.
+ *
+ * PreviewManager is replaced with a lightweight mock object. The real
+ * node:fs functions (existsSync, statSync, createReadStream) touch the
+ * local filesystem, but the test JPEG is written to a temp dir so no
+ * stubs are needed — the test sets up actual files.
+ */
+
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import express from 'express';
+import { createPreviewRouter } from '../src/routes/preview.js';
+
+// ---------------------------------------------------------------------------
+// Temp directory + mock JPEG
+// ---------------------------------------------------------------------------
+
+const PREVIEW_ROOT = join(tmpdir(), `lcyt-preview-test-${Date.now()}`);
+const JPEG_KEY     = 'testkey123';
+const JPEG_DIR     = join(PREVIEW_ROOT, JPEG_KEY);
+const JPEG_FILE    = join(JPEG_DIR, 'incoming.jpg');
+
+before(() => {
+  mkdirSync(JPEG_DIR, { recursive: true });
+  // Minimal valid JPEG magic bytes + filler
+  writeFileSync(JPEG_FILE, Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46]));
+});
+
+after(() => {
+  rmSync(PREVIEW_ROOT, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Mock PreviewManager
+// ---------------------------------------------------------------------------
+
+function makeMockPreviewManager(root) {
+  return {
+    _root: root,
+    previewPath: (key) => join(root, key, 'incoming.jpg'),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test server
+// ---------------------------------------------------------------------------
+
+let server, baseUrl;
+
+const mockPreview = makeMockPreviewManager(PREVIEW_ROOT);
+
+before(() => new Promise((resolve) => {
+  const app = express();
+  app.use('/preview', createPreviewRouter(mockPreview));
+  server = createServer(app);
+  server.listen(0, () => {
+    baseUrl = `http://localhost:${server.address().port}`;
+    resolve();
+  });
+}));
+
+after(() => new Promise(r => server.close(r)));
+
+// ---------------------------------------------------------------------------
+// Key validation
+// ---------------------------------------------------------------------------
+
+describe('GET /preview/:key/incoming.jpg — key validation', () => {
+  it('returns 400 for a key that is too short', async () => {
+    const res = await fetch(`${baseUrl}/preview/ab/incoming.jpg`);
+    assert.equal(res.status, 400);
+  });
+
+  it('returns 400 for a key with invalid characters', async () => {
+    const res = await fetch(`${baseUrl}/preview/bad%20key/incoming.jpg`);
+    assert.equal(res.status, 400);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// File not found
+// ---------------------------------------------------------------------------
+
+describe('GET /preview/:key/incoming.jpg — file missing', () => {
+  it('returns 404 when preview file does not exist', async () => {
+    const res = await fetch(`${baseUrl}/preview/nostream/incoming.jpg`);
+    assert.equal(res.status, 404);
+    const body = await res.json();
+    assert.ok(body.error);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// File exists — normal response
+// ---------------------------------------------------------------------------
+
+describe('GET /preview/:key/incoming.jpg — file present', () => {
+  it('returns 200 with image/jpeg content type', async () => {
+    const res = await fetch(`${baseUrl}/preview/${JPEG_KEY}/incoming.jpg`);
+    assert.equal(res.status, 200);
+    assert.ok(res.headers.get('content-type')?.includes('image/jpeg'));
+  });
+
+  it('sets CORS header to *', async () => {
+    const res = await fetch(`${baseUrl}/preview/${JPEG_KEY}/incoming.jpg`);
+    assert.equal(res.headers.get('access-control-allow-origin'), '*');
+  });
+
+  it('sets Cache-Control with public max-age=5', async () => {
+    const res = await fetch(`${baseUrl}/preview/${JPEG_KEY}/incoming.jpg`);
+    const cc = res.headers.get('cache-control');
+    assert.ok(cc?.includes('public'));
+    assert.ok(cc?.includes('max-age=5'));
+  });
+
+  it('sets Last-Modified header', async () => {
+    const res = await fetch(`${baseUrl}/preview/${JPEG_KEY}/incoming.jpg`);
+    assert.ok(res.headers.get('last-modified'));
+  });
+
+  it('returns 304 when If-Modified-Since is in the future', async () => {
+    const future = new Date(Date.now() + 60_000).toUTCString();
+    const res = await fetch(`${baseUrl}/preview/${JPEG_KEY}/incoming.jpg`, {
+      headers: { 'If-Modified-Since': future },
+    });
+    assert.equal(res.status, 304);
+  });
+
+  it('returns 200 when If-Modified-Since is in the past', async () => {
+    const past = new Date(Date.now() - 60_000).toUTCString();
+    const res = await fetch(`${baseUrl}/preview/${JPEG_KEY}/incoming.jpg`, {
+      headers: { 'If-Modified-Since': past },
+    });
+    assert.equal(res.status, 200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CORS preflight
+// ---------------------------------------------------------------------------
+
+describe('OPTIONS /preview/:key/* — CORS preflight', () => {
+  it('returns 204 with CORS headers', async () => {
+    const res = await fetch(`${baseUrl}/preview/${JPEG_KEY}/incoming.jpg`, { method: 'OPTIONS' });
+    assert.equal(res.status, 204);
+    assert.equal(res.headers.get('access-control-allow-origin'), '*');
+  });
+});

--- a/packages/lcyt-backend/test/rtmp-manager.test.js
+++ b/packages/lcyt-backend/test/rtmp-manager.test.js
@@ -1,0 +1,320 @@
+/**
+ * Tests for RtmpRelayManager and probeFfmpeg.
+ *
+ * node:child_process.spawn and spawnSync are mocked so no real ffmpeg runs.
+ * Run with: node --experimental-test-module-mocks --test test/rtmp-manager.test.js
+ */
+
+import { describe, it, beforeEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+
+// ---------------------------------------------------------------------------
+// Fake ChildProcess
+// ---------------------------------------------------------------------------
+
+function makeFakeProc({ errorOnKill = false } = {}) {
+  const proc = new EventEmitter();
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.stdin = {
+    destroyed: false,
+    _written: [],
+    write(chunk) { this._written.push(chunk); return true; },
+    end() { this.destroyed = true; },
+  };
+  proc.kill = (signal = 'SIGTERM') => {
+    if (errorOnKill) throw new Error('kill failed');
+    setImmediate(() => proc.emit('close', 0));
+  };
+  return proc;
+}
+
+// ---------------------------------------------------------------------------
+// Module mocks — must be set up before dynamic import
+// ---------------------------------------------------------------------------
+
+const spawnCalls = [];
+let nextProcFactory = () => makeFakeProc();
+
+await mock.module('node:child_process', {
+  namedExports: {
+    spawn: mock.fn((cmd, args, opts) => {
+      const proc = nextProcFactory();
+      spawnCalls.push({ cmd, args, opts, proc });
+      return proc;
+    }),
+    spawnSync: mock.fn((cmd, args) => {
+      if (args && args[0] === '-version') {
+        return { stdout: Buffer.from('ffmpeg version 6.0'), status: 0, error: null };
+      }
+      // Simulate encoders output for probeFfmpeg
+      const out = 'ffmpeg version 6.0\nEncoders:\n libx264 H.264 (libx264)\n eia608 CEA-608/708\nDemuxers:\n subrip SubRip\n';
+      return { stdout: Buffer.from(out), stderr: Buffer.from(out), status: 0, error: null };
+    }),
+  },
+});
+
+// Dynamically import after mocks are set up
+const { RtmpRelayManager, probeFfmpeg } = await import('../src/rtmp-manager.js');
+
+// ---------------------------------------------------------------------------
+// Helper: reset between tests
+// ---------------------------------------------------------------------------
+
+function resetCalls() {
+  spawnCalls.length = 0;
+}
+
+const TEST_RELAYS = [
+  { slot: 1, targetUrl: 'rtmp://live.example.com/app/key1', targetName: null, captionMode: 'http' },
+];
+
+// ---------------------------------------------------------------------------
+// probeFfmpeg
+// ---------------------------------------------------------------------------
+
+describe('probeFfmpeg', () => {
+  it('returns available=true when ffmpeg exists', () => {
+    const caps = probeFfmpeg();
+    assert.equal(caps.available, true);
+  });
+
+  it('returns hasLibx264=true when encoder is in output', () => {
+    const caps = probeFfmpeg();
+    assert.equal(caps.hasLibx264, true);
+  });
+
+  it('returns hasEia608=true when encoder is in output', () => {
+    const caps = probeFfmpeg();
+    assert.equal(caps.hasEia608, true);
+  });
+
+  it('returns hasSubrip=true when demuxer is in output', () => {
+    const caps = probeFfmpeg();
+    assert.equal(caps.hasSubrip, true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RtmpRelayManager — constructor / state queries
+// ---------------------------------------------------------------------------
+
+describe('RtmpRelayManager — constructor', () => {
+  it('isRunning() returns false initially', () => {
+    const m = new RtmpRelayManager({});
+    assert.equal(m.isRunning('anykey'), false);
+  });
+
+  it('runningSlots() returns [] when nothing running', () => {
+    const m = new RtmpRelayManager({});
+    assert.deepEqual(m.runningSlots('anykey'), []);
+  });
+
+  it('startedAt() returns null initially', () => {
+    const m = new RtmpRelayManager({});
+    assert.equal(m.startedAt('anykey'), null);
+  });
+
+  it('hasCea708() returns false initially', () => {
+    const m = new RtmpRelayManager({});
+    assert.equal(m.hasCea708('anykey'), false);
+  });
+
+  it('isPublishing() returns false initially', () => {
+    const m = new RtmpRelayManager({});
+    assert.equal(m.isPublishing('anykey'), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RtmpRelayManager — publish tracking
+// ---------------------------------------------------------------------------
+
+describe('RtmpRelayManager — publish tracking', () => {
+  it('markPublishing / isPublishing / markNotPublishing', () => {
+    const m = new RtmpRelayManager({});
+    m.markPublishing('key1');
+    assert.equal(m.isPublishing('key1'), true);
+    m.markNotPublishing('key1');
+    assert.equal(m.isPublishing('key1'), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RtmpRelayManager — start()
+// ---------------------------------------------------------------------------
+
+describe('RtmpRelayManager — start()', () => {
+  beforeEach(() => { resetCalls(); nextProcFactory = () => makeFakeProc(); });
+
+  it('resolves and marks key as running', async () => {
+    const m = new RtmpRelayManager({});
+    await m.start('key1', TEST_RELAYS);
+    assert.equal(m.isRunning('key1'), true);
+    assert.equal(spawnCalls.length, 1);
+    assert.equal(spawnCalls[0].cmd, 'ffmpeg');
+  });
+
+  it('uses -c copy in simple stream copy mode', async () => {
+    const m = new RtmpRelayManager({});
+    await m.start('key1', TEST_RELAYS);
+    const args = spawnCalls[0].args;
+    assert.ok(args.includes('-c'), 'should pass -c');
+    assert.ok(args.includes('copy'), 'should use copy codec');
+    assert.ok(args.includes('-f'), 'should pass -f');
+    assert.ok(args.includes('tee'), 'should use tee muxer');
+  });
+
+  it('includes the target URL in tee args', async () => {
+    const m = new RtmpRelayManager({});
+    await m.start('key1', TEST_RELAYS);
+    const args = spawnCalls[0].args;
+    const teeArg = args.find(a => String(a).includes('rtmp://live.example.com'));
+    assert.ok(teeArg, 'tee muxer arg should include target URL');
+  });
+
+  it('stops any existing process before starting new one', async () => {
+    const m = new RtmpRelayManager({});
+    await m.start('dup', TEST_RELAYS);
+    assert.equal(m.isRunning('dup'), true);
+    // Start again — should spawn a second ffmpeg for the same key
+    await m.start('dup', TEST_RELAYS);
+    assert.equal(spawnCalls.length, 2);
+    // Allow any pending close-event callbacks to settle
+    await new Promise(r => setImmediate(r));
+  });
+
+  it('resolves immediately with no relays (stops existing proc)', async () => {
+    const m = new RtmpRelayManager({});
+    await m.start('empty', TEST_RELAYS);
+    assert.equal(m.isRunning('empty'), true);
+    await m.start('empty', []);
+    assert.equal(m.isRunning('empty'), false);
+  });
+
+  it('rejects when ffmpegCaps.available is false', async () => {
+    const m = new RtmpRelayManager({ ffmpegCaps: { available: false } });
+    await assert.rejects(() => m.start('key1', TEST_RELAYS), /ffmpeg/i);
+  });
+
+  it('records startedAt after start()', async () => {
+    const m = new RtmpRelayManager({});
+    await m.start('k', TEST_RELAYS);
+    assert.ok(m.startedAt('k') instanceof Date);
+  });
+
+  it('runningSlots() returns correct slot numbers', async () => {
+    const m = new RtmpRelayManager({});
+    const relays = [
+      { slot: 1, targetUrl: 'rtmp://a.com/live/k1', captionMode: 'http' },
+      { slot: 3, targetUrl: 'rtmp://a.com/live/k3', captionMode: 'http' },
+    ];
+    await m.start('k', relays);
+    assert.deepEqual(m.runningSlots('k'), [1, 3]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RtmpRelayManager — stop() / stopKey() / stopAll()
+// ---------------------------------------------------------------------------
+
+describe('RtmpRelayManager — stop()', () => {
+  beforeEach(() => { resetCalls(); nextProcFactory = () => makeFakeProc(); });
+
+  it('resolves immediately when key is not running', async () => {
+    const m = new RtmpRelayManager({});
+    await assert.doesNotReject(() => m.stop('notrunning'));
+  });
+
+  it('marks key as not running after stop()', async () => {
+    const m = new RtmpRelayManager({});
+    await m.start('k', TEST_RELAYS);
+    assert.equal(m.isRunning('k'), true);
+    await m.stop('k');
+    assert.equal(m.isRunning('k'), false);
+  });
+
+  it('stopKey() is an alias for stop()', async () => {
+    const m = new RtmpRelayManager({});
+    await m.start('k', TEST_RELAYS);
+    await m.stopKey('k');
+    assert.equal(m.isRunning('k'), false);
+  });
+
+  it('stopAll() stops all running processes', async () => {
+    const m = new RtmpRelayManager({});
+    await m.start('a', TEST_RELAYS);
+    await m.start('b', [{ slot: 1, targetUrl: 'rtmp://b.com/live/key', captionMode: 'http' }]);
+    assert.equal(m.isRunning('a'), true);
+    assert.equal(m.isRunning('b'), true);
+    await m.stopAll();
+    assert.equal(m.isRunning('a'), false);
+    assert.equal(m.isRunning('b'), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RtmpRelayManager — startAll() alias
+// ---------------------------------------------------------------------------
+
+describe('RtmpRelayManager — startAll()', () => {
+  beforeEach(() => { resetCalls(); nextProcFactory = () => makeFakeProc(); });
+
+  it('startAll() is an alias for start()', async () => {
+    const m = new RtmpRelayManager({});
+    await m.startAll('k', TEST_RELAYS);
+    assert.equal(m.isRunning('k'), true);
+    assert.equal(spawnCalls.length, 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RtmpRelayManager — isSlotRunning()
+// ---------------------------------------------------------------------------
+
+describe('RtmpRelayManager — isSlotRunning()', () => {
+  beforeEach(() => { resetCalls(); nextProcFactory = () => makeFakeProc(); });
+
+  it('returns false when not running', () => {
+    const m = new RtmpRelayManager({});
+    assert.equal(m.isSlotRunning('k', 1), false);
+  });
+
+  it('returns true for running slot', async () => {
+    const m = new RtmpRelayManager({});
+    await m.start('k', TEST_RELAYS);
+    assert.equal(m.isSlotRunning('k', 1), true);
+    assert.equal(m.isSlotRunning('k', 2), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RtmpRelayManager — writeCaption()
+// ---------------------------------------------------------------------------
+
+describe('RtmpRelayManager — writeCaption()', () => {
+  beforeEach(() => { resetCalls(); nextProcFactory = () => makeFakeProc(); });
+
+  it('returns false when key is not running in CEA-708 mode', async () => {
+    const m = new RtmpRelayManager({});
+    // Not running
+    assert.equal(m.writeCaption('k', 'Hello'), false);
+
+    // Running but not CEA-708
+    await m.start('k', TEST_RELAYS);
+    assert.equal(m.writeCaption('k', 'Hello'), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RtmpRelayManager — dropPublisher()
+// ---------------------------------------------------------------------------
+
+describe('RtmpRelayManager — dropPublisher()', () => {
+  it('is a no-op when RTMP_CONTROL_URL is not set', async () => {
+    const m = new RtmpRelayManager({ rtmpControlUrl: null });
+    // Should not throw
+    await assert.doesNotReject(() => m.dropPublisher('anykey'));
+  });
+});

--- a/packages/lcyt-backend/test/stream.test.js
+++ b/packages/lcyt-backend/test/stream.test.js
@@ -1,0 +1,402 @@
+/**
+ * Tests for the /stream router (RTMP relay CRUD).
+ *
+ * Uses an in-memory SQLite database with a pre-seeded API key that has
+ * relay_allowed = 1. A lightweight mock RtmpRelayManager avoids ffmpeg.
+ */
+
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import express from 'express';
+import jwt from 'jsonwebtoken';
+import { initDb } from '../src/db.js';
+import { createAuthMiddleware } from '../src/middleware/auth.js';
+import { createStreamRouter } from '../src/routes/stream.js';
+
+const JWT_SECRET = 'test-stream-secret';
+const TEST_API_KEY = 'stream-test-key-abc123';
+
+// ---------------------------------------------------------------------------
+// Mock RtmpRelayManager
+// ---------------------------------------------------------------------------
+
+function makeMockRelayManager({ runningKeys = [], publishingKeys = [] } = {}) {
+  const running = new Set(runningKeys);
+  const publishing = new Set(publishingKeys);
+  const startCalls = [];
+  const stopCalls = [];
+
+  return {
+    _running: running,
+    _startCalls: startCalls,
+    _stopCalls: stopCalls,
+    isRunning:        (key) => running.has(key),
+    isPublishing:     (key) => publishing.has(key),
+    runningSlots:     (key) => [],
+    start:            async (key, relays) => { startCalls.push({ key, relays }); running.add(key); },
+    startAll:         async (key, relays) => { startCalls.push({ key, relays }); running.add(key); },
+    stop:             async (key) => { stopCalls.push(key); running.delete(key); },
+    stopKey:          async (key) => { stopCalls.push(key); running.delete(key); },
+    stopAll:          async () => { running.clear(); },
+    dropPublisher:    async (key) => {},
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test server setup
+// ---------------------------------------------------------------------------
+
+let server, baseUrl, db, mockRelay, authToken;
+
+before(() => new Promise((resolve) => {
+  db = initDb(':memory:');
+
+  // Insert a relay-allowed API key
+  db.prepare(
+    `INSERT INTO api_keys (key, owner, active, relay_allowed, relay_active)
+     VALUES (?, 'Test Owner', 1, 1, 0)`
+  ).run(TEST_API_KEY);
+
+  mockRelay = makeMockRelayManager();
+
+  const auth = createAuthMiddleware(JWT_SECRET);
+  const app = express();
+  app.use(express.json());
+  // allowedRtmpDomains = '*' → no domain restriction
+  app.use('/stream', createStreamRouter(db, auth, mockRelay, '*'));
+
+  server = createServer(app);
+  server.listen(0, () => {
+    baseUrl = `http://localhost:${server.address().port}`;
+    resolve();
+  });
+
+  // Build a JWT for the test API key (session token format)
+  authToken = jwt.sign(
+    { sessionId: 'sess-stream-001', apiKey: TEST_API_KEY, domain: 'https://test.com' },
+    JWT_SECRET,
+  );
+}));
+
+after(() => new Promise((resolve) => {
+  db.close();
+  server.close(resolve);
+}));
+
+// Reset relay mock and DB slots before each test
+beforeEach(() => {
+  db.prepare('DELETE FROM rtmp_relays WHERE api_key = ?').run(TEST_API_KEY);
+  mockRelay._running.clear();
+  mockRelay._startCalls.length = 0;
+  mockRelay._stopCalls.length = 0;
+});
+
+// Helper
+async function streamFetch(path, opts = {}) {
+  return fetch(`${baseUrl}/stream${path}`, {
+    headers: {
+      Authorization: `Bearer ${authToken}`,
+      'Content-Type': 'application/json',
+      ...(opts.headers || {}),
+    },
+    ...opts,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Authentication
+// ---------------------------------------------------------------------------
+
+describe('GET /stream — authentication', () => {
+  it('returns 401 without token', async () => {
+    const res = await fetch(`${baseUrl}/stream`);
+    assert.equal(res.status, 401);
+  });
+
+  it('returns 401 with invalid token', async () => {
+    const res = await fetch(`${baseUrl}/stream`, {
+      headers: { Authorization: 'Bearer bad.token.value' },
+    });
+    assert.equal(res.status, 401);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// relay_allowed check
+// ---------------------------------------------------------------------------
+
+describe('/stream — relay_allowed check', () => {
+  it('returns 403 when relay_allowed = 0', async () => {
+    // Insert a key with relay_allowed = 0
+    const LOCKED_KEY = 'no-relay-key-xyz9876';
+    db.prepare(
+      `INSERT OR IGNORE INTO api_keys (key, owner, active, relay_allowed) VALUES (?, 'Locked', 1, 0)`
+    ).run(LOCKED_KEY);
+
+    const lockedToken = jwt.sign(
+      { sessionId: 'locked-sess', apiKey: LOCKED_KEY, domain: 'https://test.com' },
+      JWT_SECRET,
+    );
+
+    const res = await fetch(`${baseUrl}/stream`, {
+      headers: { Authorization: `Bearer ${lockedToken}` },
+    });
+    assert.equal(res.status, 403);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /stream
+// ---------------------------------------------------------------------------
+
+describe('POST /stream — create relay slot', () => {
+  it('returns 400 for missing targetUrl', async () => {
+    const res = await streamFetch('/', {
+      method: 'POST',
+      body: JSON.stringify({ slot: 1 }),
+    });
+    assert.equal(res.status, 400);
+    const body = await res.json();
+    assert.ok(body.error?.toLowerCase().includes('targeturl') || body.error?.toLowerCase().includes('rtmp'));
+  });
+
+  it('returns 400 for non-rtmp targetUrl', async () => {
+    const res = await streamFetch('/', {
+      method: 'POST',
+      body: JSON.stringify({ slot: 1, targetUrl: 'https://example.com' }),
+    });
+    assert.equal(res.status, 400);
+  });
+
+  it('returns 400 for invalid slot (> 4)', async () => {
+    const res = await streamFetch('/', {
+      method: 'POST',
+      body: JSON.stringify({ slot: 5, targetUrl: 'rtmp://example.com/live/key' }),
+    });
+    assert.equal(res.status, 400);
+  });
+
+  it('returns 400 for invalid scale format', async () => {
+    const res = await streamFetch('/', {
+      method: 'POST',
+      body: JSON.stringify({ targetUrl: 'rtmp://example.com/live/key', scale: 'bad' }),
+    });
+    assert.equal(res.status, 400);
+  });
+
+  it('creates a relay slot and returns 201', async () => {
+    const res = await streamFetch('/', {
+      method: 'POST',
+      body: JSON.stringify({ slot: 1, targetUrl: 'rtmp://example.com/live/key', targetName: 'mystream' }),
+    });
+    assert.equal(res.status, 201);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.ok(body.relay);
+    assert.equal(body.relay.slot, 1);
+    assert.equal(body.relay.targetUrl, 'rtmp://example.com/live/key');
+    assert.equal(body.relay.targetName, 'mystream');
+  });
+
+  it('returns 400 when all 4 slots are used', async () => {
+    // Fill all 4 slots
+    for (let s = 1; s <= 4; s++) {
+      await streamFetch('/', {
+        method: 'POST',
+        body: JSON.stringify({ slot: s, targetUrl: `rtmp://example.com/live/slot${s}` }),
+      });
+    }
+    // Attempt to add a new slot 5 — already blocked, try to add beyond 4
+    const res = await streamFetch('/', {
+      method: 'POST',
+      body: JSON.stringify({ slot: 4, targetUrl: 'rtmp://example.com/live/new' }),
+    });
+    // Slot 4 already exists → upsert is OK (not a new slot)
+    assert.equal(res.status, 201);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /stream
+// ---------------------------------------------------------------------------
+
+describe('GET /stream — list slots', () => {
+  it('returns 200 with empty relays when none configured', async () => {
+    const res = await streamFetch('/');
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(Array.isArray(body.relays));
+    assert.equal(body.relays.length, 0);
+    assert.ok(Array.isArray(body.runningSlots));
+  });
+
+  it('lists configured slots', async () => {
+    await streamFetch('/', {
+      method: 'POST',
+      body: JSON.stringify({ slot: 1, targetUrl: 'rtmp://example.com/live/s1' }),
+    });
+    const res = await streamFetch('/');
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.relays.length, 1);
+    assert.equal(body.relays[0].slot, 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /stream/history
+// ---------------------------------------------------------------------------
+
+describe('GET /stream/history', () => {
+  it('returns 200 with empty streams array initially', async () => {
+    const res = await streamFetch('/history');
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(Array.isArray(body.streams));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PUT /stream/active
+// ---------------------------------------------------------------------------
+
+describe('PUT /stream/active', () => {
+  it('returns 400 when active is not boolean', async () => {
+    const res = await streamFetch('/active', {
+      method: 'PUT',
+      body: JSON.stringify({ active: 'yes' }),
+    });
+    assert.equal(res.status, 400);
+  });
+
+  it('sets relay_active to true and returns 200', async () => {
+    const res = await streamFetch('/active', {
+      method: 'PUT',
+      body: JSON.stringify({ active: true }),
+    });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.active, true);
+
+    // Verify persisted
+    const row = db.prepare('SELECT relay_active FROM api_keys WHERE key = ?').get(TEST_API_KEY);
+    assert.equal(row.relay_active, 1);
+  });
+
+  it('sets relay_active to false and stops running process', async () => {
+    // Simulate a running process
+    mockRelay._running.add(TEST_API_KEY);
+    const res = await streamFetch('/active', {
+      method: 'PUT',
+      body: JSON.stringify({ active: false }),
+    });
+    assert.equal(res.status, 200);
+    assert.equal(mockRelay._stopCalls.includes(TEST_API_KEY), true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PUT /stream/:slot
+// ---------------------------------------------------------------------------
+
+describe('PUT /stream/:slot — update slot', () => {
+  it('returns 404 for a slot that does not exist', async () => {
+    const res = await streamFetch('/2', {
+      method: 'PUT',
+      body: JSON.stringify({ targetUrl: 'rtmp://example.com/live/updated' }),
+    });
+    assert.equal(res.status, 404);
+  });
+
+  it('returns 400 for invalid slot number', async () => {
+    const res = await streamFetch('/0', {
+      method: 'PUT',
+      body: JSON.stringify({ targetUrl: 'rtmp://example.com/live/s1' }),
+    });
+    assert.equal(res.status, 400);
+  });
+
+  it('updates an existing slot and returns 200', async () => {
+    // Create slot 1 first
+    await streamFetch('/', {
+      method: 'POST',
+      body: JSON.stringify({ slot: 1, targetUrl: 'rtmp://example.com/live/original' }),
+    });
+
+    const res = await streamFetch('/1', {
+      method: 'PUT',
+      body: JSON.stringify({ targetUrl: 'rtmp://example.com/live/updated', targetName: 'newname' }),
+    });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.relay.targetUrl, 'rtmp://example.com/live/updated');
+    assert.equal(body.relay.targetName, 'newname');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /stream/:slot
+// ---------------------------------------------------------------------------
+
+describe('DELETE /stream/:slot', () => {
+  it('returns 400 for invalid slot', async () => {
+    const res = await streamFetch('/99', { method: 'DELETE' });
+    assert.equal(res.status, 400);
+  });
+
+  it('deletes a slot and returns 200', async () => {
+    // Create slot 1
+    await streamFetch('/', {
+      method: 'POST',
+      body: JSON.stringify({ slot: 1, targetUrl: 'rtmp://example.com/live/s1' }),
+    });
+
+    const res = await streamFetch('/1', { method: 'DELETE' });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.slot, 1);
+
+    // Verify gone from DB
+    const remaining = db.prepare('SELECT * FROM rtmp_relays WHERE api_key = ?').all(TEST_API_KEY);
+    assert.equal(remaining.length, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /stream
+// ---------------------------------------------------------------------------
+
+describe('DELETE /stream — delete all slots', () => {
+  it('deletes all slots and returns count', async () => {
+    // Create two slots
+    await streamFetch('/', {
+      method: 'POST',
+      body: JSON.stringify({ slot: 1, targetUrl: 'rtmp://example.com/live/s1' }),
+    });
+    await streamFetch('/', {
+      method: 'POST',
+      body: JSON.stringify({ slot: 2, targetUrl: 'rtmp://example.com/live/s2' }),
+    });
+
+    const res = await streamFetch('/', { method: 'DELETE' });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.deleted, 2);
+
+    // Verify DB is empty
+    const remaining = db.prepare('SELECT * FROM rtmp_relays WHERE api_key = ?').all(TEST_API_KEY);
+    assert.equal(remaining.length, 0);
+  });
+
+  it('returns 0 deleted when nothing was configured', async () => {
+    const res = await streamFetch('/', { method: 'DELETE' });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.deleted, 0);
+  });
+});

--- a/packages/lcyt-backend/test/video.test.js
+++ b/packages/lcyt-backend/test/video.test.js
@@ -1,0 +1,206 @@
+/**
+ * Tests for the /video router.
+ *
+ * HlsManager and HlsSubsManager are replaced with lightweight mock objects,
+ * and fs functions (createReadStream, existsSync) are injected via a mini
+ * test-only variant that overrides process.env.BACKEND_URL.
+ */
+
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import express from 'express';
+import { createVideoRouter } from '../src/routes/video.js';
+
+// ---------------------------------------------------------------------------
+// Mock HlsManager
+// ---------------------------------------------------------------------------
+
+function makeMockHlsManager({ running = [] } = {}) {
+  const runningSet = new Set(running);
+  return {
+    isRunning: (key) => runningSet.has(key),
+    _runningSet: runningSet,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mock HlsSubsManager
+// ---------------------------------------------------------------------------
+
+function makeMockSubsManager({ languages = {}, playlists = {}, subsRoot = '/tmp/subs' } = {}) {
+  return {
+    _subsRoot: subsRoot,
+    getLanguages: (key) => languages[key] || [],
+    getPlaylist: (key, lang) => playlists[`${key}:${lang}`] || null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test server setup
+// ---------------------------------------------------------------------------
+
+let server, baseUrl;
+
+const mockHls  = makeMockHlsManager({ running: ['live-key'] });
+const mockSubs = makeMockSubsManager({
+  languages : { 'live-key': ['en-US', 'fi-FI'] },
+  playlists : { 'live-key:en-US': '#EXTM3U\n#EXT-X-VERSION:3\n' },
+  subsRoot  : '/tmp/subs',
+});
+
+before(() => new Promise((resolve) => {
+  process.env.BACKEND_URL = 'http://backend.test';
+
+  const app = express();
+  app.use('/video', createVideoRouter(null, mockHls, mockSubs));
+
+  server = createServer(app);
+  server.listen(0, () => {
+    baseUrl = `http://localhost:${server.address().port}`;
+    resolve();
+  });
+}));
+
+after(() => new Promise((resolve) => {
+  delete process.env.BACKEND_URL;
+  server.close(resolve);
+}));
+
+// ---------------------------------------------------------------------------
+// GET /video/:key — player page
+// ---------------------------------------------------------------------------
+
+describe('GET /video/:key — player HTML page', () => {
+  it('returns 400 for an invalid key (too short)', async () => {
+    const res = await fetch(`${baseUrl}/video/ab`);
+    assert.equal(res.status, 400);
+  });
+
+  it('returns 400 for a key with invalid characters', async () => {
+    const res = await fetch(`${baseUrl}/video/bad%20key`);
+    assert.equal(res.status, 400);
+  });
+
+  it('returns 200 HTML for a valid key regardless of stream status', async () => {
+    const res = await fetch(`${baseUrl}/video/validkey`);
+    assert.equal(res.status, 200);
+    assert.ok(res.headers.get('content-type')?.includes('text/html'));
+    const body = await res.text();
+    assert.ok(body.includes('<!DOCTYPE html>'));
+    assert.ok(body.includes('validkey'));
+  });
+
+  it('includes CORS headers', async () => {
+    const res = await fetch(`${baseUrl}/video/validkey`);
+    assert.equal(res.headers.get('access-control-allow-origin'), '*');
+  });
+
+  it('applies dark theme by default', async () => {
+    const res = await fetch(`${baseUrl}/video/validkey`);
+    const body = await res.text();
+    assert.ok(body.includes('#111'), 'dark background');
+  });
+
+  it('applies light theme when ?theme=light', async () => {
+    const res = await fetch(`${baseUrl}/video/validkey?theme=light`);
+    const body = await res.text();
+    assert.ok(body.includes('#f5f5f5'), 'light background');
+  });
+
+  it('sets Cache-Control: no-cache', async () => {
+    const res = await fetch(`${baseUrl}/video/validkey`);
+    assert.ok(res.headers.get('cache-control')?.includes('no-cache'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /video/:key/master.m3u8
+// ---------------------------------------------------------------------------
+
+describe('GET /video/:key/master.m3u8 — HLS master manifest', () => {
+  it('returns 404 when stream is not live', async () => {
+    const res = await fetch(`${baseUrl}/video/offline-key/master.m3u8`);
+    assert.equal(res.status, 404);
+  });
+
+  it('returns 400 for invalid key', async () => {
+    const res = await fetch(`${baseUrl}/video/x/master.m3u8`);
+    assert.equal(res.status, 400);
+  });
+
+  it('returns 200 with HLS manifest for a running stream', async () => {
+    const res = await fetch(`${baseUrl}/video/live-key/master.m3u8`);
+    assert.equal(res.status, 200);
+    assert.ok(res.headers.get('content-type')?.includes('mpegurl'));
+    const body = await res.text();
+    assert.ok(body.includes('#EXTM3U'), 'should be an HLS playlist');
+    assert.ok(body.includes('live-key'), 'should reference the key');
+  });
+
+  it('includes subtitle tracks in manifest when subs manager has languages', async () => {
+    const res = await fetch(`${baseUrl}/video/live-key/master.m3u8`);
+    const body = await res.text();
+    // Subtitle groups are present since getLanguages returns ['en-US', 'fi-FI']
+    assert.ok(body.includes('en-US') || body.includes('subs'), 'should include subtitle tracks');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /video/:key/subs/:lang/playlist.m3u8
+// ---------------------------------------------------------------------------
+
+describe('GET /video/:key/subs/:lang/playlist.m3u8 — subtitle playlist', () => {
+  it('returns 404 when playlist is not available', async () => {
+    const res = await fetch(`${baseUrl}/video/live-key/subs/de-DE/playlist.m3u8`);
+    assert.equal(res.status, 404);
+  });
+
+  it('returns 400 for invalid lang tag', async () => {
+    const res = await fetch(`${baseUrl}/video/live-key/subs/../etc/playlist.m3u8`);
+    assert.notEqual(res.status, 200); // traversal attempt blocked
+  });
+
+  it('returns 200 with playlist content when available', async () => {
+    const res = await fetch(`${baseUrl}/video/live-key/subs/en-US/playlist.m3u8`);
+    assert.equal(res.status, 200);
+    assert.ok(res.headers.get('content-type')?.includes('mpegurl'));
+    const body = await res.text();
+    assert.ok(body.includes('#EXTM3U'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /video/:key/subs/:lang/:segment — WebVTT segment
+// ---------------------------------------------------------------------------
+
+describe('GET /video/:key/subs/:lang/:segment — WebVTT segment file', () => {
+  it('returns 400 for invalid segment filename format', async () => {
+    const res = await fetch(`${baseUrl}/video/live-key/subs/en-US/badname.vtt`);
+    assert.equal(res.status, 400);
+  });
+
+  it('returns 400 for invalid key', async () => {
+    const res = await fetch(`${baseUrl}/video/x/subs/en-US/seg000001.vtt`);
+    assert.equal(res.status, 400);
+  });
+
+  it('returns 404 when segment file does not exist (existsSync returns false)', async () => {
+    // The router calls existsSync(file); since we did not mock it here,
+    // the real fs will return false for a non-existent path.
+    const res = await fetch(`${baseUrl}/video/live-key/subs/en-US/seg000001.vtt`);
+    assert.equal(res.status, 404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OPTIONS preflight
+// ---------------------------------------------------------------------------
+
+describe('OPTIONS /video/* — CORS preflight', () => {
+  it('returns 204 with CORS headers', async () => {
+    const res = await fetch(`${baseUrl}/video/live-key`, { method: 'OPTIONS' });
+    assert.equal(res.status, 204);
+    assert.equal(res.headers.get('access-control-allow-origin'), '*');
+  });
+});

--- a/packages/lcyt-backend/test/youtube.test.js
+++ b/packages/lcyt-backend/test/youtube.test.js
@@ -1,0 +1,95 @@
+/**
+ * Tests for GET /youtube/config
+ *
+ * Verifies that the route returns the YOUTUBE_CLIENT_ID env var when configured
+ * and 503 when it is not set.
+ */
+
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import express from 'express';
+import jwt from 'jsonwebtoken';
+import { createYouTubeRouter } from '../src/routes/youtube.js';
+import { createAuthMiddleware } from '../src/middleware/auth.js';
+
+const JWT_SECRET = 'test-youtube-secret';
+
+let server, baseUrl;
+
+before(() => new Promise((resolve) => {
+  const auth = createAuthMiddleware(JWT_SECRET);
+  const app = express();
+  app.use('/youtube', createYouTubeRouter(auth));
+
+  server = createServer(app);
+  server.listen(0, () => {
+    baseUrl = `http://localhost:${server.address().port}`;
+    resolve();
+  });
+}));
+
+after(() => new Promise(r => server.close(r)));
+
+// Helper: make a valid token (session token format)
+function makeToken() {
+  return jwt.sign(
+    { sessionId: 'sess-001', apiKey: 'test-key', domain: 'https://test.com' },
+    JWT_SECRET,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Authentication
+// ---------------------------------------------------------------------------
+
+describe('GET /youtube/config — authentication', () => {
+  it('returns 401 without a token', async () => {
+    const res = await fetch(`${baseUrl}/youtube/config`);
+    assert.equal(res.status, 401);
+  });
+
+  it('returns 401 for an invalid token', async () => {
+    const res = await fetch(`${baseUrl}/youtube/config`, {
+      headers: { Authorization: 'Bearer bad.token.here' },
+    });
+    assert.equal(res.status, 401);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// With YOUTUBE_CLIENT_ID not set
+// ---------------------------------------------------------------------------
+
+describe('GET /youtube/config — client ID not configured', () => {
+  beforeEach(() => { delete process.env.YOUTUBE_CLIENT_ID; });
+
+  it('returns 503 when YOUTUBE_CLIENT_ID is not set', async () => {
+    const token = makeToken();
+    const res = await fetch(`${baseUrl}/youtube/config`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    assert.equal(res.status, 503);
+    const body = await res.json();
+    assert.ok(body.error);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// With YOUTUBE_CLIENT_ID set
+// ---------------------------------------------------------------------------
+
+describe('GET /youtube/config — client ID configured', () => {
+  beforeEach(() => { process.env.YOUTUBE_CLIENT_ID = 'test-client-id.apps.googleusercontent.com'; });
+  after(() => { delete process.env.YOUTUBE_CLIENT_ID; });
+
+  it('returns 200 with clientId', async () => {
+    const token = makeToken();
+    const res = await fetch(`${baseUrl}/youtube/config`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.clientId, 'test-client-id.apps.googleusercontent.com');
+  });
+});

--- a/packages/lcyt-bridge/package.json
+++ b/packages/lcyt-bridge/package.json
@@ -8,6 +8,7 @@
     "lcyt-bridge": "src/index.js"
   },
   "scripts": {
+    "test": "node --test test/*.test.js",
     "start": "node src/index.js",
     "build:win": "pkg . --target node18-win-x64 --output dist/lcyt-bridge.exe",
     "build:mac": "pkg . --target node18-macos-x64 --output dist/lcyt-bridge-mac",

--- a/packages/lcyt-bridge/test/bridge.test.js
+++ b/packages/lcyt-bridge/test/bridge.test.js
@@ -1,0 +1,525 @@
+/**
+ * Tests for Bridge — SSE client + command dispatcher + status reporter.
+ *
+ * Covers:
+ *   - Constructor / status() initial state
+ *   - destroy() is safe to call before start()
+ *   - destroy() prevents reconnect timers from firing
+ *   - _handleCommand() — tcp_send dispatched to TcpPool and status POSTed
+ *   - _handleCommand() — unknown command type emits error
+ *   - _handleCommand() — non-JSON data emits error
+ *   - _handleCommand() — tcp_send failure reports { ok: false } to backend
+ *   - _postStatus() — network failure emits 'error' event (does not throw)
+ *   - startHeartbeat() — calls _postStatus on interval; cleared on destroy
+ *   - reconnectAll() closes existing SSE and reconnects TCP pool
+ *   - TCP pool events forwarded as bridge tcp:* events
+ *
+ * The SSE transport (EventSource) is mocked so no real HTTP server is needed.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { Bridge } from '../src/bridge.js';
+
+// ---------------------------------------------------------------------------
+// Mock EventSource
+//
+// We monkey-patch the dynamic `import('eventsource')` used by Bridge._connect()
+// by replacing globalThis with a fake module registry. Instead, we intercept
+// Bridge's internal _connect() method and inject our own fake EventSource.
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a fake EventSource instance that behaves like the real thing.
+ * Exposes .simulateOpen(), .simulateEvent(type, data), .simulateError() for tests.
+ */
+function makeFakeEventSource() {
+  const emitter = new EventEmitter();
+  const es = {
+    readyState: 0, // CONNECTING
+    _listeners: {},
+    onopen: null,
+    onerror: null,
+    _closed: false,
+
+    addEventListener(type, listener) {
+      if (!this._listeners[type]) this._listeners[type] = [];
+      this._listeners[type].push(listener);
+    },
+
+    removeEventListener(type, listener) {
+      if (this._listeners[type]) {
+        this._listeners[type] = this._listeners[type].filter(l => l !== listener);
+      }
+    },
+
+    close() {
+      this._closed = true;
+      this.readyState = 2; // CLOSED
+    },
+
+    // Test helpers -------------------------------------------------------
+
+    simulateOpen() {
+      this.readyState = 1; // OPEN
+      if (this.onopen) this.onopen();
+      (this._listeners['connected'] ?? []).forEach(l => l({ data: '{}' }));
+    },
+
+    simulateEvent(type, data) {
+      const rawData = typeof data === 'string' ? data : JSON.stringify(data);
+      (this._listeners[type] ?? []).forEach(l => l({ data: rawData }));
+    },
+
+    simulateError(err) {
+      this.readyState = 2; // CLOSED
+      if (this.onerror) this.onerror(err ?? new Error('SSE error'));
+    },
+  };
+  return es;
+}
+
+/**
+ * Patch Bridge._connect so it never actually imports eventsource.
+ * The caller gets back the fake EventSource for manipulation.
+ */
+function injectFakeEventSource(bridge) {
+  let fakeEs = null;
+
+  bridge._connect = async function () {
+    if (this._destroyed) return;
+    fakeEs = makeFakeEventSource();
+    this._es = fakeEs;
+    this.emit('connecting', 'fake://url');
+
+    fakeEs.onopen = () => {
+      this._reconnectDelay = 5000;
+      this.emit('connected');
+    };
+
+    fakeEs.addEventListener('connected', () => {
+      this.emit('connected');
+    });
+
+    fakeEs.addEventListener('command', (evt) => {
+      this._handleCommand(evt.data);
+    });
+
+    fakeEs.onerror = (err) => {
+      this.emit('disconnected');
+      fakeEs.close();
+      this._es = null;
+      if (!this._destroyed) {
+        this.emit('reconnecting', this._reconnectDelay);
+        this._reconnectTimer = setTimeout(() => {
+          this._reconnectTimer = null;
+          this._reconnectDelay = Math.min(this._reconnectDelay * 2, 60_000);
+          this._connect();
+        }, this._reconnectDelay);
+      }
+    };
+  };
+
+  return () => fakeEs; // getter — call after _connect() resolves
+}
+
+// ---------------------------------------------------------------------------
+// Mock TcpPool
+// ---------------------------------------------------------------------------
+
+function makeMockTcpPool({ sendError = null } = {}) {
+  const pool = new EventEmitter();
+  pool._sent = [];
+  pool._statusCalls = [];
+  pool.send = async (host, port, payload) => {
+    pool._sent.push({ host, port, payload });
+    if (sendError) throw sendError;
+  };
+  pool.status = () => [];
+  pool.reconnectAll = () => {};
+  pool.destroy = () => {};
+  return pool;
+}
+
+// ---------------------------------------------------------------------------
+// _postStatus mock — capture calls without real HTTP
+// ---------------------------------------------------------------------------
+
+function mockFetch(bridge) {
+  const calls = [];
+  bridge._postStatus = async (body) => {
+    calls.push(body);
+  };
+  return calls;
+}
+
+// ---------------------------------------------------------------------------
+// Constructor / status()
+// ---------------------------------------------------------------------------
+
+describe('Bridge — constructor and status()', () => {
+  it('initialises with sse: false and no TCP entries', () => {
+    const bridge = new Bridge({ backendUrl: 'http://backend.test', token: 'tok' });
+    const s = bridge.status();
+    assert.equal(s.sse, false);
+    assert.deepEqual(s.tcp, []);
+    bridge.destroy();
+  });
+
+  it('strips trailing slash from backendUrl', () => {
+    const bridge = new Bridge({ backendUrl: 'http://backend.test/', token: 'tok' });
+    assert.equal(bridge._backendUrl, 'http://backend.test');
+    bridge.destroy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// destroy()
+// ---------------------------------------------------------------------------
+
+describe('Bridge — destroy()', () => {
+  it('is safe to call before start()', () => {
+    const bridge = new Bridge({ backendUrl: 'http://backend.test', token: 'tok' });
+    assert.doesNotThrow(() => bridge.destroy());
+  });
+
+  it('sets _destroyed = true so subsequent _connect() calls are no-ops', async () => {
+    const bridge = new Bridge({ backendUrl: 'http://backend.test', token: 'tok' });
+    injectFakeEventSource(bridge);
+    bridge.destroy();
+    // _connect should return immediately without setting _es
+    await bridge._connect();
+    assert.equal(bridge._es, null);
+  });
+
+  it('clears a pending reconnect timer', async () => {
+    const bridge = new Bridge({ backendUrl: 'http://backend.test', token: 'tok' });
+    injectFakeEventSource(bridge);
+    bridge.start();
+    await new Promise(r => setImmediate(r));
+
+    // Simulate error to trigger reconnect timer
+    bridge._reconnectDelay = 60_000; // long delay so timer is still pending
+    bridge._reconnectTimer = setTimeout(() => {}, 60_000);
+
+    assert.doesNotThrow(() => bridge.destroy());
+    // destroy() calls clearTimeout() but does not null the ref;
+    // what matters is _destroyed is true so the timer callback is a no-op.
+    assert.equal(bridge._destroyed, true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SSE connection lifecycle
+// ---------------------------------------------------------------------------
+
+describe('Bridge — SSE connection', () => {
+  it('emits "connected" when the SSE stream opens', async () => {
+    const bridge = new Bridge({ backendUrl: 'http://backend.test', token: 'tok' });
+    const getEs = injectFakeEventSource(bridge);
+    mockFetch(bridge);
+
+    const connected = new Promise(r => bridge.once('connected', r));
+    bridge.start();
+    await new Promise(r => setImmediate(r));
+    getEs().simulateOpen();
+
+    await connected; // should resolve
+    bridge.destroy();
+  });
+
+  it('emits "disconnected" and schedules reconnect on SSE error', async () => {
+    const bridge = new Bridge({ backendUrl: 'http://backend.test', token: 'tok' });
+    bridge._reconnectDelay = 60_000; // prevent actual reconnect
+    const getEs = injectFakeEventSource(bridge);
+    mockFetch(bridge);
+
+    const disconnected = new Promise(r => bridge.once('disconnected', r));
+    bridge.start();
+    await new Promise(r => setImmediate(r));
+    getEs().simulateError();
+
+    await disconnected;
+    assert.notEqual(bridge._reconnectTimer, null);
+    bridge.destroy();
+  });
+
+  it('resets reconnect delay to initial value on successful reconnect', async () => {
+    const bridge = new Bridge({ backendUrl: 'http://backend.test', token: 'tok' });
+    const getEs = injectFakeEventSource(bridge);
+    mockFetch(bridge);
+
+    bridge.start();
+    await new Promise(r => setImmediate(r));
+
+    // Simulate a previous backoff
+    bridge._reconnectDelay = 30_000;
+    getEs().simulateOpen();
+
+    // onopen resets the delay
+    assert.equal(bridge._reconnectDelay, 5_000);
+    bridge.destroy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// _handleCommand() — tcp_send
+// ---------------------------------------------------------------------------
+
+describe('Bridge — _handleCommand() tcp_send', () => {
+  it('calls TcpPool.send() with correct host/port/payload', async () => {
+    const bridge = new Bridge({ backendUrl: 'http://backend.test', token: 'tok' });
+    bridge._tcpPool = makeMockTcpPool();
+    const statusCalls = mockFetch(bridge);
+
+    await bridge._handleCommand(JSON.stringify({
+      type: 'tcp_send',
+      requestId: 'req-1',
+      host: '192.168.1.1',
+      port: '9000',
+      payload: 'PRESET 1\r\n',
+    }));
+
+    assert.equal(bridge._tcpPool._sent.length, 1);
+    assert.deepEqual(bridge._tcpPool._sent[0], {
+      host: '192.168.1.1',
+      port: 9000,
+      payload: 'PRESET 1\r\n',
+    });
+    bridge.destroy();
+  });
+
+  it('posts { ok: true } status after a successful tcp_send', async () => {
+    const bridge = new Bridge({ backendUrl: 'http://backend.test', token: 'tok' });
+    bridge._tcpPool = makeMockTcpPool();
+    const statusCalls = mockFetch(bridge);
+
+    await bridge._handleCommand(JSON.stringify({
+      type: 'tcp_send',
+      requestId: 'req-ok',
+      host: '10.0.0.1',
+      port: 8000,
+      payload: 'GO',
+    }));
+
+    assert.ok(statusCalls.some(c => c.requestId === 'req-ok' && c.ok === true));
+    bridge.destroy();
+  });
+
+  it('emits "command:ok" after a successful tcp_send', async () => {
+    const bridge = new Bridge({ backendUrl: 'http://backend.test', token: 'tok' });
+    bridge._tcpPool = makeMockTcpPool();
+    mockFetch(bridge);
+
+    const okEvent = new Promise(r => bridge.once('command:ok', r));
+
+    await bridge._handleCommand(JSON.stringify({
+      type: 'tcp_send',
+      requestId: 'r',
+      host: '10.0.0.1',
+      port: 1234,
+      payload: 'data',
+    }));
+
+    const evt = await okEvent;
+    assert.equal(evt.host, '10.0.0.1');
+    assert.equal(evt.port, 1234);
+    bridge.destroy();
+  });
+
+  it('posts { ok: false, error } when TcpPool.send() rejects', async () => {
+    const sendErr = new Error('TCP write failed');
+    const bridge = new Bridge({ backendUrl: 'http://backend.test', token: 'tok' });
+    bridge._tcpPool = makeMockTcpPool({ sendError: sendErr });
+    const statusCalls = mockFetch(bridge);
+
+    await bridge._handleCommand(JSON.stringify({
+      type: 'tcp_send',
+      requestId: 'req-fail',
+      host: '10.0.0.1',
+      port: 9001,
+      payload: 'CMD',
+    }));
+
+    const failCall = statusCalls.find(c => c.requestId === 'req-fail');
+    assert.ok(failCall, 'should have posted status for failed command');
+    assert.equal(failCall.ok, false);
+    assert.ok(failCall.error.includes('TCP write failed'));
+    bridge.destroy();
+  });
+
+  it('emits "command:error" when TcpPool.send() rejects', async () => {
+    const bridge = new Bridge({ backendUrl: 'http://backend.test', token: 'tok' });
+    bridge._tcpPool = makeMockTcpPool({ sendError: new Error('oops') });
+    mockFetch(bridge);
+
+    const errEvent = new Promise(r => bridge.once('command:error', r));
+
+    await bridge._handleCommand(JSON.stringify({
+      type: 'tcp_send',
+      requestId: 'r2',
+      host: '10.0.0.2',
+      port: 1234,
+      payload: 'x',
+    }));
+
+    const evt = await errEvent;
+    assert.equal(evt.host, '10.0.0.2');
+    assert.ok(evt.error.includes('oops'));
+    bridge.destroy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// _handleCommand() — bad input
+// ---------------------------------------------------------------------------
+
+describe('Bridge — _handleCommand() invalid input', () => {
+  it('emits "error" for non-JSON data', async () => {
+    const bridge = new Bridge({ backendUrl: 'http://backend.test', token: 'tok' });
+    bridge._tcpPool = makeMockTcpPool();
+    mockFetch(bridge);
+
+    const errEvent = new Promise(r => bridge.once('error', r));
+    await bridge._handleCommand('not valid json {{{{');
+    const err = await errEvent;
+    assert.ok(err.message.includes('non-JSON'));
+    bridge.destroy();
+  });
+
+  it('emits "error" for unknown command type', async () => {
+    const bridge = new Bridge({ backendUrl: 'http://backend.test', token: 'tok' });
+    bridge._tcpPool = makeMockTcpPool();
+    mockFetch(bridge);
+
+    const errEvent = new Promise(r => bridge.once('error', r));
+    await bridge._handleCommand(JSON.stringify({ type: 'unknown_op', requestId: 'x' }));
+    const err = await errEvent;
+    assert.ok(err.message.includes('Unknown command type'));
+    bridge.destroy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// _postStatus() — network failure
+// ---------------------------------------------------------------------------
+
+describe('Bridge — _postStatus() network failure', () => {
+  it('emits "error" when fetch throws (does not propagate exception)', async () => {
+    const bridge = new Bridge({ backendUrl: 'http://backend.test', token: 'tok' });
+
+    // Override fetch to throw
+    const origFetch = global.fetch;
+    global.fetch = async () => { throw new Error('Network down'); };
+
+    const errEvent = new Promise(r => bridge.once('error', r));
+    await bridge._postStatus({ type: 'heartbeat' });
+
+    const err = await errEvent;
+    assert.ok(err.message.includes('Status POST failed'));
+
+    global.fetch = origFetch;
+    bridge.destroy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// startHeartbeat()
+// ---------------------------------------------------------------------------
+
+describe('Bridge — startHeartbeat()', () => {
+  it('calls _postStatus at each interval', async () => {
+    const bridge = new Bridge({ backendUrl: 'http://backend.test', token: 'tok' });
+    const calls = mockFetch(bridge);
+
+    const timer = bridge.startHeartbeat(20);
+    await new Promise(r => setTimeout(r, 75));
+    clearInterval(timer);
+
+    assert.ok(calls.length >= 2, `expected ≥ 2 heartbeats, got ${calls.length}`);
+    assert.ok(calls.every(c => c.type === 'heartbeat'));
+    bridge.destroy();
+  });
+
+  it('stops heartbeats after bridge.destroy()', async () => {
+    const bridge = new Bridge({ backendUrl: 'http://backend.test', token: 'tok' });
+    const calls = mockFetch(bridge);
+
+    bridge.startHeartbeat(20);
+    bridge.destroy();
+
+    const countAfterDestroy = calls.length;
+    await new Promise(r => setTimeout(r, 60));
+
+    // No new heartbeats should arrive after destroy
+    assert.equal(calls.length, countAfterDestroy);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TCP pool event forwarding
+// ---------------------------------------------------------------------------
+
+describe('Bridge — TCP pool event forwarding', () => {
+  it('forwards TcpPool "connected" as "tcp:connected"', async () => {
+    const bridge = new Bridge({ backendUrl: 'http://backend.test', token: 'tok' });
+
+    const tcpConnected = new Promise(r => bridge.once('tcp:connected', r));
+    bridge._tcpPool.emit('connected', 'host:1234');
+
+    const key = await tcpConnected;
+    assert.equal(key, 'host:1234');
+    bridge.destroy();
+  });
+
+  it('forwards TcpPool "disconnected" as "tcp:disconnected"', async () => {
+    const bridge = new Bridge({ backendUrl: 'http://backend.test', token: 'tok' });
+
+    const tcpDisconnected = new Promise(r => bridge.once('tcp:disconnected', r));
+    bridge._tcpPool.emit('disconnected', 'host:5678');
+
+    const key = await tcpDisconnected;
+    assert.equal(key, 'host:5678');
+    bridge.destroy();
+  });
+
+  it('forwards TcpPool "error" as "tcp:error" with key and error', async () => {
+    const bridge = new Bridge({ backendUrl: 'http://backend.test', token: 'tok' });
+
+    const tcpError = new Promise(r => bridge.once('tcp:error', (k, e) => r({ k, e })));
+    const err = new Error('conn refused');
+    bridge._tcpPool.emit('error', 'host:9999', err);
+
+    const { k, e } = await tcpError;
+    assert.equal(k, 'host:9999');
+    assert.equal(e, err);
+    bridge.destroy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reconnectAll()
+// ---------------------------------------------------------------------------
+
+describe('Bridge — reconnectAll()', () => {
+  it('closes the existing SSE connection and calls tcpPool.reconnectAll()', async () => {
+    const bridge = new Bridge({ backendUrl: 'http://backend.test', token: 'tok' });
+    let tcpReconnectCalled = false;
+    bridge._tcpPool.reconnectAll = () => { tcpReconnectCalled = true; };
+
+    let newConnectCalled = false;
+    bridge._connect = async () => { newConnectCalled = true; };
+
+    // Simulate an open SSE connection
+    let esClosed = false;
+    bridge._es = { close() { esClosed = true; }, readyState: 1 };
+
+    bridge.reconnectAll();
+
+    assert.equal(esClosed, true);
+    assert.equal(tcpReconnectCalled, true);
+    assert.equal(newConnectCalled, true);
+    bridge.destroy();
+  });
+});

--- a/packages/lcyt-bridge/test/tcp-pool.test.js
+++ b/packages/lcyt-bridge/test/tcp-pool.test.js
@@ -1,0 +1,323 @@
+/**
+ * Tests for TcpPool — managed TCP connection pool.
+ *
+ * Covers:
+ *   - ensure() is idempotent (does not open duplicate connections)
+ *   - send() throws when the connection is not yet established
+ *   - send() delegates to socket.write() when connected
+ *   - status() reflects connected / disconnected state
+ *   - reconnectAll() destroys and re-opens all entries
+ *   - destroy() clears all connections and cancels reconnect timers
+ *   - 'connected' / 'disconnected' / 'error' events are forwarded
+ *   - Auto-reconnect on socket close (entry is cleaned up and re-opened)
+ */
+
+import { describe, it, before, after, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:net';
+import { EventEmitter } from 'node:events';
+import { TcpPool } from '../src/tcp-pool.js';
+
+// ---------------------------------------------------------------------------
+// Helpers — real TCP server on a random OS-assigned port
+// ---------------------------------------------------------------------------
+
+function startTcpServer() {
+  return new Promise((resolve) => {
+    const server = createServer();
+    server.listen(0, '127.0.0.1', () => {
+      resolve(server);
+    });
+  });
+}
+
+function stopTcpServer(server) {
+  return new Promise((resolve) => server.close(resolve));
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests using a mock net.Socket
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal mock socket that behaves like a net.Socket.
+ * Emits 'connect' synchronously when connect() is called, simulating a
+ * successful TCP connection so tests are deterministic.
+ */
+function makeMockSocket({ autoConnect = true, writeError = null } = {}) {
+  const emitter = new EventEmitter();
+
+  const socket = Object.assign(emitter, {
+    _written: [],
+    destroyed: false,
+    setKeepAlive() {},
+    destroy() {
+      this.destroyed = true;
+      this.emit('close');
+    },
+    write(data, encoding, callback) {
+      if (writeError) {
+        callback(writeError);
+      } else {
+        this._written.push(data);
+        callback(null);
+      }
+    },
+  });
+
+  if (autoConnect) {
+    // Simulate asynchronous connection establishment
+    setImmediate(() => socket.emit('connect'));
+  }
+
+  return socket;
+}
+
+// ---------------------------------------------------------------------------
+// status()
+// ---------------------------------------------------------------------------
+
+describe('TcpPool — status()', () => {
+  it('returns an empty array when the pool has no connections', () => {
+    const pool = new TcpPool();
+    assert.deepEqual(pool.status(), []);
+    pool.destroy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// destroy()
+// ---------------------------------------------------------------------------
+
+describe('TcpPool — destroy()', () => {
+  it('clears all connections and returns an empty status', async () => {
+    const server = await startTcpServer();
+    const { port } = server.address();
+    const pool = new TcpPool();
+
+    pool.ensure('127.0.0.1', port);
+
+    // Give the connection a moment to be registered
+    await new Promise(r => setTimeout(r, 50));
+
+    pool.destroy();
+
+    assert.deepEqual(pool.status(), []);
+
+    await stopTcpServer(server);
+  });
+
+  it('does not throw when called on an already-empty pool', () => {
+    const pool = new TcpPool();
+    assert.doesNotThrow(() => pool.destroy());
+  });
+
+  it('can be called multiple times without throwing', () => {
+    const pool = new TcpPool();
+    assert.doesNotThrow(() => {
+      pool.destroy();
+      pool.destroy();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ensure() — idempotency
+// ---------------------------------------------------------------------------
+
+describe('TcpPool — ensure()', () => {
+  it('does not create a duplicate entry when called twice for the same host:port', async () => {
+    const server = await startTcpServer();
+    const { port } = server.address();
+    const pool = new TcpPool();
+
+    pool.ensure('127.0.0.1', port);
+    pool.ensure('127.0.0.1', port); // second call — should be no-op
+
+    await new Promise(r => setTimeout(r, 50));
+
+    const statuses = pool.status();
+    assert.equal(statuses.length, 1);
+
+    pool.destroy();
+    await stopTcpServer(server);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// send() — connection required
+// ---------------------------------------------------------------------------
+
+describe('TcpPool — send()', () => {
+  it('throws when the connection is not yet established', async () => {
+    const server = await startTcpServer();
+    const { port } = server.address();
+
+    const pool = new TcpPool();
+    pool.ensure('127.0.0.1', port);
+
+    // `createConnection` is always asynchronous — the connect callback fires
+    // on the next event loop tick, so calling send() synchronously here
+    // guarantees the socket is in CONNECTING state (entry.connected === false).
+    await assert.rejects(
+      () => pool.send('127.0.0.1', port, 'hello'),
+      /not connected/i,
+    );
+
+    pool.destroy();
+    await stopTcpServer(server);
+  });
+
+  it('delivers data to the socket when connected', async () => {
+    const received = [];
+    const server = await startTcpServer();
+    server.on('connection', (socket) => {
+      socket.on('data', (buf) => received.push(buf.toString()));
+    });
+
+    const { port } = server.address();
+    const pool = new TcpPool();
+
+    // Wait for the pool to mark the socket as connected
+    await new Promise((resolve, reject) => {
+      pool.once('connected', resolve);
+      pool.once('error', (key, err) => reject(err));
+      pool.ensure('127.0.0.1', port);
+    });
+
+    await pool.send('127.0.0.1', port, 'Hello, TCP!');
+
+    // Give the server socket time to receive the data
+    await new Promise(r => setTimeout(r, 50));
+
+    assert.ok(received.some(d => d.includes('Hello, TCP!')));
+
+    pool.destroy();
+    await stopTcpServer(server);
+  });
+
+  it('creates a new connection automatically when send() is called without ensure()', async () => {
+    const server = await startTcpServer();
+    const { port } = server.address();
+    const pool = new TcpPool();
+
+    // Calling send() without ensure() — pool._open() is called internally
+    // The socket won't be connected yet so it should reject
+    await assert.rejects(
+      () => pool.send('127.0.0.1', port, 'data'),
+      /not connected/i,
+    );
+
+    pool.destroy();
+    await stopTcpServer(server);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reconnectAll()
+// ---------------------------------------------------------------------------
+
+describe('TcpPool — reconnectAll()', () => {
+  it('does not throw when called on an empty pool', () => {
+    const pool = new TcpPool();
+    assert.doesNotThrow(() => pool.reconnectAll());
+    pool.destroy();
+  });
+
+  it('re-establishes connections: emits a second connected event after reconnectAll()', async () => {
+    const server = await startTcpServer();
+    const { port } = server.address();
+    const pool = new TcpPool();
+
+    // Initial connection
+    await new Promise((resolve) => {
+      pool.once('connected', resolve);
+      pool.ensure('127.0.0.1', port);
+    });
+
+    // Count total connected events from this point
+    let extraConnects = 0;
+    pool.on('connected', () => { extraConnects++; });
+
+    // reconnectAll() should open a new socket that fires 'connected' again
+    pool.reconnectAll();
+
+    // Give the new socket time to connect
+    await new Promise(r => setTimeout(r, 200));
+
+    pool.destroy();
+    // The old socket's 'close' handler (from before reconnectAll) holds a
+    // reference to the old entry and schedules a 5 s reconnect timer that
+    // pool.destroy() cannot reach (the entry is no longer in the pool map).
+    // Override _open so that stray timer fires harmlessly and lets the process
+    // exit without looping indefinitely.
+    pool._open = () => {};
+    await stopTcpServer(server);
+
+    assert.ok(extraConnects >= 1, `expected ≥1 extra connected event, got ${extraConnects}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Events — connected / disconnected / error
+// ---------------------------------------------------------------------------
+
+describe('TcpPool — events', () => {
+  it('emits "connected" with the host:port key when the socket connects', async () => {
+    const server = await startTcpServer();
+    const { port } = server.address();
+    const pool = new TcpPool();
+
+    const key = await new Promise((resolve) => {
+      pool.once('connected', resolve);
+      pool.ensure('127.0.0.1', port);
+    });
+
+    assert.equal(key, `127.0.0.1:${port}`);
+
+    pool.destroy();
+    await stopTcpServer(server);
+  });
+
+  it('emits "disconnected" when the server closes the connection', async () => {
+    const server = await startTcpServer();
+    const { port } = server.address();
+    const pool = new TcpPool();
+
+    // Wait for connection, then have the server drop it
+    await new Promise((resolve) => {
+      server.once('connection', (socket) => {
+        pool.once('connected', () => {
+          // Server forcefully ends the connection after we're connected
+          socket.destroy();
+          resolve();
+        });
+      });
+      pool.ensure('127.0.0.1', port);
+    });
+
+    const key = await new Promise((resolve) => {
+      pool.once('disconnected', resolve);
+    });
+
+    assert.equal(key, `127.0.0.1:${port}`);
+
+    pool.destroy();
+    await stopTcpServer(server);
+  });
+
+  it('emits "error" with key and error when the socket errors', async () => {
+    // Connect to a port where nothing is listening — ECONNREFUSED
+    const pool = new TcpPool();
+
+    const [key, err] = await new Promise((resolve) => {
+      pool.once('error', (k, e) => resolve([k, e]));
+      pool.ensure('127.0.0.1', 1); // port 1 is reserved and unreachable
+    });
+
+    assert.ok(key.startsWith('127.0.0.1:'));
+    assert.ok(err instanceof Error);
+
+    pool.destroy();
+  });
+});

--- a/packages/lcyt-cli/test/interactive-ui.test.js
+++ b/packages/lcyt-cli/test/interactive-ui.test.js
@@ -1,0 +1,515 @@
+/**
+ * Tests for InteractiveUI pure-logic methods.
+ *
+ * The blessed screen (initScreen/start) is never called, so all UI widgets
+ * remain null.  All update methods guard with `if (!this.widget) return;`
+ * so they are safe to call — they simply become no-ops.
+ *
+ * Tested: loadFile, shiftPointer, gotoLine, isSendableLine, sendCurrentLine,
+ *         sendCustomCaption, sendBatch, handleCommand (/load, /goto, /batch,
+ *         /timestamps, /send, /stream, /reload), _parseVideoId.
+ */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { InteractiveUI } from '../src/interactive-ui.js';
+
+// ---------------------------------------------------------------------------
+// Temp file fixture
+// ---------------------------------------------------------------------------
+
+const TMP_DIR  = join(tmpdir(), `lcyt-cli-ui-test-${Date.now()}`);
+const TMP_FILE = join(TMP_DIR, 'test.txt');
+const FILE_CONTENT = [
+  '# Heading',
+  'First line',
+  'Second line',
+  '',
+  'Third line',
+].join('\n');
+
+mkdirSync(TMP_DIR, { recursive: true });
+writeFileSync(TMP_FILE, FILE_CONTENT);
+
+// Clean up after all tests (best-effort)
+process.on('exit', () => {
+  try { rmSync(TMP_DIR, { recursive: true, force: true }); } catch {}
+});
+
+// ---------------------------------------------------------------------------
+// Mock sender
+// ---------------------------------------------------------------------------
+
+function makeMockSender() {
+  let seq = 1;
+  const sent = [];
+  const batches = [];
+  return {
+    sent,
+    batches,
+    getSequence: () => seq,
+    send: async (text) => { sent.push(text); seq++; },
+    sendBatch: async (captions) => { batches.push(captions); seq += captions.length; },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helper: create UI without starting blessed
+// ---------------------------------------------------------------------------
+
+function makeUI(senderOverride) {
+  const sender = senderOverride || makeMockSender();
+  const config = { sequence: 1, streamKey: 'testkey123' };
+  const ui = new InteractiveUI(sender, config, '/tmp/fake-config.json', null);
+  return { ui, sender, config };
+}
+
+// ---------------------------------------------------------------------------
+// loadFile
+// ---------------------------------------------------------------------------
+
+describe('InteractiveUI.loadFile()', () => {
+  it('loads a real file and splits into lines', () => {
+    const { ui } = makeUI();
+    const ok = ui.loadFile(TMP_FILE);
+    assert.equal(ok, true);
+    assert.equal(ui.loadedFile, TMP_FILE);
+    assert.ok(ui.lines.length > 0);
+    assert.equal(ui.currentLine, 0);
+  });
+
+  it('returns false for a non-existent file', () => {
+    const { ui } = makeUI();
+    const ok = ui.loadFile('/does/not/exist.txt');
+    assert.equal(ok, false);
+  });
+
+  it('logs an error message on failure', () => {
+    const { ui } = makeUI();
+    ui.loadFile('/does/not/exist.txt');
+    const lastLog = ui.logMessages[ui.logMessages.length - 1];
+    assert.equal(lastLog.type, 'error');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shiftPointer
+// ---------------------------------------------------------------------------
+
+describe('InteractiveUI.shiftPointer()', () => {
+  it('advances pointer by positive offset', () => {
+    const { ui } = makeUI();
+    ui.loadFile(TMP_FILE);
+    const ok = ui.shiftPointer(1);
+    assert.equal(ok, true);
+    assert.equal(ui.currentLine, 1);
+  });
+
+  it('returns false when offset would go out of bounds (negative)', () => {
+    const { ui } = makeUI();
+    ui.loadFile(TMP_FILE);
+    const ok = ui.shiftPointer(-1); // already at 0
+    assert.equal(ok, false);
+    assert.equal(ui.currentLine, 0);
+  });
+
+  it('returns false when offset goes past end', () => {
+    const { ui } = makeUI();
+    ui.loadFile(TMP_FILE);
+    const ok = ui.shiftPointer(9999);
+    assert.equal(ok, false);
+  });
+
+  it('returns false when no content is loaded', () => {
+    const { ui } = makeUI();
+    // lines is empty
+    const ok = ui.shiftPointer(1);
+    assert.equal(ok, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// gotoLine
+// ---------------------------------------------------------------------------
+
+describe('InteractiveUI.gotoLine()', () => {
+  it('jumps to a valid 1-indexed line number', () => {
+    const { ui } = makeUI();
+    ui.loadFile(TMP_FILE);
+    const ok = ui.gotoLine(2);
+    assert.equal(ok, true);
+    assert.equal(ui.currentLine, 1);
+  });
+
+  it('returns false for line 0 (out of range)', () => {
+    const { ui } = makeUI();
+    ui.loadFile(TMP_FILE);
+    const ok = ui.gotoLine(0);
+    assert.equal(ok, false);
+  });
+
+  it('returns false for line beyond file length', () => {
+    const { ui } = makeUI();
+    ui.loadFile(TMP_FILE);
+    const ok = ui.gotoLine(9999);
+    assert.equal(ok, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isSendableLine
+// ---------------------------------------------------------------------------
+
+describe('InteractiveUI.isSendableLine()', () => {
+  it('returns false for an out-of-range index', () => {
+    const { ui } = makeUI();
+    assert.equal(ui.isSendableLine(0), false);
+  });
+
+  it('returns false for a heading line (starts with #)', () => {
+    const { ui } = makeUI();
+    ui.lines = ['# Heading', 'Normal line'];
+    assert.equal(ui.isSendableLine(0), false);
+  });
+
+  it('returns false for an empty line', () => {
+    const { ui } = makeUI();
+    ui.lines = ['', 'Normal'];
+    assert.equal(ui.isSendableLine(0), false);
+  });
+
+  it('returns true for a normal text line', () => {
+    const { ui } = makeUI();
+    ui.lines = ['# Heading', 'Normal line'];
+    assert.equal(ui.isSendableLine(1), true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sendCurrentLine
+// ---------------------------------------------------------------------------
+
+describe('InteractiveUI.sendCurrentLine()', () => {
+  it('logs warning when no content loaded', async () => {
+    const { ui } = makeUI();
+    await ui.sendCurrentLine();
+    const log = ui.logMessages.find(m => m.message.includes('No content'));
+    assert.ok(log);
+  });
+
+  it('skips heading lines and advances pointer', async () => {
+    const { ui } = makeUI();
+    ui.lines = ['# Heading', 'Normal line'];
+    ui.currentLine = 0;
+    await ui.sendCurrentLine();
+    assert.equal(ui.currentLine, 1); // advanced past heading
+  });
+
+  it('sends a sendable line and advances pointer', async () => {
+    const sender = makeMockSender();
+    const { ui } = makeUI(sender);
+    ui.lines = ['First line', 'Second line'];
+    ui.currentLine = 0;
+    await ui.sendCurrentLine();
+    assert.equal(sender.sent.length, 1);
+    assert.equal(sender.sent[0], 'First line');
+    assert.equal(ui.currentLine, 1);
+  });
+
+  it('queues to batch when batchMode is on', async () => {
+    const { ui } = makeUI();
+    ui.lines = ['Batch line'];
+    ui.currentLine = 0;
+    ui.batchMode = true;
+    await ui.sendCurrentLine();
+    assert.equal(ui.batchCaptions.length, 1);
+    assert.equal(ui.batchCaptions[0].text, 'Batch line');
+    // Clean up timer
+    if (ui.batchTimer) clearTimeout(ui.batchTimer);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sendCustomCaption
+// ---------------------------------------------------------------------------
+
+describe('InteractiveUI.sendCustomCaption()', () => {
+  it('logs warning for empty string', async () => {
+    const { ui } = makeUI();
+    await ui.sendCustomCaption('  ');
+    const log = ui.logMessages.find(m => m.message.includes('Empty'));
+    assert.ok(log);
+  });
+
+  it('sends trimmed text via sender', async () => {
+    const sender = makeMockSender();
+    const { ui } = makeUI(sender);
+    await ui.sendCustomCaption('  Hello world  ');
+    assert.equal(sender.sent[0], 'Hello world');
+  });
+
+  it('does not advance pointer', async () => {
+    const { ui } = makeUI();
+    ui.lines = ['Line 1', 'Line 2'];
+    ui.currentLine = 0;
+    await ui.sendCustomCaption('Custom text');
+    assert.equal(ui.currentLine, 0); // pointer unchanged
+  });
+
+  it('queues to batch when batchMode is on', async () => {
+    const { ui } = makeUI();
+    ui.batchMode = true;
+    await ui.sendCustomCaption('Batch text');
+    assert.equal(ui.batchCaptions[0].text, 'Batch text');
+    if (ui.batchTimer) clearTimeout(ui.batchTimer);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sendBatch
+// ---------------------------------------------------------------------------
+
+describe('InteractiveUI.sendBatch()', () => {
+  it('logs warning when queue is empty', async () => {
+    const { ui } = makeUI();
+    await ui.sendBatch();
+    const log = ui.logMessages.find(m => m.message.includes('empty'));
+    assert.ok(log);
+  });
+
+  it('flushes all queued captions', async () => {
+    const sender = makeMockSender();
+    const { ui } = makeUI(sender);
+    ui.batchCaptions = [
+      { text: 'Cap 1', timestamp: null },
+      { text: 'Cap 2', timestamp: null },
+    ];
+    await ui.sendBatch();
+    assert.equal(sender.batches.length, 1);
+    assert.equal(sender.batches[0].length, 2);
+    assert.equal(ui.batchCaptions.length, 0); // cleared
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleCommand — /goto
+// ---------------------------------------------------------------------------
+
+describe('InteractiveUI.handleCommand() — /goto', () => {
+  it('logs warning when no argument given', async () => {
+    const { ui } = makeUI();
+    await ui.handleCommand('/goto');
+    const log = ui.logMessages.find(m => m.message.includes('Usage'));
+    assert.ok(log);
+  });
+
+  it('logs warning for non-numeric argument', async () => {
+    const { ui } = makeUI();
+    ui.lines = ['a', 'b', 'c'];
+    await ui.handleCommand('/goto abc');
+    const log = ui.logMessages.find(m => m.message.includes('Not a number'));
+    assert.ok(log);
+  });
+
+  it('jumps to line and logs success', async () => {
+    const { ui } = makeUI();
+    ui.lines = ['a', 'b', 'c'];
+    await ui.handleCommand('/goto 2');
+    assert.equal(ui.currentLine, 1);
+    const log = ui.logMessages.find(m => m.message.includes('Jumped'));
+    assert.ok(log);
+  });
+
+  it('logs warning for out-of-range line', async () => {
+    const { ui } = makeUI();
+    ui.lines = ['a', 'b'];
+    await ui.handleCommand('/goto 100');
+    const log = ui.logMessages.find(m => m.message.includes('out of range'));
+    assert.ok(log);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleCommand — /batch
+// ---------------------------------------------------------------------------
+
+describe('InteractiveUI.handleCommand() — /batch', () => {
+  it('toggles batch mode on', async () => {
+    const { ui } = makeUI();
+    assert.equal(ui.batchMode, false);
+    await ui.handleCommand('/batch');
+    assert.equal(ui.batchMode, true);
+  });
+
+  it('toggles batch mode off (and flushes if queued)', async () => {
+    const sender = makeMockSender();
+    const { ui } = makeUI(sender);
+    ui.batchMode = true;
+    ui.batchCaptions = [{ text: 'queued', timestamp: null }];
+    await ui.handleCommand('/batch');
+    assert.equal(ui.batchMode, false);
+    // Batch should have been flushed
+    assert.equal(sender.batches.length, 1);
+  });
+
+  it('sets custom timeout when provided', async () => {
+    const { ui } = makeUI();
+    await ui.handleCommand('/batch 10');
+    assert.equal(ui.batchTimeout, 10);
+    assert.equal(ui.batchMode, true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleCommand — /timestamps (/ts)
+// ---------------------------------------------------------------------------
+
+describe('InteractiveUI.handleCommand() — /timestamps', () => {
+  it('toggles showTimestamps off', async () => {
+    const { ui } = makeUI();
+    assert.equal(ui.showTimestamps, true);
+    await ui.handleCommand('/timestamps');
+    assert.equal(ui.showTimestamps, false);
+  });
+
+  it('/ts alias also toggles', async () => {
+    const { ui } = makeUI();
+    await ui.handleCommand('/ts');
+    assert.equal(ui.showTimestamps, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleCommand — /load
+// ---------------------------------------------------------------------------
+
+describe('InteractiveUI.handleCommand() — /load', () => {
+  it('logs usage warning with no args', async () => {
+    const { ui } = makeUI();
+    await ui.handleCommand('/load');
+    const log = ui.logMessages.find(m => m.message.includes('Usage'));
+    assert.ok(log);
+  });
+
+  it('loads a file successfully', async () => {
+    const { ui } = makeUI();
+    await ui.handleCommand(`/load ${TMP_FILE}`);
+    assert.ok(ui.lines.length > 0);
+    assert.equal(ui.loadedFile, TMP_FILE);
+  });
+
+  it('loads a file and jumps to specified line', async () => {
+    const { ui } = makeUI();
+    await ui.handleCommand(`/load ${TMP_FILE} 2`);
+    assert.equal(ui.currentLine, 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleCommand — /reload
+// ---------------------------------------------------------------------------
+
+describe('InteractiveUI.handleCommand() — /reload', () => {
+  it('logs warning when nothing loaded', async () => {
+    const { ui } = makeUI();
+    await ui.handleCommand('/reload');
+    const log = ui.logMessages.find(m => m.message.includes('No content'));
+    assert.ok(log);
+  });
+
+  it('reloads the currently loaded file', async () => {
+    const { ui } = makeUI();
+    ui.loadFile(TMP_FILE);
+    const linesBefore = ui.lines.length;
+    ui.lines = []; // simulate clearing
+    await ui.handleCommand('/reload');
+    assert.equal(ui.lines.length, linesBefore);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleCommand — /stream
+// ---------------------------------------------------------------------------
+
+describe('InteractiveUI.handleCommand() — /stream', () => {
+  it('logs usage warning with no args', async () => {
+    const { ui } = makeUI();
+    await ui.handleCommand('/stream');
+    const log = ui.logMessages.find(m => m.message.includes('Usage'));
+    assert.ok(log);
+  });
+
+  it('sets watchVideoId from a bare 11-char video ID', async () => {
+    const { ui } = makeUI();
+    await ui.handleCommand('/stream abcdefghijk');
+    assert.equal(ui.watchVideoId, 'abcdefghijk');
+  });
+
+  it('extracts video ID from a youtube.com URL', async () => {
+    const { ui } = makeUI();
+    await ui.handleCommand('/stream https://www.youtube.com/watch?v=abc12345678');
+    assert.equal(ui.watchVideoId, 'abc12345678');
+  });
+
+  it('logs error for invalid input', async () => {
+    const { ui } = makeUI();
+    await ui.handleCommand('/stream not-a-valid-id');
+    const log = ui.logMessages.find(m => m.type === 'error');
+    assert.ok(log);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleCommand — /send
+// ---------------------------------------------------------------------------
+
+describe('InteractiveUI.handleCommand() — /send', () => {
+  it('logs warning when batch queue is empty', async () => {
+    const { ui } = makeUI();
+    await ui.handleCommand('/send');
+    const log = ui.logMessages.find(m => m.message.includes('empty'));
+    assert.ok(log);
+  });
+
+  it('flushes the batch queue', async () => {
+    const sender = makeMockSender();
+    const { ui } = makeUI(sender);
+    ui.batchCaptions = [{ text: 'A', timestamp: null }];
+    await ui.handleCommand('/send');
+    assert.equal(sender.batches.length, 1);
+    assert.equal(ui.batchCaptions.length, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// _parseVideoId
+// ---------------------------------------------------------------------------
+
+describe('InteractiveUI._parseVideoId()', () => {
+  let ui;
+  beforeEach(() => { ({ ui } = makeUI()); });
+
+  it('returns null for invalid input', () => {
+    assert.equal(ui._parseVideoId('not-valid'), null);
+    assert.equal(ui._parseVideoId(''), null);
+  });
+
+  it('returns a bare 11-char ID unchanged', () => {
+    assert.equal(ui._parseVideoId('abcdefghijk'), 'abcdefghijk');
+  });
+
+  it('extracts ID from watch?v= URL', () => {
+    assert.equal(ui._parseVideoId('https://www.youtube.com/watch?v=abc12345678'), 'abc12345678');
+  });
+
+  it('extracts ID from youtu.be short URL', () => {
+    assert.equal(ui._parseVideoId('https://youtu.be/abc12345678'), 'abc12345678');
+  });
+
+  it('extracts ID from /live/ URL', () => {
+    assert.equal(ui._parseVideoId('https://www.youtube.com/live/abc12345678'), 'abc12345678');
+  });
+});

--- a/packages/lcyt-mcp-sse/test/server.test.js
+++ b/packages/lcyt-mcp-sse/test/server.test.js
@@ -1,0 +1,172 @@
+/**
+ * Tests for the HTTP routes defined in lcyt-mcp-sse/src/server.js.
+ *
+ * To avoid importing server.js (which starts a persistent HTTP server that
+ * would keep the test process alive), we replicate the route logic in a local
+ * Express test app — the same pattern used by speech.test.js.
+ *
+ * Routes tested:
+ *   POST /messages  — returns 404 when sessionId is not in the transports map
+ *   GET  /sse       — returns 401 when REQUIRE_API_KEY is set and no key provided
+ *                     returns 200 text/event-stream otherwise
+ *   POST /messages  — delegates to transport.handlePostMessage when session exists
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import express from 'express';
+
+// ── Replication of the POST /messages route ────────────────────────────────
+
+const transports = new Map();
+
+const app = express();
+app.use(express.json());
+
+// POST /messages — exact copy of the route logic from server.js
+app.post('/messages', async (req, res) => {
+  const sessionId = req.query.sessionId;
+  const transport = transports.get(sessionId);
+  if (!transport) {
+    res.status(404).json({ error: 'Session not found' });
+    return;
+  }
+  await transport.handlePostMessage(req, res);
+});
+
+// GET /sse — auth guard logic from server.js (db=null path, REQUIRE_API_KEY flag)
+function makeSseRoute(requireApiKey = false) {
+  return (req, res) => {
+    // db is null in tests, so `provided` is always null
+    const provided = null;
+    if (!provided && requireApiKey) {
+      res.status(401).json({ error: 'X-Api-Key header required' });
+      return;
+    }
+    // Minimal SSE response (no actual MCP handshake in this test)
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Connection', 'keep-alive');
+    res.status(200).end();
+  };
+}
+
+app.get('/sse-open', makeSseRoute(false));
+app.get('/sse-gated', makeSseRoute(true));
+
+// ── HTTP server lifecycle ─────────────────────────────────────────────────
+
+let server;
+let baseUrl;
+
+before(
+  () =>
+    new Promise(resolve => {
+      server = createServer(app);
+      server.listen(0, '127.0.0.1', () => {
+        const { port } = server.address();
+        baseUrl = `http://127.0.0.1:${port}`;
+        resolve();
+      });
+    })
+);
+
+after(
+  () =>
+    new Promise(resolve => {
+      server.close(() => resolve());
+    })
+);
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+async function postJson(path, body = {}, headers = {}) {
+  return fetch(`${baseUrl}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+// ── POST /messages ────────────────────────────────────────────────────────────
+
+describe('POST /messages — session not found', () => {
+  it('returns 404 when sessionId query param is missing', async () => {
+    const res = await postJson('/messages');
+    assert.equal(res.status, 404);
+  });
+
+  it('returns 404 for an unknown sessionId', async () => {
+    const res = await postJson('/messages?sessionId=does-not-exist');
+    assert.equal(res.status, 404);
+    const body = await res.json();
+    assert.equal(body.error, 'Session not found');
+  });
+});
+
+describe('POST /messages — known session', () => {
+  it('delegates to transport.handlePostMessage for a known session', async () => {
+    const fakeSessionId = 'test-session-001';
+    let delegated = false;
+    transports.set(fakeSessionId, {
+      async handlePostMessage(req, res) {
+        delegated = true;
+        res.status(200).json({ ok: true });
+      },
+    });
+
+    const res = await postJson(`/messages?sessionId=${fakeSessionId}`, { jsonrpc: '2.0', id: 1, method: 'tools/list' });
+    assert.equal(res.status, 200);
+    assert.equal(delegated, true);
+    transports.delete(fakeSessionId);
+  });
+});
+
+// ── GET /sse — auth guard ─────────────────────────────────────────────────────
+
+describe('GET /sse — no API key required', () => {
+  it('returns 200 with text/event-stream content-type when auth is not required', async () => {
+    const res = await fetch(`${baseUrl}/sse-open`);
+    assert.equal(res.status, 200);
+    assert.ok(
+      res.headers.get('content-type')?.startsWith('text/event-stream'),
+      `expected text/event-stream, got ${res.headers.get('content-type')}`
+    );
+  });
+});
+
+describe('GET /sse — API key required', () => {
+  it('returns 401 when X-Api-Key is missing and REQUIRE_API_KEY is set', async () => {
+    const res = await fetch(`${baseUrl}/sse-gated`);
+    assert.equal(res.status, 401);
+    const body = await res.json();
+    assert.equal(body.error, 'X-Api-Key header required');
+  });
+});
+
+// ── Session map isolation ─────────────────────────────────────────────────────
+
+describe('transports map', () => {
+  it('different sessions are independent', async () => {
+    const id1 = 'session-a';
+    const id2 = 'session-b';
+
+    const calls = [];
+    transports.set(id1, {
+      async handlePostMessage(req, res) { calls.push('a'); res.json({ ok: true }); }
+    });
+    transports.set(id2, {
+      async handlePostMessage(req, res) { calls.push('b'); res.json({ ok: true }); }
+    });
+
+    await postJson(`/messages?sessionId=${id1}`, {});
+    await postJson(`/messages?sessionId=${id2}`, {});
+    await postJson('/messages?sessionId=unknown', {});
+
+    assert.deepEqual(calls, ['a', 'b']);
+
+    transports.delete(id1);
+    transports.delete(id2);
+  });
+});

--- a/packages/lcyt-web/package.json
+++ b/packages/lcyt-web/package.json
@@ -8,7 +8,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "node --test test/*.test.js"
+    "test": "node --test test/*.test.js",
+    "test:components": "vitest run"
   },
   "dependencies": {
     "@jsilvanus/matrox-monarch-control": "^0.5.0",
@@ -18,7 +19,12 @@
     "react-dom": "^18.3.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@vitejs/plugin-react": "^4.0.0",
-    "vite": "^5.0.0"
+    "jsdom": "^29.0.0",
+    "vite": "^5.0.0",
+    "vitest": "^4.1.0"
   }
 }

--- a/packages/lcyt-web/test/components/AppProviders.test.jsx
+++ b/packages/lcyt-web/test/components/AppProviders.test.jsx
@@ -1,0 +1,228 @@
+/**
+ * Tests for AppProviders.
+ *
+ * BackendCaptionSender is mocked so no real HTTP traffic occurs.
+ * Tests cover: smoke render, autoConnect behaviour, and embed BroadcastChannel.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { AppProviders } from '../../src/contexts/AppProviders.jsx';
+
+// ---------------------------------------------------------------------------
+// Mock BackendCaptionSender
+// ---------------------------------------------------------------------------
+
+const mockSender = {
+  _token: 'mock-jwt-token',
+  sequence: 0,
+  syncOffset: 0,
+  startedAt: new Date(),
+  graphicsEnabled: false,
+  apiKey: 'test-api-key',
+  start: vi.fn().mockResolvedValue(undefined),
+  end: vi.fn().mockResolvedValue(undefined),
+  sync: vi.fn().mockResolvedValue({ syncOffset: 0 }),
+  send: vi.fn().mockResolvedValue({ ok: true, requestId: 'req-1' }),
+  sendBatch: vi.fn().mockResolvedValue({ ok: true, requestId: 'req-batch', count: 2 }),
+  construct: vi.fn().mockReturnValue(undefined),
+  heartbeat: vi.fn().mockResolvedValue({ ok: true }),
+  updateSession: vi.fn().mockResolvedValue(undefined),
+};
+
+vi.mock('lcyt/backend', () => ({
+  BackendCaptionSender: vi.fn(function () { return mockSender; }),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const VALID_CONFIG = {
+  backendUrl: 'http://backend.test',
+  apiKey: 'test-api-key',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSender._token = 'mock-jwt-token';
+  mockSender.sequence = 0;
+  mockSender.syncOffset = 0;
+});
+
+// ---------------------------------------------------------------------------
+// Smoke test
+// ---------------------------------------------------------------------------
+
+describe('AppProviders — smoke test', () => {
+  it('renders children without crashing', () => {
+    render(
+      <AppProviders>
+        <div data-testid="child">Hello</div>
+      </AppProviders>
+    );
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+  });
+
+  it('renders children text content', () => {
+    render(
+      <AppProviders>
+        <span>test content</span>
+      </AppProviders>
+    );
+    expect(screen.getByText('test content')).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// autoConnect
+// ---------------------------------------------------------------------------
+
+describe('AppProviders — autoConnect', () => {
+  it('connects automatically when autoConnect=true and valid initConfig', async () => {
+    await act(async () => {
+      render(
+        <AppProviders autoConnect initConfig={VALID_CONFIG}>
+          <div>child</div>
+        </AppProviders>
+      );
+    });
+    expect(mockSender.start).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not connect when autoConnect is not set', async () => {
+    await act(async () => {
+      render(
+        <AppProviders initConfig={VALID_CONFIG}>
+          <div>child</div>
+        </AppProviders>
+      );
+    });
+    expect(mockSender.start).not.toHaveBeenCalled();
+  });
+
+  it('does not connect when initConfig is missing backendUrl', async () => {
+    await act(async () => {
+      render(
+        <AppProviders autoConnect initConfig={{ apiKey: 'test-key' }}>
+          <div>child</div>
+        </AppProviders>
+      );
+    });
+    expect(mockSender.start).not.toHaveBeenCalled();
+  });
+
+  it('does not connect when initConfig is missing apiKey', async () => {
+    await act(async () => {
+      render(
+        <AppProviders autoConnect initConfig={{ backendUrl: 'http://backend.test' }}>
+          <div>child</div>
+        </AppProviders>
+      );
+    });
+    expect(mockSender.start).not.toHaveBeenCalled();
+  });
+
+  it('does not connect when initConfig is not provided', async () => {
+    await act(async () => {
+      render(
+        <AppProviders autoConnect>
+          <div>child</div>
+        </AppProviders>
+      );
+    });
+    expect(mockSender.start).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// embed mode
+// ---------------------------------------------------------------------------
+
+describe('AppProviders — embed mode', () => {
+  // Capture the last BroadcastChannel instance created by the component.
+  // The global stub (class FakeBroadcastChannel) is installed in setup.vitest.js.
+  let lastChannel;
+
+  beforeEach(() => {
+    lastChannel = null;
+    // Extend the stub to capture the latest instance
+    global.BroadcastChannel = class FakeBroadcastChannel {
+      constructor(name) {
+        this._name = name;
+        this.onmessage = null;
+        this.postMessage = vi.fn();
+        this.close = vi.fn();
+        lastChannel = this;
+      }
+    };
+  });
+
+  it('opens a BroadcastChannel named "lcyt-embed" when embed=true', async () => {
+    await act(async () => {
+      render(
+        <AppProviders embed>
+          <div>child</div>
+        </AppProviders>
+      );
+    });
+
+    expect(lastChannel).not.toBeNull();
+    expect(lastChannel._name).toBe('lcyt-embed');
+  });
+
+  it('does not open a BroadcastChannel when embed is not set', async () => {
+    await act(async () => {
+      render(
+        <AppProviders>
+          <div>child</div>
+        </AppProviders>
+      );
+    });
+
+    expect(lastChannel).toBeNull();
+  });
+
+  it('broadcasts lcyt:session after autoConnect + embed', async () => {
+    await act(async () => {
+      render(
+        <AppProviders embed autoConnect initConfig={VALID_CONFIG}>
+          <div>child</div>
+        </AppProviders>
+      );
+    });
+
+    expect(lastChannel.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'lcyt:session',
+        token: 'mock-jwt-token',
+        backendUrl: 'http://backend.test',
+      })
+    );
+  });
+
+  it('responds to lcyt:request_session after connect', async () => {
+    await act(async () => {
+      render(
+        <AppProviders embed autoConnect initConfig={VALID_CONFIG}>
+          <div>child</div>
+        </AppProviders>
+      );
+    });
+
+    lastChannel.postMessage.mockClear();
+
+    // Simulate a late-joining sentlog requesting the session
+    await act(async () => {
+      lastChannel.onmessage({ data: { type: 'lcyt:request_session' } });
+    });
+
+    expect(lastChannel.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'lcyt:session',
+        token: 'mock-jwt-token',
+        backendUrl: 'http://backend.test',
+      })
+    );
+  });
+});

--- a/packages/lcyt-web/test/components/useFileStore.test.jsx
+++ b/packages/lcyt-web/test/components/useFileStore.test.jsx
@@ -1,0 +1,397 @@
+/**
+ * Tests for useFileStore hook.
+ *
+ * FileReader is provided by jsdom; all file-loading tests create real File objects.
+ * localStorage is cleared between tests in test/setup.vitest.js.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useFileStore } from '../../src/hooks/useFileStore.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeFile(name, content) {
+  return new File([content], name, { type: 'text/plain' });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Initial state
+// ---------------------------------------------------------------------------
+
+describe('useFileStore — initial state', () => {
+  it('starts with no files', () => {
+    const { result } = renderHook(() => useFileStore());
+    expect(result.current.files).toEqual([]);
+  });
+
+  it('activeId starts null', () => {
+    const { result } = renderHook(() => useFileStore());
+    expect(result.current.activeId).toBeNull();
+  });
+
+  it('activeFile starts null', () => {
+    const { result } = renderHook(() => useFileStore());
+    expect(result.current.activeFile).toBeNull();
+  });
+
+  it('rawEditMode starts false', () => {
+    const { result } = renderHook(() => useFileStore());
+    expect(result.current.rawEditMode).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadFile()
+// ---------------------------------------------------------------------------
+
+describe('useFileStore — loadFile()', () => {
+  it('adds a file to the store', async () => {
+    const { result } = renderHook(() => useFileStore());
+    await act(() => result.current.loadFile(makeFile('test.txt', 'Hello world')));
+    expect(result.current.files).toHaveLength(1);
+    expect(result.current.files[0].name).toBe('test.txt');
+  });
+
+  it('parses lines from file content', async () => {
+    const { result } = renderHook(() => useFileStore());
+    await act(() => result.current.loadFile(makeFile('test.txt', 'Line one\nLine two')));
+    expect(result.current.files[0].lines).toEqual(['Line one', 'Line two']);
+  });
+
+  it('sets the first loaded file as active', async () => {
+    const { result } = renderHook(() => useFileStore());
+    await act(() => result.current.loadFile(makeFile('first.txt', 'Hello')));
+    expect(result.current.activeId).toBe(result.current.files[0].id);
+  });
+
+  it('fires onFileLoaded callback', async () => {
+    const onFileLoaded = vi.fn();
+    const { result } = renderHook(() => useFileStore({ onFileLoaded }));
+    await act(() => result.current.loadFile(makeFile('test.txt', 'Hello')));
+    expect(onFileLoaded).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'test.txt' })
+    );
+  });
+
+  it('fires onActiveChanged for the first file', async () => {
+    const onActiveChanged = vi.fn();
+    const { result } = renderHook(() => useFileStore({ onActiveChanged }));
+    await act(() => result.current.loadFile(makeFile('test.txt', 'Hello')));
+    expect(onActiveChanged).toHaveBeenCalledWith(
+      expect.objectContaining({ file: expect.objectContaining({ name: 'test.txt' }) })
+    );
+  });
+
+  it('does NOT fire onActiveChanged when a file is already active', async () => {
+    const onActiveChanged = vi.fn();
+    const { result } = renderHook(() => useFileStore({ onActiveChanged }));
+    await act(() => result.current.loadFile(makeFile('first.txt', 'First')));
+    onActiveChanged.mockClear();
+    await act(() => result.current.loadFile(makeFile('second.txt', 'Second')));
+    expect(onActiveChanged).not.toHaveBeenCalled();
+  });
+
+  it('persists rawText to localStorage', async () => {
+    const { result } = renderHook(() => useFileStore());
+    await act(() => result.current.loadFile(makeFile('test.txt', 'Hello')));
+    const stored = JSON.parse(localStorage.getItem('lcyt:files'));
+    expect(stored[0].rawText).toBe('Hello');
+  });
+
+  it('returns the entry as the resolved value', async () => {
+    const { result } = renderHook(() => useFileStore());
+    let entry;
+    await act(async () => {
+      entry = await result.current.loadFile(makeFile('test.txt', 'Hi'));
+    });
+    expect(entry).toMatchObject({ name: 'test.txt', lines: ['Hi'] });
+  });
+
+  it('loads multiple files', async () => {
+    const { result } = renderHook(() => useFileStore());
+    await act(() => result.current.loadFile(makeFile('a.txt', 'A')));
+    await act(() => result.current.loadFile(makeFile('b.txt', 'B')));
+    expect(result.current.files).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// removeFile()
+// ---------------------------------------------------------------------------
+
+describe('useFileStore — removeFile()', () => {
+  it('removes the file from the list', async () => {
+    const { result } = renderHook(() => useFileStore());
+    await act(() => result.current.loadFile(makeFile('a.txt', 'A')));
+    const id = result.current.files[0].id;
+    act(() => result.current.removeFile(id));
+    expect(result.current.files).toHaveLength(0);
+  });
+
+  it('fires onFileRemoved with the file id', async () => {
+    const onFileRemoved = vi.fn();
+    const { result } = renderHook(() => useFileStore({ onFileRemoved }));
+    await act(() => result.current.loadFile(makeFile('a.txt', 'A')));
+    const id = result.current.files[0].id;
+    act(() => result.current.removeFile(id));
+    expect(onFileRemoved).toHaveBeenCalledWith(id);
+  });
+
+  it('sets activeId to null when the last file is removed', async () => {
+    const { result } = renderHook(() => useFileStore());
+    await act(() => result.current.loadFile(makeFile('only.txt', 'X')));
+    const id = result.current.files[0].id;
+    act(() => result.current.removeFile(id));
+    expect(result.current.activeId).toBeNull();
+  });
+
+  it('switches active to the next file when the active file is removed', async () => {
+    const { result } = renderHook(() => useFileStore());
+    await act(() => result.current.loadFile(makeFile('a.txt', 'A')));
+    await act(() => result.current.loadFile(makeFile('b.txt', 'B')));
+    const firstId = result.current.files[0].id;
+    const secondId = result.current.files[1].id;
+    act(() => result.current.setActive(firstId));
+    act(() => result.current.removeFile(firstId));
+    expect(result.current.activeId).toBe(secondId);
+  });
+
+  it('is a no-op for unknown ids', async () => {
+    const { result } = renderHook(() => useFileStore());
+    await act(() => result.current.loadFile(makeFile('a.txt', 'A')));
+    act(() => result.current.removeFile('non-existent-id'));
+    expect(result.current.files).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setActive() / cycleActive()
+// ---------------------------------------------------------------------------
+
+describe('useFileStore — setActive() / cycleActive()', () => {
+  it('setActive changes the active file', async () => {
+    const { result } = renderHook(() => useFileStore());
+    await act(() => result.current.loadFile(makeFile('a.txt', 'A')));
+    await act(() => result.current.loadFile(makeFile('b.txt', 'B')));
+    const secondId = result.current.files[1].id;
+    act(() => result.current.setActive(secondId));
+    expect(result.current.activeId).toBe(secondId);
+  });
+
+  it('cycleActive advances to the next file', async () => {
+    const { result } = renderHook(() => useFileStore());
+    await act(() => result.current.loadFile(makeFile('a.txt', 'A')));
+    await act(() => result.current.loadFile(makeFile('b.txt', 'B')));
+    const firstId = result.current.files[0].id;
+    const secondId = result.current.files[1].id;
+    act(() => result.current.setActive(firstId));
+    act(() => result.current.cycleActive());
+    expect(result.current.activeId).toBe(secondId);
+  });
+
+  it('cycleActive wraps around to the first file', async () => {
+    const { result } = renderHook(() => useFileStore());
+    await act(() => result.current.loadFile(makeFile('a.txt', 'A')));
+    await act(() => result.current.loadFile(makeFile('b.txt', 'B')));
+    const firstId = result.current.files[0].id;
+    const secondId = result.current.files[1].id;
+    act(() => result.current.setActive(secondId));
+    act(() => result.current.cycleActive());
+    expect(result.current.activeId).toBe(firstId);
+  });
+
+  it('cycleActive is a no-op with only one file', async () => {
+    const onActiveChanged = vi.fn();
+    const { result } = renderHook(() => useFileStore({ onActiveChanged }));
+    await act(() => result.current.loadFile(makeFile('only.txt', 'X')));
+    onActiveChanged.mockClear();
+    act(() => result.current.cycleActive());
+    expect(onActiveChanged).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setPointer()
+// ---------------------------------------------------------------------------
+
+describe('useFileStore — setPointer()', () => {
+  it('updates the pointer within bounds', async () => {
+    const { result } = renderHook(() => useFileStore());
+    await act(() => result.current.loadFile(makeFile('test.txt', 'L1\nL2\nL3')));
+    const id = result.current.files[0].id;
+    act(() => result.current.setPointer(id, 2));
+    expect(result.current.files[0].pointer).toBe(2);
+  });
+
+  it('clamps pointer to the max line index', async () => {
+    const { result } = renderHook(() => useFileStore());
+    await act(() => result.current.loadFile(makeFile('test.txt', 'L1\nL2')));
+    const id = result.current.files[0].id;
+    act(() => result.current.setPointer(id, 999));
+    expect(result.current.files[0].pointer).toBe(1);
+  });
+
+  it('clamps pointer to 0', async () => {
+    const { result } = renderHook(() => useFileStore());
+    await act(() => result.current.loadFile(makeFile('test.txt', 'L1\nL2')));
+    const id = result.current.files[0].id;
+    act(() => result.current.setPointer(id, -5));
+    expect(result.current.files[0].pointer).toBe(0);
+  });
+
+  it('fires onPointerChanged callback', async () => {
+    const onPointerChanged = vi.fn();
+    const { result } = renderHook(() => useFileStore({ onPointerChanged }));
+    await act(() => result.current.loadFile(makeFile('test.txt', 'L1\nL2\nL3')));
+    const id = result.current.files[0].id;
+    act(() => result.current.setPointer(id, 1));
+    expect(onPointerChanged).toHaveBeenCalledWith(
+      expect.objectContaining({ fileId: id, fromIndex: 0, toIndex: 1 })
+    );
+  });
+
+  it('persists pointer to localStorage', async () => {
+    const { result } = renderHook(() => useFileStore());
+    await act(() => result.current.loadFile(makeFile('named.txt', 'L1\nL2\nL3')));
+    const id = result.current.files[0].id;
+    act(() => result.current.setPointer(id, 2));
+    const stored = JSON.parse(localStorage.getItem('lcyt-pointers'));
+    expect(stored['named.txt']).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// advancePointer()
+// ---------------------------------------------------------------------------
+
+describe('useFileStore — advancePointer()', () => {
+  it('increments the pointer by 1', async () => {
+    const { result } = renderHook(() => useFileStore());
+    await act(() => result.current.loadFile(makeFile('test.txt', 'L1\nL2\nL3')));
+    const id = result.current.files[0].id;
+    act(() => result.current.advancePointer(id));
+    expect(result.current.files[0].pointer).toBe(1);
+  });
+
+  it('does not advance past the last line', async () => {
+    const { result } = renderHook(() => useFileStore());
+    await act(() => result.current.loadFile(makeFile('test.txt', 'L1\nL2')));
+    const id = result.current.files[0].id;
+    act(() => result.current.setPointer(id, 1));
+    act(() => result.current.advancePointer(id));
+    expect(result.current.files[0].pointer).toBe(1);
+  });
+
+  it('fires onPointerChanged callback', async () => {
+    const onPointerChanged = vi.fn();
+    const { result } = renderHook(() => useFileStore({ onPointerChanged }));
+    await act(() => result.current.loadFile(makeFile('test.txt', 'L1\nL2')));
+    const id = result.current.files[0].id;
+    act(() => result.current.advancePointer(id));
+    expect(onPointerChanged).toHaveBeenCalledWith(
+      expect.objectContaining({ fileId: id, fromIndex: 0, toIndex: 1 })
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createEmptyFile()
+// ---------------------------------------------------------------------------
+
+describe('useFileStore — createEmptyFile()', () => {
+  it('creates a file with zero lines', () => {
+    const { result } = renderHook(() => useFileStore());
+    act(() => result.current.createEmptyFile('new.txt'));
+    expect(result.current.files[0].lines).toEqual([]);
+  });
+
+  it('sets the new file as active', () => {
+    const { result } = renderHook(() => useFileStore());
+    act(() => result.current.createEmptyFile('new.txt'));
+    expect(result.current.activeId).toBe(result.current.files[0].id);
+  });
+
+  it('enters rawEditMode', () => {
+    const { result } = renderHook(() => useFileStore());
+    act(() => result.current.createEmptyFile('new.txt'));
+    expect(result.current.rawEditMode).toBe(true);
+  });
+
+  it('fires onFileLoaded callback', () => {
+    const onFileLoaded = vi.fn();
+    const { result } = renderHook(() => useFileStore({ onFileLoaded }));
+    act(() => result.current.createEmptyFile('new.txt'));
+    expect(onFileLoaded).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'new.txt', lines: [] })
+    );
+  });
+
+  it('fires onActiveChanged callback', () => {
+    const onActiveChanged = vi.fn();
+    const { result } = renderHook(() => useFileStore({ onActiveChanged }));
+    act(() => result.current.createEmptyFile('new.txt'));
+    expect(onActiveChanged).toHaveBeenCalledWith(
+      expect.objectContaining({ file: expect.objectContaining({ name: 'new.txt' }) })
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateFileFromRawText()
+// ---------------------------------------------------------------------------
+
+describe('useFileStore — updateFileFromRawText()', () => {
+  it('re-parses and updates the file lines', async () => {
+    const { result } = renderHook(() => useFileStore());
+    await act(() => result.current.loadFile(makeFile('test.txt', 'Old line')));
+    const id = result.current.files[0].id;
+    act(() => result.current.updateFileFromRawText(id, 'New line A\nNew line B'));
+    expect(result.current.files[0].lines).toEqual(['New line A', 'New line B']);
+  });
+
+  it('persists updated rawText to localStorage', async () => {
+    const { result } = renderHook(() => useFileStore());
+    await act(() => result.current.loadFile(makeFile('test.txt', 'Old')));
+    const id = result.current.files[0].id;
+    act(() => result.current.updateFileFromRawText(id, 'New content'));
+    const stored = JSON.parse(localStorage.getItem('lcyt:files'));
+    expect(stored[0].rawText).toBe('New content');
+  });
+
+  it('clamps pointer when line count shrinks', async () => {
+    const { result } = renderHook(() => useFileStore());
+    await act(() => result.current.loadFile(makeFile('test.txt', 'L1\nL2\nL3')));
+    const id = result.current.files[0].id;
+    act(() => result.current.setPointer(id, 2));
+    act(() => result.current.updateFileFromRawText(id, 'Only one'));
+    expect(result.current.files[0].pointer).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// localStorage persistence across remount
+// ---------------------------------------------------------------------------
+
+describe('useFileStore — localStorage restore on mount', () => {
+  it('restores files saved in localStorage on mount', async () => {
+    // First hook instance: load a file
+    const { result: r1, unmount } = renderHook(() => useFileStore());
+    await act(() => r1.current.loadFile(makeFile('restore.txt', 'Restored line')));
+    unmount();
+
+    // Second hook instance: should restore from localStorage
+    const { result: r2 } = renderHook(() => useFileStore());
+    // useEffect runs after render; act flushes it
+    await act(async () => {});
+    expect(r2.current.files).toHaveLength(1);
+    expect(r2.current.files[0].name).toBe('restore.txt');
+    expect(r2.current.files[0].lines).toEqual(['Restored line']);
+  });
+});

--- a/packages/lcyt-web/test/components/useSentLog.test.jsx
+++ b/packages/lcyt-web/test/components/useSentLog.test.jsx
@@ -1,0 +1,284 @@
+/**
+ * Tests for useSentLog hook.
+ *
+ * localStorage is cleared between tests in test/setup.vitest.js.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useSentLog } from '../../src/hooks/useSentLog.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Initial state
+// ---------------------------------------------------------------------------
+
+describe('useSentLog — initial state', () => {
+  it('starts with an empty entries list', () => {
+    const { result } = renderHook(() => useSentLog());
+    expect(result.current.entries).toEqual([]);
+  });
+
+  it('restores confirmed entries from localStorage on mount', () => {
+    const saved = [
+      { requestId: 'r1', text: 'Hello', pending: false, error: false, sequence: 1 },
+    ];
+    localStorage.setItem('lcyt:sent-log', JSON.stringify(saved));
+
+    const { result } = renderHook(() => useSentLog());
+    expect(result.current.entries).toHaveLength(1);
+    expect(result.current.entries[0].requestId).toBe('r1');
+  });
+
+  it('returns empty list when localStorage has invalid JSON', () => {
+    localStorage.setItem('lcyt:sent-log', 'not-json');
+    const { result } = renderHook(() => useSentLog());
+    expect(result.current.entries).toEqual([]);
+  });
+
+  it('returns empty list when localStorage value is not an array', () => {
+    localStorage.setItem('lcyt:sent-log', JSON.stringify({ invalid: true }));
+    const { result } = renderHook(() => useSentLog());
+    expect(result.current.entries).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// add()
+// ---------------------------------------------------------------------------
+
+describe('useSentLog — add()', () => {
+  it('adds an entry to the front of the list', () => {
+    const { result } = renderHook(() => useSentLog());
+    act(() => {
+      result.current.add({ requestId: 'r1', sequence: 1, text: 'Hello' });
+    });
+    expect(result.current.entries).toHaveLength(1);
+    expect(result.current.entries[0].text).toBe('Hello');
+  });
+
+  it('prepends newer entries (newest-first order)', () => {
+    const { result } = renderHook(() => useSentLog());
+    act(() => {
+      result.current.add({ requestId: 'r1', sequence: 1, text: 'First' });
+      result.current.add({ requestId: 'r2', sequence: 2, text: 'Second' });
+    });
+    expect(result.current.entries[0].text).toBe('Second');
+    expect(result.current.entries[1].text).toBe('First');
+  });
+
+  it('sets pending=false by default', () => {
+    const { result } = renderHook(() => useSentLog());
+    act(() => {
+      result.current.add({ requestId: 'r1', sequence: 1, text: 'Hello' });
+    });
+    expect(result.current.entries[0].pending).toBe(false);
+  });
+
+  it('sets pending=true when passed', () => {
+    const { result } = renderHook(() => useSentLog());
+    act(() => {
+      result.current.add({ requestId: 'r1', sequence: 1, text: 'Hello', pending: true });
+    });
+    expect(result.current.entries[0].pending).toBe(true);
+  });
+
+  it('sets error=false on new entries', () => {
+    const { result } = renderHook(() => useSentLog());
+    act(() => {
+      result.current.add({ requestId: 'r1', sequence: 1, text: 'Hello' });
+    });
+    expect(result.current.entries[0].error).toBe(false);
+  });
+
+  it('adds a timestamp to each entry', () => {
+    const { result } = renderHook(() => useSentLog());
+    act(() => {
+      result.current.add({ requestId: 'r1', sequence: 1, text: 'Hello' });
+    });
+    expect(result.current.entries[0].timestamp).toBeDefined();
+    expect(() => new Date(result.current.entries[0].timestamp)).not.toThrow();
+  });
+
+  it('does not persist pending entries to localStorage', () => {
+    const { result } = renderHook(() => useSentLog());
+    act(() => {
+      result.current.add({ requestId: 'r1', sequence: 1, text: 'Hello', pending: true });
+    });
+    const stored = JSON.parse(localStorage.getItem('lcyt:sent-log') || '[]');
+    expect(stored).toHaveLength(0);
+  });
+
+  it('persists confirmed (non-pending) entries to localStorage', () => {
+    const { result } = renderHook(() => useSentLog());
+    act(() => {
+      result.current.add({ requestId: 'r1', sequence: 1, text: 'Hello' });
+    });
+    const stored = JSON.parse(localStorage.getItem('lcyt:sent-log') || '[]');
+    expect(stored).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// confirm()
+// ---------------------------------------------------------------------------
+
+describe('useSentLog — confirm()', () => {
+  it('clears the pending flag by requestId string', () => {
+    const { result } = renderHook(() => useSentLog());
+    act(() => {
+      result.current.add({ requestId: 'r1', sequence: 1, text: 'Hello', pending: true });
+    });
+    act(() => {
+      result.current.confirm('r1', { sequence: 2, serverTimestamp: '2026-01-01T00:00:00.000' });
+    });
+    expect(result.current.entries[0].pending).toBe(false);
+  });
+
+  it('accepts an object argument for requestId', () => {
+    const { result } = renderHook(() => useSentLog());
+    act(() => {
+      result.current.add({ requestId: 'r1', sequence: 1, text: 'Hello', pending: true });
+    });
+    act(() => {
+      result.current.confirm({ requestId: 'r1', sequence: 2, serverTimestamp: '2026-01-01T00:00:00.000' });
+    });
+    expect(result.current.entries[0].pending).toBe(false);
+  });
+
+  it('updates the sequence from the server', () => {
+    const { result } = renderHook(() => useSentLog());
+    act(() => {
+      result.current.add({ requestId: 'r1', sequence: 0, text: 'Hello', pending: true });
+    });
+    act(() => {
+      result.current.confirm('r1', { sequence: 42 });
+    });
+    expect(result.current.entries[0].sequence).toBe(42);
+  });
+
+  it('is a no-op for unknown requestId', () => {
+    const { result } = renderHook(() => useSentLog());
+    act(() => {
+      result.current.add({ requestId: 'r1', sequence: 1, text: 'Hello', pending: true });
+    });
+    act(() => {
+      result.current.confirm('unknown-id');
+    });
+    expect(result.current.entries[0].pending).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// markError()
+// ---------------------------------------------------------------------------
+
+describe('useSentLog — markError()', () => {
+  it('sets error=true on the matching entry', () => {
+    const { result } = renderHook(() => useSentLog());
+    act(() => {
+      result.current.add({ requestId: 'r1', sequence: 1, text: 'Hello', pending: true });
+    });
+    act(() => {
+      result.current.markError('r1');
+    });
+    expect(result.current.entries[0].error).toBe(true);
+  });
+
+  it('clears the pending flag when marking error', () => {
+    const { result } = renderHook(() => useSentLog());
+    act(() => {
+      result.current.add({ requestId: 'r1', sequence: 1, text: 'Hello', pending: true });
+    });
+    act(() => {
+      result.current.markError('r1');
+    });
+    expect(result.current.entries[0].pending).toBe(false);
+  });
+
+  it('does not persist error entries to localStorage', () => {
+    const { result } = renderHook(() => useSentLog());
+    act(() => {
+      result.current.add({ requestId: 'r1', sequence: 1, text: 'Hello', pending: true });
+    });
+    act(() => {
+      result.current.markError('r1');
+    });
+    const stored = JSON.parse(localStorage.getItem('lcyt:sent-log') || '[]');
+    expect(stored.filter(e => e.error)).toHaveLength(0);
+  });
+
+  it('is a no-op for unknown requestId', () => {
+    const { result } = renderHook(() => useSentLog());
+    act(() => {
+      result.current.add({ requestId: 'r1', sequence: 1, text: 'Hello', pending: true });
+    });
+    act(() => {
+      result.current.markError('unknown-id');
+    });
+    expect(result.current.entries[0].error).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateRequestId()
+// ---------------------------------------------------------------------------
+
+describe('useSentLog — updateRequestId()', () => {
+  it('remaps oldId to newId', () => {
+    const { result } = renderHook(() => useSentLog());
+    act(() => {
+      result.current.add({ requestId: 'temp-1', sequence: 1, text: 'Hello', pending: true });
+    });
+    act(() => {
+      result.current.updateRequestId('temp-1', 'real-server-id');
+    });
+    expect(result.current.entries[0].requestId).toBe('real-server-id');
+  });
+
+  it('is a no-op for unknown oldId', () => {
+    const { result } = renderHook(() => useSentLog());
+    act(() => {
+      result.current.add({ requestId: 'r1', sequence: 1, text: 'Hello' });
+    });
+    act(() => {
+      result.current.updateRequestId('unknown', 'new-id');
+    });
+    expect(result.current.entries[0].requestId).toBe('r1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// clear()
+// ---------------------------------------------------------------------------
+
+describe('useSentLog — clear()', () => {
+  it('removes all entries from the list', () => {
+    const { result } = renderHook(() => useSentLog());
+    act(() => {
+      result.current.add({ requestId: 'r1', sequence: 1, text: 'A' });
+      result.current.add({ requestId: 'r2', sequence: 2, text: 'B' });
+    });
+    act(() => {
+      result.current.clear();
+    });
+    expect(result.current.entries).toHaveLength(0);
+  });
+
+  it('empties the localStorage entry', () => {
+    const { result } = renderHook(() => useSentLog());
+    act(() => {
+      result.current.add({ requestId: 'r1', sequence: 1, text: 'A' });
+    });
+    act(() => {
+      result.current.clear();
+    });
+    // The useEffect re-saves [] after clear() removes the key, so the result is an empty array.
+    const raw = localStorage.getItem('lcyt:sent-log');
+    const stored = raw ? JSON.parse(raw) : [];
+    expect(stored).toHaveLength(0);
+  });
+});

--- a/packages/lcyt-web/test/components/useSession.test.jsx
+++ b/packages/lcyt-web/test/components/useSession.test.jsx
@@ -1,0 +1,262 @@
+/**
+ * Tests for useSession hook.
+ *
+ * BackendCaptionSender is mocked so no real HTTP traffic occurs.
+ * EventSource is stubbed globally in test/setup.vitest.js.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useSession } from '../../src/hooks/useSession.js';
+
+// ---------------------------------------------------------------------------
+// Mock BackendCaptionSender
+// ---------------------------------------------------------------------------
+
+const mockSender = {
+  _token: 'mock-jwt-token',
+  sequence: 0,
+  syncOffset: 0,
+  startedAt: new Date(),
+  graphicsEnabled: false,
+  apiKey: 'test-api-key',
+  start: vi.fn().mockResolvedValue(undefined),
+  end: vi.fn().mockResolvedValue(undefined),
+  sync: vi.fn().mockResolvedValue({ syncOffset: 0 }),
+  send: vi.fn().mockResolvedValue({ ok: true, requestId: 'req-1' }),
+  sendBatch: vi.fn().mockResolvedValue({ ok: true, requestId: 'req-batch', count: 2 }),
+  construct: vi.fn().mockReturnValue(undefined),
+  heartbeat: vi.fn().mockResolvedValue({ ok: true }),
+  updateSession: vi.fn().mockResolvedValue(undefined),
+};
+
+vi.mock('lcyt/backend', () => ({
+  BackendCaptionSender: vi.fn(function () { return mockSender; }),
+}));
+
+// targetConfig reads from localStorage — starts empty (cleared in setup.vitest.js)
+// so getEnabledTargets() returns [] and connect() calls sender.start({})
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const VALID_CONFIG = {
+  backendUrl: 'http://backend.test',
+  apiKey: 'test-api-key',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSender._token = 'mock-jwt-token';
+  mockSender.sequence = 0;
+  mockSender.syncOffset = 0;
+});
+
+// ---------------------------------------------------------------------------
+// Initial state
+// ---------------------------------------------------------------------------
+
+describe('useSession — initial state', () => {
+  it('starts disconnected', () => {
+    const { result } = renderHook(() => useSession());
+    expect(result.current.connected).toBe(false);
+  });
+
+  it('sequence starts at 0', () => {
+    const { result } = renderHook(() => useSession());
+    expect(result.current.sequence).toBe(0);
+  });
+
+  it('backendUrl starts empty', () => {
+    const { result } = renderHook(() => useSession());
+    expect(result.current.backendUrl).toBe('');
+  });
+
+  it('healthStatus starts as "unknown"', () => {
+    const { result } = renderHook(() => useSession());
+    expect(result.current.healthStatus).toBe('unknown');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Persistence helpers (getPersistedConfig / getAutoConnect / setAutoConnect)
+// ---------------------------------------------------------------------------
+
+describe('useSession — persistence helpers', () => {
+  it('getPersistedConfig returns {} when nothing stored', () => {
+    const { result } = renderHook(() => useSession());
+    expect(result.current.getPersistedConfig()).toEqual({});
+  });
+
+  it('getAutoConnect returns false when nothing stored', () => {
+    const { result } = renderHook(() => useSession());
+    expect(result.current.getAutoConnect()).toBe(false);
+  });
+
+  it('setAutoConnect / getAutoConnect round-trip', () => {
+    const { result } = renderHook(() => useSession());
+    act(() => { result.current.setAutoConnect(true); });
+    expect(result.current.getAutoConnect()).toBe(true);
+    act(() => { result.current.setAutoConnect(false); });
+    expect(result.current.getAutoConnect()).toBe(false);
+  });
+
+  it('clearPersistedConfig removes both keys', () => {
+    const { result } = renderHook(() => useSession());
+    act(() => { result.current.setAutoConnect(true); });
+    act(() => { result.current.clearPersistedConfig(); });
+    expect(result.current.getAutoConnect()).toBe(false);
+    expect(result.current.getPersistedConfig()).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// connect()
+// ---------------------------------------------------------------------------
+
+describe('useSession — connect()', () => {
+  it('sets connected=true after successful connect', async () => {
+    const { result } = renderHook(() => useSession());
+    await act(() => result.current.connect(VALID_CONFIG));
+    expect(result.current.connected).toBe(true);
+  });
+
+  it('calls BackendCaptionSender.start()', async () => {
+    const { result } = renderHook(() => useSession());
+    await act(() => result.current.connect(VALID_CONFIG));
+    expect(mockSender.start).toHaveBeenCalledTimes(1);
+  });
+
+  it('sets backendUrl from config', async () => {
+    const { result } = renderHook(() => useSession());
+    await act(() => result.current.connect(VALID_CONFIG));
+    expect(result.current.backendUrl).toBe('http://backend.test');
+  });
+
+  it('sets apiKey from config', async () => {
+    const { result } = renderHook(() => useSession());
+    await act(() => result.current.connect(VALID_CONFIG));
+    expect(result.current.apiKey).toBe('test-api-key');
+  });
+
+  it('sets healthStatus to "ok" after connect', async () => {
+    const { result } = renderHook(() => useSession());
+    await act(() => result.current.connect(VALID_CONFIG));
+    expect(result.current.healthStatus).toBe('ok');
+  });
+
+  it('calls onConnected callback with token + backendUrl', async () => {
+    const onConnected = vi.fn();
+    const { result } = renderHook(() => useSession({ onConnected }));
+    await act(() => result.current.connect(VALID_CONFIG));
+    expect(onConnected).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: 'mock-jwt-token',
+        backendUrl: 'http://backend.test',
+      })
+    );
+  });
+
+  it('persists backendUrl + apiKey to localStorage', async () => {
+    const { result } = renderHook(() => useSession());
+    await act(() => result.current.connect(VALID_CONFIG));
+    const cfg = result.current.getPersistedConfig();
+    expect(cfg.backendUrl).toBe('http://backend.test');
+    expect(cfg.apiKey).toBe('test-api-key');
+  });
+
+  it('throws and calls onError when no token received', async () => {
+    mockSender._token = null;
+    const onError = vi.fn();
+    const { result } = renderHook(() => useSession({ onError }));
+    await expect(act(() => result.current.connect(VALID_CONFIG))).rejects.toThrow();
+    expect(onError).toHaveBeenCalled();
+    expect(result.current.connected).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// disconnect()
+// ---------------------------------------------------------------------------
+
+describe('useSession — disconnect()', () => {
+  it('sets connected=false after disconnect', async () => {
+    const { result } = renderHook(() => useSession());
+    await act(() => result.current.connect(VALID_CONFIG));
+    expect(result.current.connected).toBe(true);
+    await act(() => result.current.disconnect());
+    expect(result.current.connected).toBe(false);
+  });
+
+  it('calls sender.end()', async () => {
+    const { result } = renderHook(() => useSession());
+    await act(() => result.current.connect(VALID_CONFIG));
+    await act(() => result.current.disconnect());
+    expect(mockSender.end).toHaveBeenCalled();
+  });
+
+  it('calls onDisconnected callback', async () => {
+    const onDisconnected = vi.fn();
+    const { result } = renderHook(() => useSession({ onDisconnected }));
+    await act(() => result.current.connect(VALID_CONFIG));
+    await act(() => result.current.disconnect());
+    expect(onDisconnected).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets sequence to 0', async () => {
+    const { result } = renderHook(() => useSession());
+    await act(() => result.current.connect(VALID_CONFIG));
+    await act(() => result.current.disconnect());
+    expect(result.current.sequence).toBe(0);
+  });
+
+  it('is a no-op when not connected', async () => {
+    const onDisconnected = vi.fn();
+    const { result } = renderHook(() => useSession({ onDisconnected }));
+    await act(() => result.current.disconnect());
+    expect(onDisconnected).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// send()
+// ---------------------------------------------------------------------------
+
+describe('useSession — send()', () => {
+  it('throws when not connected', async () => {
+    const { result } = renderHook(() => useSession());
+    await expect(result.current.send('Hello')).rejects.toThrow('Not connected');
+  });
+
+  it('delegates to sender.send() and fires onCaptionSent', async () => {
+    const onCaptionSent = vi.fn();
+    const { result } = renderHook(() => useSession({ onCaptionSent }));
+    await act(() => result.current.connect(VALID_CONFIG));
+    await act(() => result.current.send('Hello world'));
+    expect(mockSender.send).toHaveBeenCalledWith('Hello world', undefined, undefined);
+    expect(onCaptionSent).toHaveBeenCalledWith(
+      expect.objectContaining({ text: 'Hello world', requestId: 'req-1', pending: true })
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sendBatch()
+// ---------------------------------------------------------------------------
+
+describe('useSession — sendBatch()', () => {
+  it('throws when not connected', async () => {
+    const { result } = renderHook(() => useSession());
+    await expect(result.current.sendBatch(['a', 'b'])).rejects.toThrow('Not connected');
+  });
+
+  it('delegates to sender.sendBatch()', async () => {
+    const { result } = renderHook(() => useSession());
+    await act(() => result.current.connect(VALID_CONFIG));
+    await act(() => result.current.sendBatch(['Cap 1', 'Cap 2']));
+    expect(mockSender.sendBatch).toHaveBeenCalledWith(
+      [{ text: 'Cap 1' }, { text: 'Cap 2' }]
+    );
+  });
+});

--- a/packages/lcyt-web/test/components/useToast.test.jsx
+++ b/packages/lcyt-web/test/components/useToast.test.jsx
@@ -1,0 +1,209 @@
+/**
+ * Tests for useToast hook and ToastContainer component.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, render, screen, act, fireEvent } from '@testing-library/react';
+import { useToast } from '../../src/hooks/useToast.js';
+import { ToastProvider } from '../../src/contexts/ToastContext.jsx';
+import { ToastContainer } from '../../src/components/ToastContainer.jsx';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// useToast hook
+// ---------------------------------------------------------------------------
+
+describe('useToast — initial state', () => {
+  it('starts with an empty toasts list', () => {
+    const { result } = renderHook(() => useToast());
+    expect(result.current.toasts).toEqual([]);
+  });
+});
+
+describe('useToast — showToast()', () => {
+  it('adds a toast to the list', () => {
+    const { result } = renderHook(() => useToast());
+    act(() => {
+      result.current.showToast('Hello!');
+    });
+    expect(result.current.toasts).toHaveLength(1);
+    expect(result.current.toasts[0].message).toBe('Hello!');
+  });
+
+  it('defaults to type "info"', () => {
+    const { result } = renderHook(() => useToast());
+    act(() => {
+      result.current.showToast('Hello!');
+    });
+    expect(result.current.toasts[0].type).toBe('info');
+  });
+
+  it('accepts a custom type', () => {
+    const { result } = renderHook(() => useToast());
+    act(() => {
+      result.current.showToast('Error!', 'error');
+    });
+    expect(result.current.toasts[0].type).toBe('error');
+  });
+
+  it('assigns a unique id to each toast', () => {
+    const { result } = renderHook(() => useToast());
+    act(() => {
+      result.current.showToast('A');
+      result.current.showToast('B');
+    });
+    const ids = result.current.toasts.map(t => t.id);
+    expect(new Set(ids).size).toBe(2);
+  });
+
+  it('auto-dismisses after the duration elapses', () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useToast());
+    act(() => {
+      result.current.showToast('Bye', 'info', 1000);
+    });
+    expect(result.current.toasts).toHaveLength(1);
+    act(() => {
+      vi.advanceTimersByTime(1001);
+    });
+    expect(result.current.toasts).toHaveLength(0);
+    vi.useRealTimers();
+  });
+
+  it('does NOT auto-dismiss when duration=0', () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useToast());
+    act(() => {
+      result.current.showToast('Sticky', 'info', 0);
+    });
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(result.current.toasts).toHaveLength(1);
+    vi.useRealTimers();
+  });
+});
+
+describe('useToast — dismissToast()', () => {
+  it('removes the toast with the given id', () => {
+    const { result } = renderHook(() => useToast());
+    act(() => {
+      result.current.showToast('A');
+    });
+    const id = result.current.toasts[0].id;
+    act(() => {
+      result.current.dismissToast(id);
+    });
+    expect(result.current.toasts).toHaveLength(0);
+  });
+
+  it('only removes the matching toast', () => {
+    const { result } = renderHook(() => useToast());
+    act(() => {
+      result.current.showToast('A');
+      result.current.showToast('B');
+    });
+    const firstId = result.current.toasts[0].id;
+    act(() => {
+      result.current.dismissToast(firstId);
+    });
+    expect(result.current.toasts).toHaveLength(1);
+    expect(result.current.toasts[0].message).toBe('B');
+  });
+
+  it('is a no-op for unknown id', () => {
+    const { result } = renderHook(() => useToast());
+    act(() => {
+      result.current.showToast('A');
+    });
+    act(() => {
+      result.current.dismissToast(99999);
+    });
+    expect(result.current.toasts).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ToastContainer component
+// ---------------------------------------------------------------------------
+
+function Wrapper({ children }) {
+  return <ToastProvider>{children}</ToastProvider>;
+}
+
+describe('ToastContainer', () => {
+  it('renders without crashing when there are no toasts', () => {
+    render(<Wrapper><ToastContainer /></Wrapper>);
+    expect(document.getElementById('toast-container')).toBeInTheDocument();
+  });
+
+  it('renders a toast message', async () => {
+    const { ToastContext } = await import('../../src/contexts/ToastContext.jsx');
+    const mockCtx = {
+      toasts: [{ id: 1, message: 'Hello toast!', type: 'info', duration: 5000 }],
+      dismissToast: vi.fn(),
+    };
+    render(
+      <ToastContext.Provider value={mockCtx}>
+        <ToastContainer />
+      </ToastContext.Provider>
+    );
+    expect(screen.getByText('Hello toast!')).toBeInTheDocument();
+  });
+
+  it('renders toast with correct CSS class', async () => {
+    const { ToastContext } = await import('../../src/contexts/ToastContext.jsx');
+    const mockCtx = {
+      toasts: [{ id: 1, message: 'Alert!', type: 'error', duration: 5000 }],
+      dismissToast: vi.fn(),
+    };
+    render(
+      <ToastContext.Provider value={mockCtx}>
+        <ToastContainer />
+      </ToastContext.Provider>
+    );
+    expect(screen.getByText('Alert!')).toBeInTheDocument();
+    expect(document.querySelector('.toast--error')).toBeInTheDocument();
+  });
+
+  it('renders multiple toasts', async () => {
+    const { ToastContext } = await import('../../src/contexts/ToastContext.jsx');
+    const mockCtx = {
+      toasts: [
+        { id: 1, message: 'First', type: 'info', duration: 5000 },
+        { id: 2, message: 'Second', type: 'warning', duration: 5000 },
+      ],
+      dismissToast: vi.fn(),
+    };
+    render(
+      <ToastContext.Provider value={mockCtx}>
+        <ToastContainer />
+      </ToastContext.Provider>
+    );
+    expect(screen.getByText('First')).toBeInTheDocument();
+    expect(screen.getByText('Second')).toBeInTheDocument();
+  });
+
+  it('calls dismissToast when a toast is clicked', async () => {
+    vi.useFakeTimers();
+    const { ToastContext } = await import('../../src/contexts/ToastContext.jsx');
+    const dismissToast = vi.fn();
+    const mockCtx = {
+      toasts: [{ id: 42, message: 'Click me', type: 'info', duration: 5000 }],
+      dismissToast,
+    };
+    render(
+      <ToastContext.Provider value={mockCtx}>
+        <ToastContainer />
+      </ToastContext.Provider>
+    );
+    fireEvent.click(screen.getByText('Click me'));
+    // dismissToast is called after 200ms fade-out
+    act(() => { vi.advanceTimersByTime(200); });
+    expect(dismissToast).toHaveBeenCalledWith(42);
+    vi.useRealTimers();
+  });
+});

--- a/packages/lcyt-web/test/fileUtils.test.js
+++ b/packages/lcyt-web/test/fileUtils.test.js
@@ -1,0 +1,181 @@
+/**
+ * Tests for parseFileContent() from src/lib/fileUtils.js
+ *
+ * parseFileContent() is a pure function — no browser APIs required.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseFileContent } from '../src/lib/fileUtils.js';
+
+// ---------------------------------------------------------------------------
+// Basic parsing
+// ---------------------------------------------------------------------------
+
+describe('parseFileContent() — basic', () => {
+  it('returns empty arrays for empty string', () => {
+    const { lines, lineCodes, lineNumbers } = parseFileContent('');
+    assert.deepEqual(lines, []);
+    assert.deepEqual(lineCodes, []);
+    assert.deepEqual(lineNumbers, []);
+  });
+
+  it('parses plain lines', () => {
+    const raw = 'First line\nSecond line\nThird line';
+    const { lines, lineNumbers } = parseFileContent(raw);
+    assert.deepEqual(lines, ['First line', 'Second line', 'Third line']);
+    assert.deepEqual(lineNumbers, [1, 2, 3]);
+  });
+
+  it('ignores blank lines', () => {
+    const raw = 'Line 1\n\n\nLine 2';
+    const { lines } = parseFileContent(raw);
+    assert.deepEqual(lines, ['Line 1', 'Line 2']);
+  });
+
+  it('trims leading/trailing whitespace from each line', () => {
+    const raw = '  hello  \n  world  ';
+    const { lines } = parseFileContent(raw);
+    assert.deepEqual(lines, ['hello', 'world']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Metadata comments
+// ---------------------------------------------------------------------------
+
+describe('parseFileContent() — metadata comments', () => {
+  it('does not include metadata comment lines in output', () => {
+    const raw = '<!-- lang: fi-FI -->\nCaption line';
+    const { lines } = parseFileContent(raw);
+    assert.equal(lines.length, 1);
+    assert.equal(lines[0], 'Caption line');
+  });
+
+  it('attaches metadata code to subsequent lines', () => {
+    const raw = '<!-- lang: fi-FI -->\nCaption line';
+    const { lineCodes } = parseFileContent(raw);
+    assert.equal(lineCodes[0].lang, 'fi-FI');
+  });
+
+  it('metadata persists across multiple lines', () => {
+    const raw = '<!-- lang: fi-FI -->\nLine 1\nLine 2';
+    const { lineCodes } = parseFileContent(raw);
+    assert.equal(lineCodes[0].lang, 'fi-FI');
+    assert.equal(lineCodes[1].lang, 'fi-FI');
+  });
+
+  it('removes a code when value is empty', () => {
+    const raw = '<!-- lang: fi-FI -->\nLine 1\n<!-- lang: -->\nLine 2';
+    const { lineCodes } = parseFileContent(raw);
+    assert.equal(lineCodes[0].lang, 'fi-FI');
+    assert.equal(lineCodes[1].lang, undefined);
+  });
+
+  it('overrides a code with a new value', () => {
+    const raw = '<!-- lang: fi-FI -->\nLine 1\n<!-- lang: en-US -->\nLine 2';
+    const { lineCodes } = parseFileContent(raw);
+    assert.equal(lineCodes[0].lang, 'fi-FI');
+    assert.equal(lineCodes[1].lang, 'en-US');
+  });
+
+  it('accepts custom metadata keys', () => {
+    const raw = '<!-- speaker: Alice -->\nLine 1';
+    const { lineCodes } = parseFileContent(raw);
+    assert.equal(lineCodes[0].speaker, 'Alice');
+  });
+
+  it('coerces lyrics: true to boolean', () => {
+    const raw = '<!-- lyrics: true -->\nLine 1';
+    const { lineCodes } = parseFileContent(raw);
+    assert.equal(lineCodes[0].lyrics, true);
+  });
+
+  it('coerces no-translate: true to boolean', () => {
+    const raw = '<!-- no-translate: true -->\nLine 1';
+    const { lineCodes } = parseFileContent(raw);
+    assert.equal(lineCodes[0]['no-translate'], true);
+  });
+
+  it('stores non-boolean codes as strings', () => {
+    const raw = '<!-- section: chorus -->\nLine 1';
+    const { lineCodes } = parseFileContent(raw);
+    assert.equal(typeof lineCodes[0].section, 'string');
+    assert.equal(lineCodes[0].section, 'chorus');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stanza blocks
+// ---------------------------------------------------------------------------
+
+describe('parseFileContent() — stanza blocks', () => {
+  it('does not produce a caption line for the stanza block itself', () => {
+    const raw = '<!-- stanza\nFirst song line\nSecond song line\n-->\nCaption';
+    const { lines } = parseFileContent(raw);
+    // Only 'Caption' should be in lines (not the stanza block lines)
+    assert.equal(lines.length, 1);
+    assert.equal(lines[0], 'Caption');
+  });
+
+  it('sets stanza code on the following caption line', () => {
+    const raw = '<!-- stanza\nFirst song line\nSecond song line\n-->\nCaption';
+    const { lineCodes } = parseFileContent(raw);
+    assert.ok(lineCodes[0].stanza);
+    assert.ok(lineCodes[0].stanza.includes('First song line'));
+    assert.ok(lineCodes[0].stanza.includes('Second song line'));
+  });
+
+  it('clears stanza code on empty stanza block', () => {
+    const raw = '<!-- stanza\nFirst\n-->\nLine 1\n<!-- stanza\n-->\nLine 2';
+    const { lineCodes } = parseFileContent(raw);
+    assert.ok(lineCodes[0].stanza);
+    assert.equal(lineCodes[1].stanza, undefined);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Empty-send markers
+// ---------------------------------------------------------------------------
+
+describe('parseFileContent() — empty-send markers', () => {
+  it('creates an entry with empty string and emptySend=true for bare _', () => {
+    const raw = '_\nCaption';
+    const { lines, lineCodes } = parseFileContent(raw);
+    assert.equal(lines[0], '');
+    assert.equal(lineCodes[0].emptySend, true);
+    assert.equal(lines[1], 'Caption');
+  });
+
+  it('captures optional label after _ space', () => {
+    const raw = '_ intro\nCaption';
+    const { lineCodes } = parseFileContent(raw);
+    assert.equal(lineCodes[0].emptySend, true);
+    assert.equal(lineCodes[0].emptySendLabel, 'intro');
+  });
+
+  it('empty-send inherits current metadata codes', () => {
+    const raw = '<!-- lang: fi-FI -->\n_\nCaption';
+    const { lineCodes } = parseFileContent(raw);
+    assert.equal(lineCodes[0].lang, 'fi-FI');
+    assert.equal(lineCodes[0].emptySend, true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// lineNumbers
+// ---------------------------------------------------------------------------
+
+describe('parseFileContent() — lineNumbers', () => {
+  it('assigns sequential 1-based line numbers to text lines only', () => {
+    const raw = '<!-- lang: fi-FI -->\nLine 1\nLine 2\n<!-- section: x -->\nLine 3';
+    const { lineNumbers } = parseFileContent(raw);
+    assert.deepEqual(lineNumbers, [1, 2, 3]);
+  });
+
+  it('counts empty-send markers in line numbers', () => {
+    const raw = '_\nLine 1\nLine 2';
+    const { lineNumbers } = parseFileContent(raw);
+    assert.deepEqual(lineNumbers, [1, 2, 3]);
+  });
+});

--- a/packages/lcyt-web/test/i18n.test.js
+++ b/packages/lcyt-web/test/i18n.test.js
@@ -1,0 +1,95 @@
+/**
+ * Tests for translate() and getMessages() from src/lib/i18n.js
+ *
+ * getStoredLang() and storeLang() use localStorage/navigator — browser-only,
+ * not tested here.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { translate, getMessages } from '../src/lib/i18n.js';
+
+// ---------------------------------------------------------------------------
+// getMessages()
+// ---------------------------------------------------------------------------
+
+describe('getMessages()', () => {
+  it('returns an object for "en"', () => {
+    const msgs = getMessages('en');
+    assert.ok(msgs && typeof msgs === 'object');
+  });
+
+  it('returns an object for "fi"', () => {
+    const msgs = getMessages('fi');
+    assert.ok(msgs && typeof msgs === 'object');
+  });
+
+  it('returns an object for "sv"', () => {
+    const msgs = getMessages('sv');
+    assert.ok(msgs && typeof msgs === 'object');
+  });
+
+  it('falls back to English for unknown locale', () => {
+    const en = getMessages('en');
+    const unknown = getMessages('zz');
+    // Should get the same object as English
+    assert.deepEqual(unknown, en);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// translate()
+// ---------------------------------------------------------------------------
+
+describe('translate()', () => {
+  const msgs = getMessages('en');
+
+  it('returns a top-level string value', () => {
+    // settings is a nested object; try a known top-level direct string if any
+    // Use a nested key known to exist in en.js
+    const result = translate(msgs, 'settings.title');
+    assert.equal(typeof result, 'string');
+    assert.ok(result.length > 0);
+    assert.notEqual(result, 'settings.title'); // should not return the key
+  });
+
+  it('returns a nested dot-path value', () => {
+    const result = translate(msgs, 'settings.connection.backendUrl');
+    assert.equal(typeof result, 'string');
+    assert.ok(result.length > 0);
+  });
+
+  it('returns the key as fallback when path does not exist', () => {
+    const result = translate(msgs, 'nonexistent.deeply.nested.key');
+    assert.equal(result, 'nonexistent.deeply.nested.key');
+  });
+
+  it('returns the key when value is an object (not a leaf string)', () => {
+    // 'settings' is an object, not a string
+    const result = translate(msgs, 'settings');
+    assert.equal(result, 'settings');
+  });
+
+  it('returns the key when messages is null', () => {
+    const result = translate(null, 'settings.title');
+    assert.equal(result, 'settings.title');
+  });
+
+  it('returns the key for empty messages object', () => {
+    const result = translate({}, 'settings.title');
+    assert.equal(result, 'settings.title');
+  });
+
+  it('handles single-segment keys', () => {
+    // Any direct string key at top level
+    const customMsgs = { greeting: 'Hello' };
+    const result = translate(customMsgs, 'greeting');
+    assert.equal(result, 'Hello');
+  });
+
+  it('handles deep nesting', () => {
+    const customMsgs = { a: { b: { c: 'deep value' } } };
+    const result = translate(customMsgs, 'a.b.c');
+    assert.equal(result, 'deep value');
+  });
+});

--- a/packages/lcyt-web/test/setup.vitest.js
+++ b/packages/lcyt-web/test/setup.vitest.js
@@ -1,0 +1,24 @@
+import '@testing-library/jest-dom';
+import { vi, beforeEach } from 'vitest';
+
+beforeEach(() => {
+  localStorage.clear();
+  sessionStorage.clear();
+});
+
+// Stub EventSource — jsdom does not implement it
+global.EventSource = vi.fn(function () {
+  this.addEventListener = vi.fn();
+  this.removeEventListener = vi.fn();
+  this.close = vi.fn();
+  this.readyState = 1;
+});
+
+// Stub BroadcastChannel — jsdom does not implement it
+global.BroadcastChannel = class FakeBroadcastChannel {
+  constructor() {
+    this.onmessage = null;
+    this.postMessage = vi.fn();
+    this.close = vi.fn();
+  }
+};

--- a/packages/lcyt-web/vitest.config.js
+++ b/packages/lcyt-web/vitest.config.js
@@ -1,0 +1,11 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import viteConfig from './vite.config.js';
+
+export default mergeConfig(viteConfig, defineConfig({
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./test/setup.vitest.js'],
+    include: ['test/components/**/*.test.{js,jsx}'],
+  },
+}));

--- a/packages/plugins/lcyt-dsk/src/renderer.js
+++ b/packages/plugins/lcyt-dsk/src/renderer.js
@@ -194,6 +194,7 @@ function buildSseBindingsScript(serverUrl, apiKey) {
   connect();
 })();
 </script>`;
+}
 
 function escHtml(s) {
   return String(s)

--- a/python-packages/lcyt/tests/test_backend_sender.py
+++ b/python-packages/lcyt/tests/test_backend_sender.py
@@ -1,0 +1,430 @@
+"""Tests for BackendCaptionSender (backend_sender.py).
+
+HTTP calls are intercepted by monkeypatching urllib.request so no real
+network connections are made.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+import urllib.error
+import urllib.request
+
+import pytest
+
+from lcyt.backend_sender import BackendCaptionSender
+from lcyt.errors import NetworkError
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_sender(**kwargs):
+    defaults = dict(
+        backend_url="http://backend.test",
+        api_key="test-api-key",
+        stream_key="stream-key-123",
+        domain="https://example.com",
+    )
+    defaults.update(kwargs)
+    return BackendCaptionSender(**defaults)
+
+
+def _make_urlopen_response(data: dict):
+    """Return a context-manager mock that yields a response with `data`."""
+    body = json.dumps(data).encode()
+    resp = MagicMock()
+    resp.read.return_value = body
+    ctx = MagicMock()
+    ctx.__enter__ = MagicMock(return_value=resp)
+    ctx.__exit__ = MagicMock(return_value=False)
+    return ctx
+
+
+def _make_http_error(code: int, body: dict | None = None):
+    body_bytes = json.dumps(body or {}).encode() if body else b""
+    err = urllib.error.HTTPError(
+        url="http://backend.test/live",
+        code=code,
+        msg=f"HTTP {code}",
+        hdrs=None,
+        fp=MagicMock(read=MagicMock(return_value=body_bytes)),
+    )
+    return err
+
+
+# ---------------------------------------------------------------------------
+# Constructor
+# ---------------------------------------------------------------------------
+
+class TestConstructor:
+    def test_strips_trailing_slash(self):
+        s = _make_sender(backend_url="http://backend.test/")
+        assert s._backend_url == "http://backend.test"
+
+    def test_defaults(self):
+        s = _make_sender()
+        assert s._token is None
+        assert s._is_started is False
+        assert s._sequence == 0
+        assert s._sync_offset == 0
+        assert s._started_at == 0.0
+        assert s.get_queue() == []
+
+    def test_is_started_property(self):
+        s = _make_sender()
+        assert s.is_started is False
+
+
+# ---------------------------------------------------------------------------
+# start()
+# ---------------------------------------------------------------------------
+
+class TestStart:
+    def test_start_posts_to_live_and_stores_token(self):
+        s = _make_sender()
+        resp_data = {
+            "token": "jwt.token.here",
+            "sequence": 5,
+            "syncOffset": 100,
+            "startedAt": 1700000000.0,
+        }
+        with patch("urllib.request.urlopen", return_value=_make_urlopen_response(resp_data)):
+            s.start()
+
+        assert s._token == "jwt.token.here"
+        assert s._sequence == 5
+        assert s._sync_offset == 100
+        assert s._started_at == 1700000000.0
+        assert s._is_started is True
+
+    def test_start_returns_self(self):
+        s = _make_sender()
+        resp_data = {"token": "t", "sequence": 0, "syncOffset": 0, "startedAt": 0.0}
+        with patch("urllib.request.urlopen", return_value=_make_urlopen_response(resp_data)):
+            result = s.start()
+        assert result is s
+
+    def test_start_raises_network_error_on_http_error(self):
+        s = _make_sender()
+        with patch("urllib.request.urlopen", side_effect=_make_http_error(401)):
+            with pytest.raises(NetworkError):
+                s.start()
+
+    def test_start_raises_network_error_on_connection_failure(self):
+        s = _make_sender()
+        with patch("urllib.request.urlopen", side_effect=OSError("refused")):
+            with pytest.raises(NetworkError):
+                s.start()
+
+
+# ---------------------------------------------------------------------------
+# end()
+# ---------------------------------------------------------------------------
+
+class TestEnd:
+    def _started_sender(self):
+        s = _make_sender()
+        s._token = "jwt"
+        s._is_started = True
+        return s
+
+    def test_end_clears_token(self):
+        s = self._started_sender()
+        with patch("urllib.request.urlopen", return_value=_make_urlopen_response({})):
+            s.end()
+        assert s._token is None
+        assert s._is_started is False
+
+    def test_end_returns_self(self):
+        s = self._started_sender()
+        with patch("urllib.request.urlopen", return_value=_make_urlopen_response({})):
+            result = s.end()
+        assert result is s
+
+    def test_end_raises_network_error_on_failure(self):
+        s = self._started_sender()
+        with patch("urllib.request.urlopen", side_effect=_make_http_error(404)):
+            with pytest.raises(NetworkError):
+                s.end()
+
+
+# ---------------------------------------------------------------------------
+# send()
+# ---------------------------------------------------------------------------
+
+class TestSend:
+    def _started_sender(self):
+        s = _make_sender()
+        s._token = "jwt"
+        s._is_started = True
+        return s
+
+    def test_send_posts_to_captions(self):
+        s = self._started_sender()
+        resp_data = {"ok": True, "requestId": "r1", "sequence": 1}
+        with patch("urllib.request.urlopen", return_value=_make_urlopen_response(resp_data)) as mock_open:
+            result = s.send("Hello!")
+        assert result["ok"] is True
+
+    def test_send_updates_sequence(self):
+        s = self._started_sender()
+        resp_data = {"ok": True, "requestId": "r1", "sequence": 3}
+        with patch("urllib.request.urlopen", return_value=_make_urlopen_response(resp_data)):
+            s.send("test")
+        assert s._sequence == 3
+
+    def test_send_with_timestamp(self):
+        s = self._started_sender()
+        captured = []
+
+        def capture_urlopen(req):
+            captured.append(json.loads(req.data))
+            return _make_urlopen_response({"ok": True, "sequence": 0})
+
+        with patch("urllib.request.urlopen", side_effect=capture_urlopen):
+            s.send("hello", timestamp="2026-01-01T00:00:00.000")
+
+        assert captured[0]["captions"][0]["timestamp"] == "2026-01-01T00:00:00.000"
+
+    def test_send_with_time(self):
+        s = self._started_sender()
+        captured = []
+
+        def capture_urlopen(req):
+            captured.append(json.loads(req.data))
+            return _make_urlopen_response({"ok": True, "sequence": 0})
+
+        with patch("urllib.request.urlopen", side_effect=capture_urlopen):
+            s.send("hello", time=1500)
+
+        assert captured[0]["captions"][0]["time"] == 1500
+
+    def test_send_raises_network_error_on_http_error(self):
+        s = self._started_sender()
+        with patch("urllib.request.urlopen", side_effect=_make_http_error(400)):
+            with pytest.raises(NetworkError):
+                s.send("bad")
+
+
+# ---------------------------------------------------------------------------
+# send_batch()
+# ---------------------------------------------------------------------------
+
+class TestSendBatch:
+    def _started_sender(self):
+        s = _make_sender()
+        s._token = "jwt"
+        s._is_started = True
+        return s
+
+    def test_send_batch_with_list(self):
+        s = self._started_sender()
+        resp_data = {"ok": True, "requestId": "r1", "sequence": 2, "count": 2}
+        with patch("urllib.request.urlopen", return_value=_make_urlopen_response(resp_data)):
+            result = s.send_batch([{"text": "A"}, {"text": "B"}])
+        assert result["count"] == 2
+
+    def test_send_batch_drains_queue(self):
+        s = self._started_sender()
+        s.construct("x")
+        s.construct("y")
+
+        captured = []
+
+        def capture(req):
+            captured.append(json.loads(req.data))
+            return _make_urlopen_response({"ok": True, "sequence": 1})
+
+        with patch("urllib.request.urlopen", side_effect=capture):
+            s.send_batch()
+
+        assert len(captured[0]["captions"]) == 2
+        assert s.get_queue() == []
+
+    def test_send_batch_empty_list_still_posts(self):
+        s = self._started_sender()
+        resp_data = {"ok": True, "sequence": 0}
+        with patch("urllib.request.urlopen", return_value=_make_urlopen_response(resp_data)):
+            # An empty explicit list should still make the HTTP call
+            result = s.send_batch([])
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# construct() / get_queue() / clear_queue()
+# ---------------------------------------------------------------------------
+
+class TestQueue:
+    def test_construct_adds_to_queue(self):
+        s = _make_sender()
+        count = s.construct("hello")
+        assert count == 1
+        assert s.get_queue()[0]["text"] == "hello"
+
+    def test_construct_with_timestamp(self):
+        s = _make_sender()
+        s.construct("ts", timestamp="2026-01-01T00:00:00.000")
+        item = s.get_queue()[0]
+        assert item["timestamp"] == "2026-01-01T00:00:00.000"
+
+    def test_construct_with_time(self):
+        s = _make_sender()
+        s.construct("t", time=500)
+        item = s.get_queue()[0]
+        assert item["time"] == 500
+
+    def test_get_queue_returns_copy(self):
+        s = _make_sender()
+        s.construct("a")
+        q = s.get_queue()
+        q.clear()
+        assert len(s.get_queue()) == 1
+
+    def test_clear_queue(self):
+        s = _make_sender()
+        s.construct("a")
+        s.construct("b")
+        count = s.clear_queue()
+        assert count == 2
+        assert s.get_queue() == []
+
+
+# ---------------------------------------------------------------------------
+# sync()
+# ---------------------------------------------------------------------------
+
+class TestSync:
+    def _started_sender(self):
+        s = _make_sender()
+        s._token = "jwt"
+        s._is_started = True
+        return s
+
+    def test_sync_posts_to_sync_endpoint(self):
+        s = self._started_sender()
+        resp_data = {"syncOffset": 50, "roundTripTime": 20, "serverTimestamp": "2026-01-01T00:00:00.000"}
+        with patch("urllib.request.urlopen", return_value=_make_urlopen_response(resp_data)):
+            result = s.sync()
+        assert result["syncOffset"] == 50
+        assert s._sync_offset == 50
+
+    def test_sync_raises_network_error_on_failure(self):
+        s = self._started_sender()
+        with patch("urllib.request.urlopen", side_effect=_make_http_error(500)):
+            with pytest.raises(NetworkError):
+                s.sync()
+
+
+# ---------------------------------------------------------------------------
+# heartbeat()
+# ---------------------------------------------------------------------------
+
+class TestHeartbeat:
+    def _started_sender(self):
+        s = _make_sender()
+        s._token = "jwt"
+        s._is_started = True
+        return s
+
+    def test_heartbeat_gets_live_endpoint(self):
+        s = self._started_sender()
+        resp_data = {"sequence": 3, "syncOffset": 10}
+        with patch("urllib.request.urlopen", return_value=_make_urlopen_response(resp_data)):
+            result = s.heartbeat()
+        assert result["sequence"] == 3
+        assert s._sequence == 3
+        assert s._sync_offset == 10
+
+    def test_heartbeat_raises_network_error_on_failure(self):
+        s = self._started_sender()
+        with patch("urllib.request.urlopen", side_effect=_make_http_error(401)):
+            with pytest.raises(NetworkError):
+                s.heartbeat()
+
+
+# ---------------------------------------------------------------------------
+# get/set sequence and sync offset
+# ---------------------------------------------------------------------------
+
+class TestGettersSetters:
+    def test_get_set_sequence(self):
+        s = _make_sender()
+        s.set_sequence(99)
+        assert s.get_sequence() == 99
+
+    def test_set_sequence_returns_self(self):
+        s = _make_sender()
+        assert s.set_sequence(1) is s
+
+    def test_get_set_sync_offset(self):
+        s = _make_sender()
+        s.set_sync_offset(250)
+        assert s.get_sync_offset() == 250
+
+    def test_set_sync_offset_returns_self(self):
+        s = _make_sender()
+        assert s.set_sync_offset(0) is s
+
+    def test_get_started_at(self):
+        s = _make_sender()
+        s._started_at = 1700000000.0
+        assert s.get_started_at() == 1700000000.0
+
+
+# ---------------------------------------------------------------------------
+# _fetch() — HTTP error body parsing
+# ---------------------------------------------------------------------------
+
+class TestFetch:
+    def test_network_error_includes_status_code(self):
+        s = _make_sender()
+        err = _make_http_error(403, {"error": "Forbidden"})
+        with patch("urllib.request.urlopen", side_effect=err):
+            with pytest.raises(NetworkError) as exc_info:
+                s._fetch("/live")
+        assert exc_info.value.status_code == 403
+
+    def test_network_error_message_from_body(self):
+        s = _make_sender()
+        err = _make_http_error(401, {"error": "Invalid key"})
+        with patch("urllib.request.urlopen", side_effect=err):
+            with pytest.raises(NetworkError) as exc_info:
+                s._fetch("/live")
+        assert "Invalid key" in str(exc_info.value)
+
+    def test_generic_exception_wrapped_in_network_error(self):
+        s = _make_sender()
+        with patch("urllib.request.urlopen", side_effect=OSError("timeout")):
+            with pytest.raises(NetworkError):
+                s._fetch("/live")
+
+    def test_attaches_authorization_header_when_token_set(self):
+        s = _make_sender()
+        s._token = "my-jwt"
+        captured_headers = []
+
+        def capture(req):
+            captured_headers.append(dict(req.headers))
+            return _make_urlopen_response({"ok": True})
+
+        with patch("urllib.request.urlopen", side_effect=capture):
+            s._fetch("/live")
+
+        # Headers are title-cased by urllib
+        assert "Authorization" in captured_headers[0]
+        assert "my-jwt" in captured_headers[0]["Authorization"]
+
+    def test_no_auth_header_when_auth_false(self):
+        s = _make_sender()
+        s._token = "my-jwt"
+        captured_headers = []
+
+        def capture(req):
+            captured_headers.append(dict(req.headers))
+            return _make_urlopen_response({"token": "t", "sequence": 0, "syncOffset": 0, "startedAt": 0.0})
+
+        with patch("urllib.request.urlopen", side_effect=capture):
+            s._fetch("/live", method="POST", body={}, auth=False)
+
+        assert "Authorization" not in captured_headers[0]

--- a/python-packages/lcyt/tests/test_config.py
+++ b/python-packages/lcyt/tests/test_config.py
@@ -1,0 +1,188 @@
+"""Tests for lcyt configuration utilities (config.py)."""
+
+import json
+import pytest
+from pathlib import Path
+
+from lcyt.config import (
+    LCYTConfig,
+    DEFAULT_BASE_URL,
+    load_config,
+    save_config,
+    build_ingestion_url,
+    get_default_config_path,
+)
+from lcyt.errors import ConfigError
+
+
+# ---------------------------------------------------------------------------
+# LCYTConfig dataclass
+# ---------------------------------------------------------------------------
+
+class TestLCYTConfig:
+    def test_defaults(self):
+        cfg = LCYTConfig()
+        assert cfg.stream_key == ""
+        assert cfg.base_url == DEFAULT_BASE_URL
+        assert cfg.region == "reg1"
+        assert cfg.cue == "cue1"
+        assert cfg.sequence == 0
+
+    def test_custom_values(self):
+        cfg = LCYTConfig(stream_key="MY_KEY", base_url="http://custom.test", sequence=5)
+        assert cfg.stream_key == "MY_KEY"
+        assert cfg.base_url == "http://custom.test"
+        assert cfg.sequence == 5
+
+    def test_to_dict_round_trips(self):
+        cfg = LCYTConfig(stream_key="abc", region="reg2", cue="cue3", sequence=7)
+        d = cfg.to_dict()
+        assert d["stream_key"] == "abc"
+        assert d["region"] == "reg2"
+        assert d["cue"] == "cue3"
+        assert d["sequence"] == 7
+
+    def test_from_dict_snake_case(self):
+        cfg = LCYTConfig.from_dict({"stream_key": "k1", "base_url": "http://x.test", "sequence": 3})
+        assert cfg.stream_key == "k1"
+        assert cfg.base_url == "http://x.test"
+        assert cfg.sequence == 3
+
+    def test_from_dict_camel_case(self):
+        # JS config interop: camelCase keys should also work
+        cfg = LCYTConfig.from_dict({"streamKey": "k2", "baseUrl": "http://y.test"})
+        assert cfg.stream_key == "k2"
+        assert cfg.base_url == "http://y.test"
+
+    def test_from_dict_missing_keys_use_defaults(self):
+        cfg = LCYTConfig.from_dict({})
+        assert cfg.stream_key == ""
+        assert cfg.base_url == DEFAULT_BASE_URL
+        assert cfg.region == "reg1"
+
+    def test_from_dict_snake_takes_priority_over_camel(self):
+        # When both forms are present, snake_case wins
+        cfg = LCYTConfig.from_dict({"stream_key": "snake", "streamKey": "camel"})
+        assert cfg.stream_key == "snake"
+
+
+# ---------------------------------------------------------------------------
+# get_default_config_path
+# ---------------------------------------------------------------------------
+
+class TestGetDefaultConfigPath:
+    def test_returns_path_in_home(self):
+        path = get_default_config_path()
+        assert isinstance(path, Path)
+        assert path.name == ".lcyt-config.json"
+        assert path.parent == Path.home()
+
+
+# ---------------------------------------------------------------------------
+# build_ingestion_url
+# ---------------------------------------------------------------------------
+
+class TestBuildIngestionUrl:
+    def test_builds_url_with_stream_key(self):
+        cfg = LCYTConfig(stream_key="MY_KEY")
+        url = build_ingestion_url(cfg)
+        assert "MY_KEY" in url
+        assert url.startswith("http")
+
+    def test_uses_default_base_url(self):
+        cfg = LCYTConfig(stream_key="K")
+        url = build_ingestion_url(cfg)
+        assert url.startswith(DEFAULT_BASE_URL)
+        assert "cid=K" in url
+
+    def test_uses_custom_base_url(self):
+        cfg = LCYTConfig(stream_key="K", base_url="http://custom.test/cc")
+        url = build_ingestion_url(cfg)
+        assert url.startswith("http://custom.test/cc")
+        assert "cid=K" in url
+
+    def test_raises_config_error_when_no_stream_key(self):
+        cfg = LCYTConfig(stream_key="")
+        with pytest.raises(ConfigError):
+            build_ingestion_url(cfg)
+
+
+# ---------------------------------------------------------------------------
+# load_config
+# ---------------------------------------------------------------------------
+
+class TestLoadConfig:
+    def test_returns_default_config_when_file_does_not_exist(self, tmp_path):
+        path = tmp_path / "nonexistent.json"
+        cfg = load_config(path)
+        assert isinstance(cfg, LCYTConfig)
+        assert cfg.stream_key == ""
+
+    def test_loads_config_from_file(self, tmp_path):
+        path = tmp_path / "config.json"
+        path.write_text(json.dumps({"stream_key": "LOADED_KEY", "sequence": 10}))
+        cfg = load_config(path)
+        assert cfg.stream_key == "LOADED_KEY"
+        assert cfg.sequence == 10
+
+    def test_raises_config_error_for_invalid_json(self, tmp_path):
+        path = tmp_path / "bad.json"
+        path.write_text("not valid json {{{")
+        with pytest.raises(ConfigError, match="Invalid JSON"):
+            load_config(path)
+
+    def test_accepts_string_path(self, tmp_path):
+        path = tmp_path / "cfg.json"
+        path.write_text(json.dumps({"stream_key": "STRING_PATH_KEY"}))
+        cfg = load_config(str(path))
+        assert cfg.stream_key == "STRING_PATH_KEY"
+
+    def test_uses_default_path_when_none_given(self, tmp_path, monkeypatch):
+        # Point home() to tmp_path so we don't touch the real ~/.lcyt-config.json
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        # File doesn't exist — should return defaults
+        cfg = load_config(None)
+        assert isinstance(cfg, LCYTConfig)
+
+    def test_loads_camelcase_keys_from_file(self, tmp_path):
+        path = tmp_path / "js-config.json"
+        path.write_text(json.dumps({"streamKey": "JS_KEY", "baseUrl": "http://js.test"}))
+        cfg = load_config(path)
+        assert cfg.stream_key == "JS_KEY"
+        assert cfg.base_url == "http://js.test"
+
+
+# ---------------------------------------------------------------------------
+# save_config
+# ---------------------------------------------------------------------------
+
+class TestSaveConfig:
+    def test_saves_config_to_file(self, tmp_path):
+        path = tmp_path / "out.json"
+        cfg = LCYTConfig(stream_key="SAVED_KEY", sequence=3)
+        save_config(cfg, path)
+
+        assert path.exists()
+        data = json.loads(path.read_text())
+        assert data["stream_key"] == "SAVED_KEY"
+        assert data["sequence"] == 3
+
+    def test_saved_file_is_loadable(self, tmp_path):
+        path = tmp_path / "roundtrip.json"
+        original = LCYTConfig(stream_key="RT_KEY", region="reg2", sequence=99)
+        save_config(original, path)
+        loaded = load_config(path)
+        assert loaded.stream_key == original.stream_key
+        assert loaded.region == original.region
+        assert loaded.sequence == original.sequence
+
+    def test_accepts_string_path(self, tmp_path):
+        path = str(tmp_path / "str.json")
+        save_config(LCYTConfig(stream_key="STR_KEY"), path)
+        assert Path(path).exists()
+
+    def test_raises_config_error_for_unwritable_path(self, tmp_path):
+        path = tmp_path / "nodir" / "config.json"
+        # Parent directory does not exist → OSError
+        with pytest.raises(ConfigError, match="Cannot write"):
+            save_config(LCYTConfig(), path)

--- a/python-packages/lcyt/tests/test_errors.py
+++ b/python-packages/lcyt/tests/test_errors.py
@@ -1,0 +1,74 @@
+"""Tests for lcyt error hierarchy (errors.py)."""
+
+import pytest
+
+from lcyt.errors import LCYTError, ConfigError, NetworkError, ValidationError
+
+
+class TestErrorHierarchy:
+    def test_lcyt_error_is_exception(self):
+        err = LCYTError("base error")
+        assert isinstance(err, Exception)
+        assert str(err) == "base error"
+
+    def test_config_error_inherits_lcyt_error(self):
+        err = ConfigError("bad config")
+        assert isinstance(err, LCYTError)
+        assert isinstance(err, Exception)
+        assert str(err) == "bad config"
+
+    def test_network_error_inherits_lcyt_error(self):
+        err = NetworkError("connection failed")
+        assert isinstance(err, LCYTError)
+
+    def test_validation_error_inherits_lcyt_error(self):
+        err = ValidationError("invalid input")
+        assert isinstance(err, LCYTError)
+
+
+class TestNetworkError:
+    def test_default_status_code_is_none(self):
+        err = NetworkError("oops")
+        assert err.status_code is None
+
+    def test_status_code_stored(self):
+        err = NetworkError("Not Found", 404)
+        assert err.status_code == 404
+        assert str(err) == "Not Found"
+
+    def test_status_code_400(self):
+        err = NetworkError("Bad Request", 400)
+        assert err.status_code == 400
+
+    def test_status_code_500(self):
+        err = NetworkError("Server Error", 500)
+        assert err.status_code == 500
+
+
+class TestValidationError:
+    def test_default_field_is_none(self):
+        err = ValidationError("required")
+        assert err.field is None
+
+    def test_field_stored(self):
+        err = ValidationError("Stream key is required", field="stream_key")
+        assert err.field == "stream_key"
+        assert str(err) == "Stream key is required"
+
+    def test_field_text(self):
+        err = ValidationError("Cannot be empty", field="text")
+        assert err.field == "text"
+
+
+class TestCatchingByBase:
+    def test_catch_config_error_as_lcyt_error(self):
+        with pytest.raises(LCYTError):
+            raise ConfigError("catch me")
+
+    def test_catch_network_error_as_lcyt_error(self):
+        with pytest.raises(LCYTError):
+            raise NetworkError("network fail", 503)
+
+    def test_catch_validation_error_as_lcyt_error(self):
+        with pytest.raises(LCYTError):
+            raise ValidationError("bad field", field="x")

--- a/python-packages/lcyt/tests/test_sender.py
+++ b/python-packages/lcyt/tests/test_sender.py
@@ -1,0 +1,502 @@
+"""Tests for YoutubeLiveCaptionSender (sender.py).
+
+HTTP calls are intercepted by monkeypatching http.client so no real
+network connections are made.
+"""
+
+import http.client
+import time
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lcyt.sender import YoutubeLiveCaptionSender, Caption, SendResult
+from lcyt.errors import NetworkError, ValidationError
+from lcyt.config import DEFAULT_BASE_URL
+
+
+# ---------------------------------------------------------------------------
+# Helpers — mock HTTP response
+# ---------------------------------------------------------------------------
+
+def make_mock_response(status=200, body="2026-01-01T12:00:00.000"):
+    resp = MagicMock()
+    resp.status = status
+    resp.read.return_value = body.encode("utf-8")
+    return resp
+
+
+def make_mock_conn(response):
+    """Return a mock HTTPConnection that returns `response` from getresponse()."""
+    conn = MagicMock()
+    conn.getresponse.return_value = response
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# Constructor
+# ---------------------------------------------------------------------------
+
+class TestConstructor:
+    def test_defaults(self):
+        s = YoutubeLiveCaptionSender()
+        assert s._stream_key is None
+        assert s._base_url == DEFAULT_BASE_URL
+        assert s._sequence == 0
+        assert s._sync_offset == 0
+        assert not s._use_sync_offset
+        assert not s._started
+        assert s.is_started is False
+
+    def test_custom_params(self):
+        s = YoutubeLiveCaptionSender(
+            stream_key="K",
+            region="reg2",
+            cue="cue3",
+            sequence=5,
+            use_sync_offset=True,
+        )
+        assert s._stream_key == "K"
+        assert s._region == "reg2"
+        assert s._cue == "cue3"
+        assert s._sequence == 5
+        assert s._use_sync_offset is True
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle — start() / end()
+# ---------------------------------------------------------------------------
+
+class TestLifecycle:
+    def test_start_with_stream_key(self):
+        s = YoutubeLiveCaptionSender(stream_key="MY_KEY")
+        s.start()
+        assert s._started is True
+        assert "MY_KEY" in s._url
+
+    def test_start_with_explicit_ingestion_url(self):
+        s = YoutubeLiveCaptionSender(ingestion_url="http://custom.test/cc?cid=X")
+        s.start()
+        assert s._url == "http://custom.test/cc?cid=X"
+
+    def test_start_raises_when_no_key_or_url(self):
+        s = YoutubeLiveCaptionSender()
+        with pytest.raises(ValidationError) as exc_info:
+            s.start()
+        assert exc_info.value.field == "stream_key"
+
+    def test_start_returns_self(self):
+        s = YoutubeLiveCaptionSender(stream_key="K")
+        assert s.start() is s
+
+    def test_end_marks_not_started(self):
+        s = YoutubeLiveCaptionSender(stream_key="K")
+        s.start()
+        s.end()
+        assert s._started is False
+
+    def test_end_returns_self(self):
+        s = YoutubeLiveCaptionSender(stream_key="K")
+        s.start()
+        assert s.end() is s
+
+    def test_end_clears_queue(self):
+        s = YoutubeLiveCaptionSender(stream_key="K")
+        s.start()
+        s.construct("hello")
+        s.end()
+        assert s.get_queue() == []
+
+
+# ---------------------------------------------------------------------------
+# send() — validation
+# ---------------------------------------------------------------------------
+
+class TestSendValidation:
+    def test_send_raises_if_not_started(self):
+        s = YoutubeLiveCaptionSender(stream_key="K")
+        with pytest.raises(ValidationError):
+            s.send("hello")
+
+    def test_send_raises_for_empty_text(self):
+        s = YoutubeLiveCaptionSender(stream_key="K")
+        s.start()
+        with pytest.raises(ValidationError) as exc_info:
+            s.send("")
+        assert exc_info.value.field == "text"
+
+
+# ---------------------------------------------------------------------------
+# send() — HTTP dispatch
+# ---------------------------------------------------------------------------
+
+class TestSendHttp:
+    def _make_sender(self):
+        s = YoutubeLiveCaptionSender(stream_key="TEST_KEY")
+        s.start()
+        return s
+
+    def test_send_calls_post_and_returns_send_result(self):
+        s = self._make_sender()
+        mock_resp = make_mock_response(200)
+        mock_conn = make_mock_conn(mock_resp)
+
+        with patch("http.client.HTTPConnection", return_value=mock_conn):
+            result = s.send("Hello, world!")
+
+        assert isinstance(result, SendResult)
+        assert result.status_code == 200
+        mock_conn.request.assert_called_once()
+
+    def test_send_increments_sequence_on_success(self):
+        s = self._make_sender()
+        mock_resp = make_mock_response(200)
+        mock_conn = make_mock_conn(mock_resp)
+
+        with patch("http.client.HTTPConnection", return_value=mock_conn):
+            s.send("A")
+            s.send("B")
+
+        assert s._sequence == 2
+
+    def test_send_does_not_increment_sequence_on_error_status(self):
+        s = self._make_sender()
+        mock_resp = make_mock_response(400, "")
+        mock_conn = make_mock_conn(mock_resp)
+
+        with patch("http.client.HTTPConnection", return_value=mock_conn):
+            result = s.send("oops")
+
+        assert result.status_code == 400
+        assert s._sequence == 0
+
+    def test_send_raises_network_error_on_exception(self):
+        s = self._make_sender()
+        mock_conn = MagicMock()
+        mock_conn.request.side_effect = OSError("connection refused")
+
+        with patch("http.client.HTTPConnection", return_value=mock_conn):
+            with pytest.raises(NetworkError):
+                s.send("fail")
+
+    def test_send_passes_seq_in_url(self):
+        s = self._make_sender()
+        s._sequence = 7
+        captured_path = []
+
+        mock_resp = make_mock_response(200)
+        mock_conn = make_mock_conn(mock_resp)
+        original_request = mock_conn.request
+
+        def capture_request(method, path, *a, **kw):
+            captured_path.append(path)
+
+        mock_conn.request.side_effect = capture_request
+
+        with patch("http.client.HTTPConnection", return_value=mock_conn):
+            try:
+                s.send("seq test")
+            except Exception:
+                pass  # getresponse won't be called, that's fine
+
+        if captured_path:
+            assert "seq=7" in captured_path[0]
+
+    def test_send_returns_server_timestamp(self):
+        s = self._make_sender()
+        ts = "2026-03-15T10:00:00.000"
+        mock_resp = make_mock_response(200, ts)
+        mock_conn = make_mock_conn(mock_resp)
+
+        with patch("http.client.HTTPConnection", return_value=mock_conn):
+            result = s.send("with ts")
+
+        assert result.server_timestamp == ts
+
+
+# ---------------------------------------------------------------------------
+# construct() / get_queue() / clear_queue()
+# ---------------------------------------------------------------------------
+
+class TestQueue:
+    def _started_sender(self):
+        s = YoutubeLiveCaptionSender(stream_key="K")
+        s.start()
+        return s
+
+    def test_construct_raises_if_not_started(self):
+        s = YoutubeLiveCaptionSender(stream_key="K")
+        with pytest.raises(ValidationError):
+            s.construct("hello")
+
+    def test_construct_raises_for_empty_text(self):
+        s = self._started_sender()
+        with pytest.raises(ValidationError) as exc_info:
+            s.construct("")
+        assert exc_info.value.field == "text"
+
+    def test_construct_raises_for_non_string(self):
+        s = self._started_sender()
+        with pytest.raises(ValidationError):
+            s.construct(42)
+
+    def test_construct_returns_queue_length(self):
+        s = self._started_sender()
+        assert s.construct("first") == 1
+        assert s.construct("second") == 2
+
+    def test_get_queue_returns_copy(self):
+        s = self._started_sender()
+        s.construct("a")
+        q = s.get_queue()
+        assert len(q) == 1
+        q.clear()  # should not affect internal queue
+        assert len(s.get_queue()) == 1
+
+    def test_clear_queue_returns_count(self):
+        s = self._started_sender()
+        s.construct("x")
+        s.construct("y")
+        count = s.clear_queue()
+        assert count == 2
+        assert s.get_queue() == []
+
+
+# ---------------------------------------------------------------------------
+# send_batch()
+# ---------------------------------------------------------------------------
+
+class TestSendBatch:
+    def _started_sender(self):
+        s = YoutubeLiveCaptionSender(stream_key="K")
+        s.start()
+        return s
+
+    def test_send_batch_raises_if_not_started(self):
+        s = YoutubeLiveCaptionSender(stream_key="K")
+        with pytest.raises(ValidationError):
+            s.send_batch([Caption(text="x")])
+
+    def test_send_batch_raises_with_empty_list(self):
+        s = self._started_sender()
+        with pytest.raises(ValidationError):
+            s.send_batch([])
+
+    def test_send_batch_raises_when_queue_empty_and_no_arg(self):
+        s = self._started_sender()
+        with pytest.raises(ValidationError):
+            s.send_batch()
+
+    def test_send_batch_sends_given_captions(self):
+        s = self._started_sender()
+        mock_resp = make_mock_response(200)
+        mock_conn = make_mock_conn(mock_resp)
+
+        with patch("http.client.HTTPConnection", return_value=mock_conn):
+            result = s.send_batch([Caption("A"), Caption("B")])
+
+        assert result.count == 2
+        assert result.status_code == 200
+
+    def test_send_batch_drains_queue_when_no_arg(self):
+        s = self._started_sender()
+        s.construct("queue-item-1")
+        s.construct("queue-item-2")
+
+        mock_resp = make_mock_response(200)
+        mock_conn = make_mock_conn(mock_resp)
+
+        with patch("http.client.HTTPConnection", return_value=mock_conn):
+            result = s.send_batch()
+
+        assert result.count == 2
+        assert s.get_queue() == []
+
+    def test_send_batch_increments_sequence_on_success(self):
+        s = self._started_sender()
+        mock_resp = make_mock_response(200)
+        mock_conn = make_mock_conn(mock_resp)
+
+        with patch("http.client.HTTPConnection", return_value=mock_conn):
+            s.send_batch([Caption("x")])
+
+        assert s._sequence == 1
+
+
+# ---------------------------------------------------------------------------
+# heartbeat()
+# ---------------------------------------------------------------------------
+
+class TestHeartbeat:
+    def test_heartbeat_does_not_increment_sequence(self):
+        s = YoutubeLiveCaptionSender(stream_key="K")
+        s.start()
+        s._sequence = 3
+
+        mock_resp = make_mock_response(200, "")
+        mock_conn = make_mock_conn(mock_resp)
+
+        with patch("http.client.HTTPConnection", return_value=mock_conn):
+            s.heartbeat()
+
+        assert s._sequence == 3
+
+    def test_heartbeat_raises_if_not_started(self):
+        s = YoutubeLiveCaptionSender(stream_key="K")
+        with pytest.raises(ValidationError):
+            s.heartbeat()
+
+    def test_heartbeat_returns_send_result(self):
+        s = YoutubeLiveCaptionSender(stream_key="K")
+        s.start()
+        mock_resp = make_mock_response(200, "2026-01-01T00:00:00.000")
+        mock_conn = make_mock_conn(mock_resp)
+
+        with patch("http.client.HTTPConnection", return_value=mock_conn):
+            result = s.heartbeat()
+
+        assert isinstance(result, SendResult)
+        assert result.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# sync()
+# ---------------------------------------------------------------------------
+
+class TestSync:
+    def test_sync_raises_if_not_started(self):
+        s = YoutubeLiveCaptionSender(stream_key="K")
+        with pytest.raises(ValidationError):
+            s.sync()
+
+    def test_sync_updates_sync_offset_and_enables_it(self):
+        s = YoutubeLiveCaptionSender(stream_key="K")
+        s.start()
+
+        server_ts = "2026-01-01T12:00:00.000"
+        mock_resp = make_mock_response(200, server_ts)
+        mock_conn = make_mock_conn(mock_resp)
+
+        with patch("http.client.HTTPConnection", return_value=mock_conn):
+            result = s.sync()
+
+        assert isinstance(result["sync_offset"], int)
+        assert isinstance(result["round_trip_time"], int)
+        assert result["server_timestamp"] == server_ts
+        assert s._use_sync_offset is True
+
+    def test_sync_returns_none_server_timestamp_when_body_empty(self):
+        s = YoutubeLiveCaptionSender(stream_key="K")
+        s.start()
+
+        mock_resp = make_mock_response(200, "")
+        mock_conn = make_mock_conn(mock_resp)
+
+        with patch("http.client.HTTPConnection", return_value=mock_conn):
+            result = s.sync()
+
+        assert result["server_timestamp"] is None
+        # sync_offset should not change if there's no server timestamp
+        assert s._sync_offset == 0
+
+
+# ---------------------------------------------------------------------------
+# Sequence management
+# ---------------------------------------------------------------------------
+
+class TestSequence:
+    def test_get_sequence(self):
+        s = YoutubeLiveCaptionSender(sequence=42)
+        assert s.get_sequence() == 42
+
+    def test_set_sequence_returns_self(self):
+        s = YoutubeLiveCaptionSender()
+        assert s.set_sequence(10) is s
+        assert s._sequence == 10
+
+
+# ---------------------------------------------------------------------------
+# Sync offset management
+# ---------------------------------------------------------------------------
+
+class TestSyncOffset:
+    def test_get_sync_offset_default(self):
+        s = YoutubeLiveCaptionSender()
+        assert s.get_sync_offset() == 0
+
+    def test_set_sync_offset_returns_self(self):
+        s = YoutubeLiveCaptionSender()
+        assert s.set_sync_offset(500) is s
+        assert s._sync_offset == 500
+
+
+# ---------------------------------------------------------------------------
+# _format_timestamp()
+# ---------------------------------------------------------------------------
+
+class TestFormatTimestamp:
+    def _sender(self):
+        return YoutubeLiveCaptionSender(stream_key="K")
+
+    def test_datetime_object(self):
+        s = self._sender()
+        dt = datetime(2026, 3, 15, 10, 30, 0, 123000, tzinfo=timezone.utc)
+        ts = s._format_timestamp(dt)
+        assert ts.startswith("2026-03-15T10:30:00")
+        assert not ts.endswith("Z")
+        assert "+" not in ts
+
+    def test_iso_string_strips_trailing_z(self):
+        s = self._sender()
+        ts = s._format_timestamp("2026-01-01T00:00:00.000Z")
+        assert not ts.endswith("Z")
+        assert ts == "2026-01-01T00:00:00.000"
+
+    def test_iso_string_strips_plus_offset(self):
+        s = self._sender()
+        ts = s._format_timestamp("2026-01-01T12:00:00.000+00:00")
+        assert "+" not in ts
+        assert ts == "2026-01-01T12:00:00.000"
+
+    def test_iso_string_truncates_microseconds(self):
+        s = self._sender()
+        ts = s._format_timestamp("2026-01-01T00:00:00.123456")
+        assert ts == "2026-01-01T00:00:00.123"
+
+    def test_large_int_treated_as_epoch_seconds(self):
+        # Values >= 1000 are Unix epoch seconds
+        s = self._sender()
+        epoch_s = 1_700_000_000  # some time in 2023
+        ts = s._format_timestamp(epoch_s)
+        assert ts.startswith("20")  # year should be 20xx
+        assert "T" in ts
+
+    def test_small_float_treated_as_relative_offset(self):
+        # Values < 1000 are relative seconds from now
+        s = self._sender()
+        ts = s._format_timestamp(0.0)
+        assert ts.startswith("20")
+        assert "T" in ts
+
+    def test_negative_value_treated_as_relative_offset(self):
+        s = self._sender()
+        ts = s._format_timestamp(-2.0)  # 2 seconds ago
+        assert ts.startswith("20")
+
+
+# ---------------------------------------------------------------------------
+# _build_caption_body()
+# ---------------------------------------------------------------------------
+
+class TestBuildCaptionBody:
+    def test_without_region(self):
+        s = YoutubeLiveCaptionSender(stream_key="K", use_region=False)
+        body = s._build_caption_body("2026-01-01T00:00:00.000", "Hello")
+        assert body == "2026-01-01T00:00:00.000\nHello"
+
+    def test_with_region(self):
+        s = YoutubeLiveCaptionSender(stream_key="K", use_region=True, region="reg1", cue="cue1")
+        body = s._build_caption_body("2026-01-01T00:00:00.000", "Hello")
+        assert "region:reg1#cue1" in body
+        assert body.endswith("Hello")


### PR DESCRIPTION
Fills the three highest-priority gaps identified in the test coverage analysis:

• packages/lcyt-bridge/test/tcp-pool.test.js — 13 tests for TcpPool: status(),
  destroy() idempotency, ensure() idempotency, send() before/after connect,
  reconnectAll(), and connected/disconnected/error event forwarding.

• packages/lcyt-bridge/test/bridge.test.js — 22 tests for Bridge: constructor,
  destroy() safety, SSE lifecycle (connected/disconnected/backoff reconnect),
  _handleCommand() tcp_send success and failure, unknown command and non-JSON
  error handling, _postStatus() network failure, startHeartbeat() interval and
  stop-on-destroy, TCP pool event forwarding, reconnectAll().

• packages/lcyt-backend/test/events.test.js — 14 tests for GET /events SSE
  stream: auth (no token, wrong prefix, invalid/expired JWT, ?token= param),
  404 for unknown session, SSE headers, connected event (with/without micHolder),
  caption_result / caption_error / mic_state forwarding, session_closed ending
  the stream, listener cleanup on disconnect, end-to-end POST /captions integration.

• python-packages/lcyt/tests/ — 121 pytest tests for the published PyPI library:
  test_errors.py (error hierarchy, status_code, field attributes),
  test_config.py (LCYTConfig, build_ingestion_url, load/save_config),
  test_sender.py (YoutubeLiveCaptionSender full lifecycle, HTTP dispatch,
  queue ops, heartbeat, sync, _format_timestamp, _build_caption_body),
  test_backend_sender.py (BackendCaptionSender full lifecycle, _fetch error
  handling, auth headers, queue ops, sync, heartbeat).

Also fixes a pre-existing bug in packages/plugins/lcyt-dsk/src/renderer.js
where a missing closing } for buildSseBindingsScript() caused all backend tests
to fail with "SyntaxError: Unexpected token 'export'" due to the unbalanced
brace being misinterpreted by the ESM parser.

https://claude.ai/code/session_01R3kKkyfegqLkpQ46tLHAan