### PR TITLE
fix: sidebar Graphics and Production pages use session context for credentials

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -215,7 +215,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -656,7 +655,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -705,7 +703,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -755,6 +752,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -771,6 +769,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -787,6 +786,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -803,6 +803,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -819,6 +820,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -835,6 +837,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -851,6 +854,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -867,6 +871,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -883,6 +888,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -899,6 +905,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -915,6 +922,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -931,6 +939,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -947,6 +956,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -963,6 +973,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -979,6 +990,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -995,6 +1007,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1011,6 +1024,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1043,6 +1057,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1075,6 +1090,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1107,6 +1123,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1123,6 +1140,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1139,6 +1157,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1155,6 +1174,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2812,6 +2832,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2901,7 +2922,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4848,7 +4870,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5545,7 +5566,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -5750,7 +5772,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5888,7 +5909,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -6459,7 +6479,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.1.tgz",
       "integrity": "sha512-hi9afu8g0lfJVLolxElAZGANCTTl6bewIdsRNhaywfP9K8BPf++F2z6OLrYGIinUwpRKzbZHMhPwvc0ZEpAwGw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7068,6 +7087,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7088,6 +7108,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7108,6 +7129,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7128,6 +7150,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7148,6 +7171,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7168,6 +7192,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7188,6 +7213,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7208,6 +7234,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7228,6 +7255,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7248,6 +7276,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7268,6 +7297,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7356,6 +7386,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -8839,6 +8870,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -8854,6 +8886,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9025,7 +9058,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -9038,7 +9070,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -9084,7 +9115,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -9494,7 +9526,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.58.0.tgz",
       "integrity": "sha512-wbT0mBmWbIvvq8NeEYWWvevvxnOyhKChir47S66WCxw1SXqhw7ssIYejnQEVt7XYQpsj2y8F9PM+Cr3SNEa0gw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -10647,7 +10678,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -10843,7 +10873,6 @@
       "integrity": "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/runtime": "0.115.0",
         "lightningcss": "^1.32.0",
@@ -11221,7 +11250,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/packages/lcyt-web/src/components/DskControlPage.jsx
+++ b/packages/lcyt-web/src/components/DskControlPage.jsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useContext, useEffect, useState } from 'react';
+import { SessionContext } from '../contexts/SessionContext';
 
 /**
  * DSK Broadcast Control Panel
@@ -56,11 +57,12 @@ const inputStyle = {
 };
 
 export function DskControlPage() {
+  const session = useContext(SessionContext);
   const pathParts = window.location.pathname.split('/');
-  // /dsk-control/:apikey
-  const apiKey = pathParts[2] || '';
+  // /dsk-control/:apikey (standalone) or /graphics/control (sidebar)
+  const apiKey = pathParts[2] || session?.apiKey || '';
   const params = new URLSearchParams(window.location.search);
-  const serverUrl = (params.get('server') || '').replace(/\/$/, '');
+  const serverUrl = (params.get('server') || session?.backendUrl || '').replace(/\/$/, '');
 
   const [templates, setTemplates]         = useState([]);  // { id, name, updated_at, templateJson? }
   const [activeId, setActiveId]           = useState(null); // currently activated template id
@@ -213,8 +215,10 @@ export function DskControlPage() {
 
   if (!serverUrl || !apiKey) {
     return (
-      <div style={{ background: '#0d0d0d', color: '#fff', width: '100vw', height: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: 'sans-serif', fontSize: 16 }}>
-        Missing API key in URL path or <code>?server=</code> parameter.
+      <div style={{ padding: 32, color: 'var(--color-text-muted, #888)', fontFamily: 'sans-serif', fontSize: 16 }}>
+        {session
+          ? 'Connect to a backend first (click Connect in the top bar).'
+          : 'Missing API key in URL path or ?server= parameter.'}
       </div>
     );
   }

--- a/packages/lcyt-web/src/components/DskEditorPage.jsx
+++ b/packages/lcyt-web/src/components/DskEditorPage.jsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useContext, useEffect, useRef, useState } from 'react';
+import { SessionContext } from '../contexts/SessionContext';
 
 /**
  * DSK Graphics Template Editor
@@ -773,9 +774,10 @@ function newGroupId()     { _groupCounter += 1; return `grp-${_groupCounter}`; }
 // ── Main component ────────────────────────────────────────────────────────────
 
 export function DskEditorPage() {
+  const session   = useContext(SessionContext);
   const params    = new URLSearchParams(window.location.search);
-  const apiKey    = params.get('apikey') || '';
-  const serverUrl = (params.get('server') || '').replace(/\/$/, '');
+  const apiKey    = params.get('apikey') || session?.apiKey || '';
+  const serverUrl = (params.get('server') || session?.backendUrl || '').replace(/\/$/, '');
 
   const [templates, setTemplates]     = useState([]);
   const [selectedId, setSelectedId]   = useState(null);   // backend template id
@@ -1255,8 +1257,10 @@ export function DskEditorPage() {
 
   if (!serverUrl || !apiKey) {
     return (
-      <div style={{ background: '#111', color: '#fff', width: '100vw', height: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: 'sans-serif', fontSize: 16 }}>
-        Missing <code>?server=</code> and <code>?apikey=</code> URL parameters.
+      <div style={{ padding: 32, color: 'var(--color-text-muted, #888)', fontFamily: 'sans-serif', fontSize: 16 }}>
+        {session
+          ? 'Connect to a backend first (click Connect in the top bar).'
+          : 'Missing ?server= and ?apikey= URL parameters.'}
       </div>
     );
   }

--- a/packages/lcyt-web/src/components/DskViewportsPage.jsx
+++ b/packages/lcyt-web/src/components/DskViewportsPage.jsx
@@ -1,4 +1,5 @@
-import { useEffect, useState, useCallback, useId } from 'react';
+import { useContext, useEffect, useState, useCallback, useId } from 'react';
+import { SessionContext } from '../contexts/SessionContext';
 
 /**
  * DSK Viewports Management Page
@@ -62,9 +63,10 @@ const labelStyle = { display: 'block', marginBottom: 4, color: dark.muted, fontS
 // ── Component ─────────────────────────────────────────────────────────────────
 
 export function DskViewportsPage() {
+  const session   = useContext(SessionContext);
   const params    = new URLSearchParams(window.location.search);
-  const serverUrl = (params.get('server') || '').replace(/\/$/, '');
-  const apiKey    = params.get('apikey') || '';
+  const serverUrl = (params.get('server') || session?.backendUrl || '').replace(/\/$/, '');
+  const apiKey    = params.get('apikey') || session?.apiKey || '';
 
   const [viewports, setViewports]       = useState([]);     // user-defined
   const [selected, setSelected]         = useState(null);   // viewport name or 'landscape'
@@ -285,8 +287,10 @@ export function DskViewportsPage() {
 
   if (!serverUrl || !apiKey) {
     return (
-      <div style={{ background: dark.bg, minHeight: '100vh', color: dark.text, fontFamily: 'sans-serif', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24 }}>
-        <div>Missing <code>?server=</code> and <code>?apikey=</code> parameters.</div>
+      <div style={{ padding: 32, color: 'var(--color-text-muted, #888)', fontFamily: 'sans-serif', fontSize: 16 }}>
+        {session
+          ? 'Connect to a backend first (click Connect in the top bar).'
+          : 'Missing ?server= and ?apikey= URL parameters.'}
       </div>
     );
   }

--- a/packages/lcyt-web/src/components/ProductionBridgesPage.jsx
+++ b/packages/lcyt-web/src/components/ProductionBridgesPage.jsx
@@ -1,5 +1,6 @@
 import { KEYS } from '../lib/storageKeys.js';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useContext } from 'react';
+import { SessionContext } from '../contexts/SessionContext';
 
 function ConnectionDot({ connected }) {
   return (
@@ -186,8 +187,9 @@ function DeleteConfirmModal({ bridge, cameras, mixers, onConfirm, onCancel }) {
 }
 
 export function ProductionBridgesPage() {
-  const params = new URLSearchParams(window.location.search);
-  const backendUrl = params.get('server') || localStorage.getItem(KEYS.session.backendUrl) || '';
+  const session    = useContext(SessionContext);
+  const params     = new URLSearchParams(window.location.search);
+  const backendUrl = params.get('server') || session?.backendUrl || localStorage.getItem(KEYS.session.backendUrl) || '';
   const apiKey     = params.get('apikey') || '';
 
   const [bridges, setBridges] = useState([]);

--- a/packages/lcyt-web/src/components/ProductionCamerasPage.jsx
+++ b/packages/lcyt-web/src/components/ProductionCamerasPage.jsx
@@ -1,5 +1,6 @@
 import { KEYS } from '../lib/storageKeys.js';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useContext } from 'react';
+import { SessionContext } from '../contexts/SessionContext';
 
 const CONTROL_TYPES = [
   { value: 'none', label: 'None (mixer only)' },
@@ -201,8 +202,9 @@ function CameraRow({ camera, bridges, onEdit, onDelete }) {
 }
 
 export function ProductionCamerasPage() {
+  const session    = useContext(SessionContext);
   const params     = new URLSearchParams(window.location.search);
-  const backendUrl = params.get('server') || localStorage.getItem(KEYS.session.backendUrl) || '';
+  const backendUrl = params.get('server') || session?.backendUrl || localStorage.getItem(KEYS.session.backendUrl) || '';
   const apiKey     = params.get('apikey') || '';
 
   const [cameras,       setCameras]       = useState([]);

--- a/packages/lcyt-web/src/components/ProductionMixersPage.jsx
+++ b/packages/lcyt-web/src/components/ProductionMixersPage.jsx
@@ -1,5 +1,6 @@
 import { KEYS } from '../lib/storageKeys.js';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useContext } from 'react';
+import { SessionContext } from '../contexts/SessionContext';
 
 const MIXER_TYPES = [
   { value: 'roland', label: 'Roland V-series' },
@@ -243,8 +244,9 @@ function MixerRow({ mixer, bridges, onEdit, onDelete }) {
 }
 
 export function ProductionMixersPage() {
+  const session    = useContext(SessionContext);
   const params     = new URLSearchParams(window.location.search);
-  const backendUrl = params.get('server') || localStorage.getItem(KEYS.session.backendUrl) || '';
+  const backendUrl = params.get('server') || session?.backendUrl || localStorage.getItem(KEYS.session.backendUrl) || '';
   const apiKey     = params.get('apikey') || '';
 
   const [mixers,        setMixers]        = useState([]);

--- a/packages/lcyt-web/src/components/ProductionOperatorPage.jsx
+++ b/packages/lcyt-web/src/components/ProductionOperatorPage.jsx
@@ -1,5 +1,6 @@
 import { KEYS } from '../lib/storageKeys.js';
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, useContext } from 'react';
+import { SessionContext } from '../contexts/SessionContext';
 
 const PRESET_STATE = {
   idle:    'idle',
@@ -195,8 +196,9 @@ function MixerStatusBar({ mixers, onManualSwitch }) {
 // ---------------------------------------------------------------------------
 
 export function ProductionOperatorPage() {
+  const session = useContext(SessionContext);
   const params = new URLSearchParams(window.location.search);
-  const backendUrl = params.get('server') || localStorage.getItem(KEYS.session.backendUrl) || '';
+  const backendUrl = params.get('server') || session?.backendUrl || localStorage.getItem(KEYS.session.backendUrl) || '';
   const apiKey = params.get('apikey') || '';
   const token = params.get('token') || localStorage.getItem(KEYS.session.token) || '';
 

--- a/packages/lcyt-web/src/main.jsx
+++ b/packages/lcyt-web/src/main.jsx
@@ -104,9 +104,7 @@ function SidebarApp() {
             <Route path="/audio" component={AudioPage} />
             <Route path="/broadcast" component={BroadcastPage} />
             <Route path="/graphics/editor" component={DskEditorPage} />
-            <Route path="/graphics/control">
-              <StubPage icon="🖼️" title="DSK Control" description="Access DSK Control via /dsk-control/:apikey. Full sidebar integration planned for a later phase." />
-            </Route>
+            <Route path="/graphics/control" component={DskControlPage} />
             <Route path="/graphics/viewports" component={DskViewportsPage} />
             <Route path="/production/cameras" component={ProductionCamerasPage} />
             <Route path="/production/mixers" component={ProductionMixersPage} />


### PR DESCRIPTION
- DskEditorPage, DskViewportsPage, DskControlPage: fall back to
  session context (backendUrl, apiKey) when URL params are absent,
  so they work when accessed from the sidebar without ?server/apikey params.
  Show a "Connect first" prompt instead of "Missing URL params" when in
  sidebar context.
- /graphics/control: replace stub with actual DskControlPage component.
- ProductionOperatorPage, ProductionCamerasPage, ProductionMixersPage,
  ProductionBridgesPage: read backendUrl from session context instead of
  the never-populated lcyt.session.backendUrl localStorage key, fixing
  the "Unexpected token '<'" JSON parse errors caused by fetching relative
  URLs against the dev server.

All seven pages retain URL-param override (for standalone/embed use) and
fall back gracefully via optional chaining (session?.backendUrl) so they
still work outside an AppProviders tree.

https://claude.ai/code/session_01WmuK9x2cirgA5pWYkLUjyd