### PR TITLE
Fix caption write timeout, Python error swallowing, EventSource import, and YT poll circuit breaker

### DIFF
--- a/packages/lcyt-backend/src/caption-files.js
+++ b/packages/lcyt-backend/src/caption-files.js
@@ -95,7 +95,12 @@ export function writeToBackendFile(context, text, timestamp, db) {
     } else {
       line = text + '\n';
     }
+    const WRITE_TIMEOUT_MS = 5000;
+    const writeTimer = setTimeout(() => {
+      console.warn('[captions] Backend file write timed out after 5 s:', handle.filepath);
+    }, WRITE_TIMEOUT_MS);
     handle.stream.write(line, () => {
+      clearTimeout(writeTimer);
       try {
         const { size } = statSync(handle.filepath);
         updateCaptionFileSize(db, handle.dbId, size);

--- a/packages/lcyt-bridge/src/bridge.js
+++ b/packages/lcyt-bridge/src/bridge.js
@@ -65,11 +65,19 @@ export class Bridge extends EventEmitter {
   async _connect() {
     if (this._destroyed) return;
 
-    // Dynamic import of eventsource (CommonJS package)
+    // Dynamic import of eventsource — handles both ESM default and CJS shapes
     let EventSource;
     try {
       const mod = await import('eventsource');
-      EventSource = mod.default ?? mod.EventSource;
+      const candidate = mod.default ?? mod;
+      // If the default export is the constructor, use it directly;
+      // otherwise look for a named .EventSource property (CJS re-export).
+      EventSource = typeof candidate === 'function'
+        ? candidate
+        : (candidate.EventSource ?? mod.EventSource);
+      if (typeof EventSource !== 'function') {
+        throw new Error('EventSource constructor not found in module exports');
+      }
     } catch (e) {
       this.emit('error', new Error(`Cannot load eventsource: ${e.message}`));
       return;

--- a/packages/lcyt-bridge/src/tcp-pool.js
+++ b/packages/lcyt-bridge/src/tcp-pool.js
@@ -9,6 +9,7 @@ import { EventEmitter } from 'node:events';
 
 const RECONNECT_DELAY_MS = 5_000;
 const KEEPALIVE_INTERVAL_MS = 30_000;
+const WRITE_TIMEOUT_MS = 10_000;
 
 export class TcpPool extends EventEmitter {
   constructor() {
@@ -46,7 +47,17 @@ export class TcpPool extends EventEmitter {
       throw new Error(`TCP ${key} is not connected`);
     }
     return new Promise((resolve, reject) => {
+      let settled = false;
+      const timer = setTimeout(() => {
+        if (!settled) {
+          settled = true;
+          reject(new Error(`TCP write to ${key} timed out after ${WRITE_TIMEOUT_MS}ms`));
+        }
+      }, WRITE_TIMEOUT_MS);
       entry.socket.write(payload, 'utf8', (err) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
         if (err) return reject(new Error(`TCP write to ${key} failed: ${err.message}`));
         resolve();
       });

--- a/packages/lcyt-cli/src/interactive-ui.js
+++ b/packages/lcyt-cli/src/interactive-ui.js
@@ -36,6 +36,7 @@ export class InteractiveUI {
     this.watchVideoId = null;   // YouTube video ID set via /stream <url-or-id>
     this.youtubeStatus = null;  // null = unknown, 'live', 'upcoming', 'offline'
     this.youtubePoller = null;
+    this._ytPollFailures = 0;   // consecutive failure counter for circuit breaker
 
     // UI widgets
     this.screen = null;
@@ -640,21 +641,37 @@ export class InteractiveUI {
       const response = await fetch(url, { signal: AbortSignal.timeout(8000) });
 
       if (!response.ok) {
+        this._ytPollFailures++;
         this.youtubeStatus = null;
+        this._checkYtPollCircuitBreaker();
         this.updateStatus();
         return;
       }
 
+      this._ytPollFailures = 0; // reset on success
       const data = await response.json();
       const lbc = data.items?.[0]?.snippet?.liveBroadcastContent;
       if (lbc === 'live')     this.youtubeStatus = 'live';
       else if (lbc === 'upcoming') this.youtubeStatus = 'upcoming';
       else                    this.youtubeStatus = 'offline';
     } catch {
+      this._ytPollFailures++;
       this.youtubeStatus = null;
+      this._checkYtPollCircuitBreaker();
     }
 
     this.updateStatus();
+  }
+
+  /**
+   * Stop YouTube status polling after 5 consecutive failures.
+   */
+  _checkYtPollCircuitBreaker() {
+    if (this._ytPollFailures >= 5 && this.youtubePoller) {
+      clearInterval(this.youtubePoller);
+      this.youtubePoller = null;
+      this.addToLog('YouTube status polling stopped after 5 consecutive failures', 'error');
+    }
   }
 
   /**
@@ -669,6 +686,7 @@ export class InteractiveUI {
     }
     if (!this.apiKey || !this.watchVideoId) return;
 
+    this._ytPollFailures = 0; // reset on (re)start
     this._fetchYoutubeStatus();
     this.youtubePoller = setInterval(() => this._fetchYoutubeStatus(), 30000);
   }

--- a/packages/lcyt-web/test/components/DropZone.test.jsx
+++ b/packages/lcyt-web/test/components/DropZone.test.jsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DropZone } from '../../src/components/DropZone.jsx';
+import { FileContext } from '../../src/contexts/FileContext.jsx';
+
+// ---------------------------------------------------------------------------
+// Mock NormalizeLinesModal to simplify — it's a separate component
+// ---------------------------------------------------------------------------
+
+vi.mock('../../src/components/NormalizeLinesModal', () => ({
+  NormalizeLinesModal: ({ fileName, onConfirm, onSkip }) => (
+    <div data-testid="normalize-modal">
+      <span>{fileName}</span>
+      <button onClick={() => onConfirm(['normalized'])}>Confirm</button>
+      <button onClick={onSkip}>Skip</button>
+    </div>
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockFileStore() {
+  return {
+    files: [],
+    activeFile: null,
+    loadFile: vi.fn().mockResolvedValue(undefined),
+    removeFile: vi.fn(),
+    setActive: vi.fn(),
+    cycleActive: vi.fn(),
+    setPointer: vi.fn(),
+    advancePointer: vi.fn(),
+    createEmptyFile: vi.fn(),
+    updateFileFromRawText: vi.fn(),
+    setLastSentLine: vi.fn(),
+  };
+}
+
+function renderDropZone(fileStore, props = {}) {
+  const fs = fileStore || mockFileStore();
+  const result = render(
+    <FileContext.Provider value={fs}>
+      <DropZone {...props} />
+    </FileContext.Provider>
+  );
+  return { ...result, fileStore: fs };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('DropZone', () => {
+  it('renders drop zone with instructions', () => {
+    renderDropZone();
+    expect(screen.getByText(/drop text files here/i)).toBeInTheDocument();
+    expect(screen.getByText(/click to browse/i)).toBeInTheDocument();
+  });
+
+  it('renders hidden file input', () => {
+    renderDropZone();
+    const input = document.querySelector('input[type="file"]');
+    expect(input).not.toBeNull();
+    expect(input.style.display).toBe('none');
+    expect(input.accept).toContain('.txt');
+  });
+
+  it('hides the drop zone when visible=false', () => {
+    renderDropZone(null, { visible: false });
+    expect(screen.queryByText(/drop text files here/i)).not.toBeInTheDocument();
+  });
+
+  it('adds active class on drag over', () => {
+    renderDropZone();
+    const zone = document.querySelector('.drop-zone');
+    fireEvent.dragOver(zone, { preventDefault: vi.fn() });
+    expect(zone.classList.contains('drop-zone--active')).toBe(true);
+  });
+
+  it('removes active class on drag leave', () => {
+    renderDropZone();
+    const zone = document.querySelector('.drop-zone');
+    fireEvent.dragOver(zone, { preventDefault: vi.fn() });
+    fireEvent.dragLeave(zone, { relatedTarget: document.body });
+    expect(zone.classList.contains('drop-zone--active')).toBe(false);
+  });
+
+  it('triggers file input click on zone click', () => {
+    renderDropZone();
+    const input = document.querySelector('input[type="file"]');
+    const clickSpy = vi.spyOn(input, 'click');
+    const zone = document.querySelector('.drop-zone');
+    fireEvent.click(zone);
+    expect(clickSpy).toHaveBeenCalled();
+  });
+
+  it('shows error for non-txt files on drop', async () => {
+    renderDropZone();
+    const zone = document.querySelector('.drop-zone');
+
+    const file = new File(['data'], 'image.png', { type: 'image/png' });
+    fireEvent.drop(zone, {
+      preventDefault: vi.fn(),
+      dataTransfer: { files: [file] },
+    });
+
+    // Error message appears
+    expect(await screen.findByText(/only .txt files supported/i)).toBeInTheDocument();
+  });
+});

--- a/packages/lcyt-web/test/components/FloatingPanel.test.jsx
+++ b/packages/lcyt-web/test/components/FloatingPanel.test.jsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FloatingPanel } from '../../src/components/FloatingPanel.jsx';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('FloatingPanel', () => {
+  it('renders title and children', () => {
+    render(
+      <FloatingPanel title="Test Panel" onClose={vi.fn()}>
+        <p>Panel content</p>
+      </FloatingPanel>
+    );
+    expect(screen.getByText('Test Panel')).toBeInTheDocument();
+    expect(screen.getByText('Panel content')).toBeInTheDocument();
+  });
+
+  it('has dialog role with aria-label', () => {
+    render(<FloatingPanel title="My Panel" onClose={vi.fn()} />);
+    expect(screen.getByRole('dialog')).toHaveAttribute('aria-label', 'My Panel');
+  });
+
+  it('calls onClose when close button is clicked', () => {
+    const onClose = vi.fn();
+    render(<FloatingPanel title="Panel" onClose={onClose} />);
+
+    fireEvent.click(screen.getByLabelText('Close'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders with correct CSS classes', () => {
+    render(<FloatingPanel title="Panel" onClose={vi.fn()} />);
+    const panel = document.querySelector('.floating-panel');
+    expect(panel).not.toBeNull();
+    expect(document.querySelector('.floating-panel__header')).not.toBeNull();
+    expect(document.querySelector('.floating-panel__body')).not.toBeNull();
+  });
+
+  it('positions panel at initial coordinates', () => {
+    render(<FloatingPanel title="Panel" onClose={vi.fn()} />);
+    const panel = document.querySelector('.floating-panel');
+    expect(panel.style.top).toBeTruthy();
+    expect(panel.style.left).toBeTruthy();
+  });
+});

--- a/packages/lcyt-web/test/components/LoginPage.test.jsx
+++ b/packages/lcyt-web/test/components/LoginPage.test.jsx
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { LoginPage } from '../../src/components/LoginPage.jsx';
+
+// ---------------------------------------------------------------------------
+// Mock useUserAuth
+// ---------------------------------------------------------------------------
+
+const mockLogin = vi.fn();
+
+vi.mock('../../src/hooks/useUserAuth', () => ({
+  useUserAuth: () => ({
+    login: mockLogin,
+    register: vi.fn(),
+    logout: vi.fn(),
+    user: null,
+    token: null,
+    backendUrl: null,
+    loading: false,
+  }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('LoginPage', () => {
+  it('renders sign-in heading and form fields', () => {
+    render(<LoginPage />);
+    expect(screen.getByText('Sign in')).toBeInTheDocument();
+    expect(screen.getByLabelText(/server url/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument();
+  });
+
+  it('reads backend URL from localStorage', () => {
+    localStorage.setItem('lcyt-config', JSON.stringify({ backendUrl: 'https://test.api' }));
+    render(<LoginPage />);
+    expect(screen.getByLabelText(/server url/i)).toHaveValue('https://test.api');
+  });
+
+  it('has a register link', () => {
+    render(<LoginPage />);
+    const link = screen.getByText(/register/i);
+    expect(link.closest('a')).toHaveAttribute('href', expect.stringContaining('/register'));
+  });
+
+  it('has a back to app link', () => {
+    render(<LoginPage />);
+    expect(screen.getByText(/back to app/i).closest('a')).toHaveAttribute('href', '/');
+  });
+
+  it('calls login on form submit', async () => {
+    mockLogin.mockResolvedValue({});
+    render(<LoginPage />);
+
+    fireEvent.change(screen.getByLabelText(/server url/i), { target: { value: 'https://api.test' } });
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'user@test.com' } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'password123' } });
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(mockLogin).toHaveBeenCalledWith('https://api.test', 'user@test.com', 'password123');
+    });
+  });
+
+  it('shows loading state while submitting', async () => {
+    let resolveLogin;
+    mockLogin.mockReturnValue(new Promise(r => { resolveLogin = r; }));
+    render(<LoginPage />);
+
+    fireEvent.change(screen.getByLabelText(/server url/i), { target: { value: 'https://api.test' } });
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'user@test.com' } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'pass1234' } });
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /signing in/i })).toBeDisabled();
+    });
+
+    resolveLogin({});
+  });
+
+  it('displays error on login failure', async () => {
+    mockLogin.mockRejectedValue(new Error('Invalid credentials'));
+    render(<LoginPage />);
+
+    fireEvent.change(screen.getByLabelText(/server url/i), { target: { value: 'https://api.test' } });
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'user@test.com' } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'wrong' } });
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Invalid credentials')).toBeInTheDocument();
+    });
+  });
+
+  it('does not submit when fields are empty', () => {
+    render(<LoginPage />);
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+    expect(mockLogin).not.toHaveBeenCalled();
+  });
+
+  it('passes backendUrl to register link', () => {
+    render(<LoginPage />);
+    fireEvent.change(screen.getByLabelText(/server url/i), { target: { value: 'https://my.server' } });
+    const link = screen.getByText(/register/i).closest('a');
+    expect(link.getAttribute('href')).toContain(encodeURIComponent('https://my.server'));
+  });
+});

--- a/packages/lcyt-web/test/components/ProjectsPage.test.jsx
+++ b/packages/lcyt-web/test/components/ProjectsPage.test.jsx
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ProjectsPage } from '../../src/components/ProjectsPage.jsx';
+
+// ---------------------------------------------------------------------------
+// Mock useUserAuth
+// ---------------------------------------------------------------------------
+
+let mockAuth;
+
+vi.mock('../../src/hooks/useUserAuth', () => ({
+  useUserAuth: () => mockAuth,
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const MOCK_PROJECTS = [
+  { key: 'key-abc-1234567890ab', owner: 'Sunday service', createdAt: '2026-01-15T00:00:00Z' },
+  { key: 'key-xyz-9876543210cd', owner: 'Wednesday night', createdAt: '2026-02-20T00:00:00Z', expires: '2027-02-20T00:00:00Z' },
+];
+
+function setupAuth(overrides = {}) {
+  mockAuth = {
+    user: { userId: 'u1', email: 'test@example.com', name: 'Test' },
+    token: 'user-jwt-token',
+    backendUrl: 'https://api.test',
+    loading: false,
+    logout: vi.fn(),
+    login: vi.fn(),
+    register: vi.fn(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  global.fetch = vi.fn();
+  // Suppress confirm dialogs in tests
+  global.confirm = vi.fn(() => true);
+  global.alert = vi.fn();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ProjectsPage', () => {
+  it('shows loading state when auth is loading', () => {
+    setupAuth({ loading: true, user: null });
+    render(<ProjectsPage />);
+    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+  });
+
+  it('returns null (redirect) when not authenticated', () => {
+    setupAuth({ user: null });
+    render(<ProjectsPage />);
+    // No heading rendered since user is null → redirecting
+    expect(screen.queryByText('Projects')).not.toBeInTheDocument();
+  });
+
+  it('renders projects heading and user email when authenticated', async () => {
+    setupAuth();
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ keys: MOCK_PROJECTS }),
+    });
+
+    render(<ProjectsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Projects')).toBeInTheDocument();
+    });
+    expect(screen.getByText('test@example.com')).toBeInTheDocument();
+  });
+
+  it('fetches and displays projects on mount', async () => {
+    setupAuth();
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ keys: MOCK_PROJECTS }),
+    });
+
+    render(<ProjectsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Sunday service')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Wednesday night')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no projects exist', async () => {
+    setupAuth();
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ keys: [] }),
+    });
+
+    render(<ProjectsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/no projects yet/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows error when fetch fails', async () => {
+    setupAuth();
+    global.fetch.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: 'Unauthorized' }),
+    });
+
+    render(<ProjectsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Unauthorized')).toBeInTheDocument();
+    });
+  });
+
+  it('opens create project form on button click', async () => {
+    setupAuth();
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ keys: [] }),
+    });
+
+    render(<ProjectsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/new project/i)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText(/new project/i));
+    expect(screen.getByLabelText(/project name/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /create project/i })).toBeInTheDocument();
+  });
+
+  it('masks API key by default and toggles visibility', async () => {
+    setupAuth();
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ keys: MOCK_PROJECTS }),
+    });
+
+    render(<ProjectsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Sunday service')).toBeInTheDocument();
+    });
+
+    // Key should be masked (first 8 chars + dots)
+    const maskedKey = screen.getAllByText(/key-abc-/)[0];
+    expect(maskedKey.textContent).toContain('••••');
+
+    // Click show to reveal
+    const showButtons = screen.getAllByText('Show');
+    fireEvent.click(showButtons[0]);
+    expect(screen.getByText('key-abc-1234567890ab')).toBeInTheDocument();
+  });
+
+  it('calls logout on sign out click', async () => {
+    setupAuth();
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ keys: [] }),
+    });
+
+    render(<ProjectsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/sign out/i)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText(/sign out/i));
+    expect(mockAuth.logout).toHaveBeenCalled();
+  });
+
+  it('deletes a project after confirmation', async () => {
+    setupAuth();
+    global.fetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ keys: MOCK_PROJECTS }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+
+    render(<ProjectsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Sunday service')).toBeInTheDocument();
+    });
+
+    const deleteButtons = screen.getAllByText('Delete');
+    fireEvent.click(deleteButtons[0]);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/keys/key-abc-1234567890ab'),
+        expect.objectContaining({ method: 'DELETE' }),
+      );
+    });
+  });
+});

--- a/packages/lcyt-web/test/components/RegisterPage.test.jsx
+++ b/packages/lcyt-web/test/components/RegisterPage.test.jsx
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { RegisterPage } from '../../src/components/RegisterPage.jsx';
+
+// ---------------------------------------------------------------------------
+// Mock useUserAuth
+// ---------------------------------------------------------------------------
+
+const mockRegister = vi.fn();
+
+vi.mock('../../src/hooks/useUserAuth', () => ({
+  useUserAuth: () => ({
+    login: vi.fn(),
+    register: mockRegister,
+    logout: vi.fn(),
+    user: null,
+    token: null,
+    backendUrl: null,
+    loading: false,
+  }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('RegisterPage', () => {
+  it('renders create account heading and all form fields', () => {
+    render(<RegisterPage />);
+    expect(screen.getByText('Create account')).toBeInTheDocument();
+    expect(screen.getByLabelText(/server url/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^password/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/confirm password/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /create account/i })).toBeInTheDocument();
+  });
+
+  it('reads backend URL from localStorage', () => {
+    localStorage.setItem('lcyt-config', JSON.stringify({ backendUrl: 'https://saved.api' }));
+    render(<RegisterPage />);
+    expect(screen.getByLabelText(/server url/i)).toHaveValue('https://saved.api');
+  });
+
+  it('has a sign-in link and back-to-app link', () => {
+    render(<RegisterPage />);
+    expect(screen.getByText(/sign in/i).closest('a')).toHaveAttribute('href', expect.stringContaining('/login'));
+    expect(screen.getByText(/back to app/i).closest('a')).toHaveAttribute('href', '/');
+  });
+
+  it('shows error when passwords do not match', async () => {
+    render(<RegisterPage />);
+
+    fireEvent.change(screen.getByLabelText(/server url/i), { target: { value: 'https://api.test' } });
+    fireEvent.change(screen.getByLabelText(/^email/i), { target: { value: 'u@t.com' } });
+    fireEvent.change(screen.getByLabelText(/^password/i), { target: { value: 'password123' } });
+    fireEvent.change(screen.getByLabelText(/confirm password/i), { target: { value: 'different' } });
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Passwords do not match')).toBeInTheDocument();
+    });
+    expect(mockRegister).not.toHaveBeenCalled();
+  });
+
+  it('shows error when password is too short', async () => {
+    render(<RegisterPage />);
+
+    fireEvent.change(screen.getByLabelText(/server url/i), { target: { value: 'https://api.test' } });
+    fireEvent.change(screen.getByLabelText(/^email/i), { target: { value: 'u@t.com' } });
+    fireEvent.change(screen.getByLabelText(/^password/i), { target: { value: 'short' } });
+    fireEvent.change(screen.getByLabelText(/confirm password/i), { target: { value: 'short' } });
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/at least 8 characters/i)).toBeInTheDocument();
+    });
+    expect(mockRegister).not.toHaveBeenCalled();
+  });
+
+  it('calls register with correct args on valid submit', async () => {
+    mockRegister.mockResolvedValue({});
+    render(<RegisterPage />);
+
+    fireEvent.change(screen.getByLabelText(/server url/i), { target: { value: 'https://api.test' } });
+    fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'Test User' } });
+    fireEvent.change(screen.getByLabelText(/^email/i), { target: { value: 'user@test.com' } });
+    fireEvent.change(screen.getByLabelText(/^password/i), { target: { value: 'password123' } });
+    fireEvent.change(screen.getByLabelText(/confirm password/i), { target: { value: 'password123' } });
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+
+    await waitFor(() => {
+      expect(mockRegister).toHaveBeenCalledWith('https://api.test', 'user@test.com', 'password123', 'Test User');
+    });
+  });
+
+  it('calls register with undefined name when name is empty', async () => {
+    mockRegister.mockResolvedValue({});
+    render(<RegisterPage />);
+
+    fireEvent.change(screen.getByLabelText(/server url/i), { target: { value: 'https://api.test' } });
+    fireEvent.change(screen.getByLabelText(/^email/i), { target: { value: 'u@t.com' } });
+    fireEvent.change(screen.getByLabelText(/^password/i), { target: { value: 'abcdefgh' } });
+    fireEvent.change(screen.getByLabelText(/confirm password/i), { target: { value: 'abcdefgh' } });
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+
+    await waitFor(() => {
+      expect(mockRegister).toHaveBeenCalledWith('https://api.test', 'u@t.com', 'abcdefgh', undefined);
+    });
+  });
+
+  it('shows loading state during registration', async () => {
+    let resolveReg;
+    mockRegister.mockReturnValue(new Promise(r => { resolveReg = r; }));
+    render(<RegisterPage />);
+
+    fireEvent.change(screen.getByLabelText(/server url/i), { target: { value: 'https://api.test' } });
+    fireEvent.change(screen.getByLabelText(/^email/i), { target: { value: 'u@t.com' } });
+    fireEvent.change(screen.getByLabelText(/^password/i), { target: { value: 'abcdefgh' } });
+    fireEvent.change(screen.getByLabelText(/confirm password/i), { target: { value: 'abcdefgh' } });
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /creating account/i })).toBeDisabled();
+    });
+
+    resolveReg({});
+  });
+
+  it('shows server error message on registration failure', async () => {
+    mockRegister.mockRejectedValue(new Error('Email already registered'));
+    render(<RegisterPage />);
+
+    fireEvent.change(screen.getByLabelText(/server url/i), { target: { value: 'https://api.test' } });
+    fireEvent.change(screen.getByLabelText(/^email/i), { target: { value: 'u@t.com' } });
+    fireEvent.change(screen.getByLabelText(/^password/i), { target: { value: 'abcdefgh' } });
+    fireEvent.change(screen.getByLabelText(/confirm password/i), { target: { value: 'abcdefgh' } });
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Email already registered')).toBeInTheDocument();
+    });
+  });
+
+  it('does not submit when required fields are empty', () => {
+    render(<RegisterPage />);
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+    expect(mockRegister).not.toHaveBeenCalled();
+  });
+});

--- a/packages/lcyt-web/test/components/SentPanel.test.jsx
+++ b/packages/lcyt-web/test/components/SentPanel.test.jsx
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SentPanel } from '../../src/components/SentPanel.jsx';
+import { SentLogContext } from '../../src/contexts/SentLogContext.jsx';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockSentLog(entries = []) {
+  return {
+    entries,
+    add: vi.fn(),
+    confirm: vi.fn(),
+    markError: vi.fn(),
+    updateRequestId: vi.fn(),
+    clear: vi.fn(),
+  };
+}
+
+function renderSentPanel(entries = []) {
+  const sentLog = mockSentLog(entries);
+  const result = render(
+    <SentLogContext.Provider value={sentLog}>
+      <SentPanel />
+    </SentLogContext.Provider>
+  );
+  return { ...result, sentLog };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  global.confirm = vi.fn(() => true);
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SentPanel', () => {
+  it('renders header with title', () => {
+    renderSentPanel();
+    expect(screen.getByText('Sent Captions')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no entries', () => {
+    renderSentPanel([]);
+    expect(screen.getByText('No captions sent yet')).toBeInTheDocument();
+  });
+
+  it('renders confirmed entry with sequence number', () => {
+    renderSentPanel([
+      { requestId: 'r1', text: 'Hello world', sequence: 42, pending: false, error: false, timestamp: Date.now() },
+    ]);
+    expect(screen.getByText('#42')).toBeInTheDocument();
+    expect(screen.getByText('Hello world')).toBeInTheDocument();
+  });
+
+  it('renders pending entry with ? marker', () => {
+    renderSentPanel([
+      { requestId: 'r1', text: 'Pending caption', pending: true, error: false, timestamp: Date.now() },
+    ]);
+    expect(screen.getByText('?')).toBeInTheDocument();
+    expect(screen.getByText('Pending caption')).toBeInTheDocument();
+  });
+
+  it('renders error entry with error marker', () => {
+    renderSentPanel([
+      { requestId: 'r1', text: 'Failed caption', pending: false, error: true, timestamp: Date.now() },
+    ]);
+    // Error seq shows ✕
+    const items = document.querySelectorAll('.sent-item--error');
+    expect(items.length).toBe(1);
+  });
+
+  it('renders translation text when captionTranslationText exists', () => {
+    renderSentPanel([
+      {
+        requestId: 'r1',
+        text: 'Hello',
+        captionTranslationText: 'Hola',
+        showOriginal: true,
+        sequence: 1,
+        pending: false,
+        error: false,
+        timestamp: Date.now(),
+      },
+    ]);
+    expect(screen.getByText('Hola')).toBeInTheDocument();
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+  });
+
+  it('shows globe icon for entries with translations', () => {
+    renderSentPanel([
+      {
+        requestId: 'r1',
+        text: 'Test',
+        hasTranslations: true,
+        otherTranslations: { 'fi-FI': 'Testi' },
+        sequence: 1,
+        pending: false,
+        error: false,
+        timestamp: Date.now(),
+      },
+    ]);
+    expect(screen.getByTitle(/fi-FI: Testi/)).toBeInTheDocument();
+  });
+
+  it('calls clear when clear button is clicked', () => {
+    const { sentLog } = renderSentPanel([
+      { requestId: 'r1', text: 'Caption 1', sequence: 1, pending: false, error: false, timestamp: Date.now() },
+    ]);
+
+    fireEvent.click(screen.getByLabelText('Clear sent log'));
+    expect(sentLog.clear).toHaveBeenCalled();
+  });
+
+  it('renders word wrap toggle', () => {
+    renderSentPanel();
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).toBeInTheDocument();
+    expect(screen.getByText('Wrap')).toBeInTheDocument();
+  });
+
+  it('toggles word wrap and persists to localStorage', () => {
+    renderSentPanel([
+      { requestId: 'r1', text: 'Test', sequence: 1, pending: false, error: false, timestamp: Date.now() },
+    ]);
+
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox.checked).toBe(false);
+
+    fireEvent.click(checkbox);
+    expect(checkbox.checked).toBe(true);
+    expect(localStorage.getItem('lcyt:sent-panel-wrap')).toBe('1');
+
+    fireEvent.click(checkbox);
+    expect(checkbox.checked).toBe(false);
+    expect(localStorage.getItem('lcyt:sent-panel-wrap')).toBe('0');
+  });
+
+  it('renders batch continuation items without sequence', () => {
+    renderSentPanel([
+      { requestId: 'batch-1', text: 'Line 1', sequence: 10, pending: false, error: false, timestamp: Date.now() },
+      { requestId: 'batch-1', text: 'Line 2', sequence: 11, pending: false, error: false, timestamp: Date.now() },
+    ]);
+    // First item has sequence, second is a continuation (no seq label)
+    expect(screen.getByText('#10')).toBeInTheDocument();
+    expect(screen.getByText('Line 2')).toBeInTheDocument();
+    // Continuation items have empty seq span
+    const continuations = document.querySelectorAll('.sent-item--continuation');
+    expect(continuations.length).toBe(1);
+  });
+
+  it('limits visible entries to 500', () => {
+    const entries = Array.from({ length: 600 }, (_, i) => ({
+      requestId: `r${i}`,
+      text: `Caption ${i}`,
+      sequence: i,
+      pending: false,
+      error: false,
+      timestamp: Date.now(),
+    }));
+    renderSentPanel(entries);
+    const items = document.querySelectorAll('.sent-item');
+    expect(items.length).toBe(500);
+  });
+});

--- a/packages/lcyt-web/test/components/StatusBar.test.jsx
+++ b/packages/lcyt-web/test/components/StatusBar.test.jsx
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { StatusBar } from '../../src/components/StatusBar.jsx';
+import { SessionContext } from '../../src/contexts/SessionContext.jsx';
+import { ToastContext } from '../../src/contexts/ToastContext.jsx';
+import { LangProvider } from '../../src/contexts/LangContext.jsx';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockSession(overrides = {}) {
+  return {
+    connected: false,
+    sequence: 0,
+    syncOffset: 0,
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    getPersistedConfig: vi.fn(() => ({ backendUrl: 'https://api.test', apiKey: 'key123' })),
+    ...overrides,
+  };
+}
+
+function mockToast() {
+  return {
+    toasts: [],
+    showToast: vi.fn(),
+    dismissToast: vi.fn(),
+  };
+}
+
+function renderStatusBar({ session, toast, ...props } = {}) {
+  const s = session || mockSession();
+  const t = toast || mockToast();
+  const callbacks = {
+    onSettingsOpen: vi.fn(),
+    onCCOpen: vi.fn(),
+    onControlsOpen: vi.fn(),
+    onPrivacyOpen: vi.fn(),
+    onBroadcastOpen: vi.fn(),
+    ...props,
+  };
+
+  const result = render(
+    <SessionContext.Provider value={s}>
+      <ToastContext.Provider value={t}>
+        <LangProvider>
+          <StatusBar {...callbacks} />
+        </LangProvider>
+      </ToastContext.Provider>
+    </SessionContext.Provider>
+  );
+
+  return { ...result, session: s, toast: t, callbacks };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('StatusBar', () => {
+  it('renders brand name', () => {
+    renderStatusBar();
+    expect(screen.getByText('lcyt-web')).toBeInTheDocument();
+  });
+
+  it('shows connect button when disconnected', () => {
+    renderStatusBar();
+    const btn = screen.getByTitle(/connect/i);
+    expect(btn).toBeInTheDocument();
+    expect(btn).not.toBeDisabled();
+  });
+
+  it('shows disconnect button when connected', () => {
+    renderStatusBar({ session: mockSession({ connected: true }) });
+    expect(screen.getByTitle(/disconnect/i)).toBeInTheDocument();
+  });
+
+  it('calls session.connect when connect button is clicked', async () => {
+    const session = mockSession();
+    renderStatusBar({ session });
+
+    fireEvent.click(screen.getByTitle(/connect/i));
+
+    await waitFor(() => {
+      expect(session.connect).toHaveBeenCalledWith({ backendUrl: 'https://api.test', apiKey: 'key123' });
+    });
+  });
+
+  it('calls session.disconnect when already connected', async () => {
+    const session = mockSession({ connected: true });
+    renderStatusBar({ session });
+
+    fireEvent.click(screen.getByTitle(/disconnect/i));
+
+    await waitFor(() => {
+      expect(session.disconnect).toHaveBeenCalled();
+    });
+  });
+
+  it('opens settings when connecting with no config', async () => {
+    const session = mockSession({
+      getPersistedConfig: vi.fn(() => ({ backendUrl: '', apiKey: '' })),
+    });
+    const callbacks = { onSettingsOpen: vi.fn() };
+    renderStatusBar({ session, ...callbacks });
+
+    fireEvent.click(screen.getByTitle(/connect/i));
+
+    expect(callbacks.onSettingsOpen).toHaveBeenCalled();
+    expect(session.connect).not.toHaveBeenCalled();
+  });
+
+  it('shows toast on connection error', async () => {
+    const session = mockSession();
+    session.connect.mockRejectedValue(new Error('Connection refused'));
+    const toast = mockToast();
+    renderStatusBar({ session, toast });
+
+    fireEvent.click(screen.getByTitle(/connect/i));
+
+    await waitFor(() => {
+      expect(toast.showToast).toHaveBeenCalledWith('Connection refused', 'error');
+    });
+  });
+
+  it('fires onSettingsOpen callback', () => {
+    const callbacks = { onSettingsOpen: vi.fn() };
+    renderStatusBar(callbacks);
+
+    // Find Settings button by title
+    fireEvent.click(screen.getByTitle('Settings'));
+    expect(callbacks.onSettingsOpen).toHaveBeenCalled();
+  });
+
+  it('fires onCCOpen callback', () => {
+    const callbacks = { onCCOpen: vi.fn() };
+    renderStatusBar(callbacks);
+
+    fireEvent.click(screen.getByTitle('CC'));
+    expect(callbacks.onCCOpen).toHaveBeenCalled();
+  });
+
+  it('fires onControlsOpen callback', () => {
+    const callbacks = { onControlsOpen: vi.fn() };
+    renderStatusBar(callbacks);
+
+    fireEvent.click(screen.getByTitle('Controls'));
+    expect(callbacks.onControlsOpen).toHaveBeenCalled();
+  });
+
+  it('fires onPrivacyOpen callback', () => {
+    const callbacks = { onPrivacyOpen: vi.fn() };
+    renderStatusBar(callbacks);
+
+    fireEvent.click(screen.getByTitle('Privacy'));
+    expect(callbacks.onPrivacyOpen).toHaveBeenCalled();
+  });
+
+  it('fires onBroadcastOpen callback', () => {
+    const callbacks = { onBroadcastOpen: vi.fn() };
+    renderStatusBar(callbacks);
+
+    fireEvent.click(screen.getByTitle('Broadcast'));
+    expect(callbacks.onBroadcastOpen).toHaveBeenCalled();
+  });
+
+  it('disables connect button while connecting', async () => {
+    let resolveConnect;
+    const session = mockSession();
+    session.connect.mockReturnValue(new Promise(r => { resolveConnect = r; }));
+    renderStatusBar({ session });
+
+    fireEvent.click(screen.getByTitle(/connect/i));
+
+    await waitFor(() => {
+      // Find the connect button by its CSS class
+      const btn = document.querySelector('.status-bar__btn--connecting');
+      expect(btn).not.toBeNull();
+      expect(btn).toBeDisabled();
+    });
+
+    resolveConnect();
+  });
+});

--- a/packages/lcyt-web/test/components/StatusPanel.test.jsx
+++ b/packages/lcyt-web/test/components/StatusPanel.test.jsx
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { StatusPanel } from '../../src/components/StatusPanel.jsx';
+import { SessionContext } from '../../src/contexts/SessionContext.jsx';
+import { ToastContext } from '../../src/contexts/ToastContext.jsx';
+import { LangProvider } from '../../src/contexts/LangContext.jsx';
+
+// ---------------------------------------------------------------------------
+// Mock dependent modules that StatusPanel imports
+// ---------------------------------------------------------------------------
+
+vi.mock('../../src/lib/targetConfig', () => ({
+  getEnabledTargets: vi.fn(() => []),
+}));
+
+vi.mock('../../src/lib/translationConfig', () => ({
+  getEnabledTranslations: vi.fn(() => []),
+}));
+
+// Mock StatsModal and FilesModal to avoid deep dependency chains
+vi.mock('../../src/components/StatsModal', () => ({
+  StatsModal: ({ isOpen }) => isOpen ? <div data-testid="stats-modal">Stats</div> : null,
+}));
+
+vi.mock('../../src/components/FilesModal', () => ({
+  FilesModal: ({ isOpen }) => isOpen ? <div data-testid="files-modal">Files</div> : null,
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockSession(overrides = {}) {
+  return {
+    connected: true,
+    sequence: 42,
+    syncOffset: 150,
+    getStats: vi.fn().mockResolvedValue({ totalCaptions: 100 }),
+    getRelayStatus: vi.fn().mockResolvedValue(null),
+    ...overrides,
+  };
+}
+
+function mockToast() {
+  return {
+    toasts: [],
+    showToast: vi.fn(),
+    dismissToast: vi.fn(),
+  };
+}
+
+function renderStatusPanel(session, toast, props = {}) {
+  const s = session || mockSession();
+  const t = toast || mockToast();
+  const onClose = props.onClose || vi.fn();
+
+  const result = render(
+    <SessionContext.Provider value={s}>
+      <ToastContext.Provider value={t}>
+        <LangProvider>
+          <StatusPanel onClose={onClose} />
+        </LangProvider>
+      </ToastContext.Provider>
+    </SessionContext.Provider>
+  );
+
+  return { ...result, session: s, toast: t, onClose };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('StatusPanel', () => {
+  it('renders as a floating panel with status title', () => {
+    renderStatusPanel();
+    // FloatingPanel renders the title; LangProvider provides translations
+    const dialog = document.querySelector('.floating-panel');
+    expect(dialog).not.toBeNull();
+  });
+
+  it('shows connected status when session is connected', () => {
+    renderStatusPanel(mockSession({ connected: true }));
+    // The connected label text comes from i18n — defaults to English
+    const connectedEl = screen.getByText(/connected/i);
+    expect(connectedEl).toBeInTheDocument();
+  });
+
+  it('shows disconnected status when session is disconnected', () => {
+    renderStatusPanel(mockSession({ connected: false, getRelayStatus: vi.fn().mockResolvedValue(null) }));
+    expect(screen.getByText(/disconnected/i)).toBeInTheDocument();
+  });
+
+  it('shows sequence number when connected', () => {
+    renderStatusPanel(mockSession({ connected: true, sequence: 99 }));
+    expect(screen.getByText('99')).toBeInTheDocument();
+  });
+
+  it('shows sync offset when non-zero', () => {
+    renderStatusPanel(mockSession({ connected: true, syncOffset: 250 }));
+    expect(screen.getByText('250ms')).toBeInTheDocument();
+  });
+
+  it('hides sync offset when zero', () => {
+    renderStatusPanel(mockSession({ connected: true, syncOffset: 0 }));
+    expect(screen.queryByText('0ms')).not.toBeInTheDocument();
+  });
+
+  it('opens stats modal on stats button click', async () => {
+    const session = mockSession();
+    renderStatusPanel(session);
+
+    // Find stats button (contains translated text)
+    const statsBtn = document.querySelectorAll('.btn--secondary')[0];
+    fireEvent.click(statsBtn);
+
+    await waitFor(() => {
+      expect(session.getStats).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('stats-modal')).toBeInTheDocument();
+    });
+  });
+
+  it('shows toast when stats requested while disconnected', async () => {
+    const session = mockSession({ connected: false, getRelayStatus: vi.fn().mockResolvedValue(null) });
+    const toast = mockToast();
+    renderStatusPanel(session, toast);
+
+    const statsBtn = document.querySelectorAll('.btn--secondary')[0];
+    fireEvent.click(statsBtn);
+
+    expect(toast.showToast).toHaveBeenCalled();
+    expect(session.getStats).not.toHaveBeenCalled();
+  });
+
+  it('disables stats and files buttons when disconnected', () => {
+    renderStatusPanel(mockSession({ connected: false, getRelayStatus: vi.fn().mockResolvedValue(null) }));
+
+    const buttons = document.querySelectorAll('.btn--secondary');
+    for (const btn of buttons) {
+      expect(btn).toBeDisabled();
+    }
+  });
+
+  it('opens files modal on files button click', () => {
+    renderStatusPanel();
+
+    const filesBtn = document.querySelectorAll('.btn--secondary')[1];
+    fireEvent.click(filesBtn);
+
+    expect(screen.getByTestId('files-modal')).toBeInTheDocument();
+  });
+});

--- a/python-packages/lcyt-backend/lcyt_backend/routes/live.py
+++ b/python-packages/lcyt-backend/lcyt_backend/routes/live.py
@@ -1,5 +1,6 @@
 """POST/GET/DELETE /live — session registration and management."""
 
+import logging
 import os
 import time
 
@@ -82,7 +83,7 @@ def register_session():
         sync_result = _sync_sender(sender)
         sync_offset = sync_result["sync_offset"]
     except Exception:
-        pass  # not fatal
+        logging.getLogger(__name__).warning("Initial clock sync failed", exc_info=True)
 
     # Sign JWT — omit streamKey and domain from payload (sensitive; not needed by route handlers)
     try:
@@ -150,7 +151,7 @@ def remove_session():
     try:
         session["sender"].end()
     except Exception:
-        pass
+        logging.getLogger(__name__).warning("Sender cleanup failed on DELETE /live", exc_info=True)
 
     store.remove(session_id)
     return jsonify({"removed": True, "sessionId": session_id}), 200

--- a/python-packages/lcyt-backend/lcyt_backend/store.py
+++ b/python-packages/lcyt-backend/lcyt_backend/store.py
@@ -1,11 +1,14 @@
 """In-memory session store for lcyt-backend."""
 
 import hashlib
+import logging
 import os
 import threading
 import time
 from datetime import datetime, timezone
 from typing import Iterable, Iterator, Optional
+
+_log = logging.getLogger(__name__)
 
 DEFAULT_SESSION_TTL = int(os.environ.get("SESSION_TTL", str(2 * 60 * 60)))  # 2 hours (seconds)
 DEFAULT_CLEANUP_INTERVAL = int(os.environ.get("CLEANUP_INTERVAL", str(5 * 60)))  # 5 minutes
@@ -164,7 +167,7 @@ class SessionStore:
                 try:
                     session["sender"].end()
                 except Exception:
-                    pass  # best-effort cleanup
+                    _log.warning("Sender cleanup failed for session %s", sid, exc_info=True)
 
     def stop_cleanup(self) -> None:
         """Stop the periodic cleanup thread. Call during graceful shutdown."""


### PR DESCRIPTION
- caption-files.js: Add 5s per-write timeout that logs a warning if
  stream.write() callback never fires (hung write detection)
- Python live.py + store.py: Replace silent `except Exception: pass` with
  logging.warning() so sync failures, sender cleanup errors, and session
  sweep errors are visible instead of swallowed
- bridge.js: Make EventSource dynamic import robust against varying module
  export shapes (ESM default vs CJS re-export) with typeof check
- interactive-ui.js: Add circuit breaker that stops YouTube status polling
  after 5 consecutive failures, with counter reset on success or restart

https://claude.ai/code/session_01EKWoYiLBhJnzrCtFephgPm