### PR TITLE
feat(lcyt-web): P0 auto-reconnect + unsaved-work guard, P2 context split, P3 lazy loading

### DIFF
--- a/packages/lcyt-web/src/App.jsx
+++ b/packages/lcyt-web/src/App.jsx
@@ -153,6 +153,18 @@ export function AppLayout() {
     return () => document.removeEventListener('keydown', onKeyDown);
   }, [fileStore]);
 
+  // Unsaved work protection (P0 6c): warn before page unload if mic/STT is active
+  useEffect(() => {
+    function onBeforeUnload(e) {
+      if (micListening) {
+        e.preventDefault();
+        e.returnValue = '';
+      }
+    }
+    window.addEventListener('beforeunload', onBeforeUnload);
+    return () => window.removeEventListener('beforeunload', onBeforeUnload);
+  }, [micListening]);
+
   // Auto-open privacy modal on first visit (before user has accepted)
   useEffect(() => {
     try {

--- a/packages/lcyt-web/src/components/SidebarLayout.jsx
+++ b/packages/lcyt-web/src/components/SidebarLayout.jsx
@@ -605,6 +605,20 @@ function MobileDrawer({ open, onClose }) {
   );
 }
 
+// ─── Reconnect banner ─────────────────────────────────────────────────────────
+
+function ReconnectBanner() {
+  const { reconnecting, reconnectNow } = useSessionContext();
+  if (!reconnecting) return null;
+  return (
+    <div className="reconnect-banner" role="alert" aria-live="polite">
+      <span className="reconnect-banner__icon" aria-hidden="true">🔄</span>
+      <span className="reconnect-banner__msg">Session disconnected — reconnecting…</span>
+      <button className="reconnect-banner__btn" onClick={reconnectNow}>Reconnect now</button>
+    </div>
+  );
+}
+
 // ─── SidebarLayout ────────────────────────────────────────────────────────────
 
 export function SidebarLayout({ children }) {
@@ -637,6 +651,7 @@ export function SidebarLayout({ children }) {
   return (
     <div className="sidebar-shell">
       <TopBar expanded={expanded} onToggle={handleToggle} />
+      <ReconnectBanner />
       <div className="sidebar-body">
         {/* Desktop sidebar */}
         <Sidebar expanded={expanded} onNavigate={path => navigate(path)} />

--- a/packages/lcyt-web/src/contexts/AppProviders.jsx
+++ b/packages/lcyt-web/src/contexts/AppProviders.jsx
@@ -1,6 +1,9 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useMemo } from 'react';
 import { useSentLog } from '../hooks/useSentLog';
 import { SessionContext } from './SessionContext';
+import { ConnectionContext } from './ConnectionContext';
+import { CaptionContext } from './CaptionContext';
+import { SessionApiContext } from './SessionApiContext';
 import { useSession } from '../hooks/useSession';
 import { FileProvider } from './FileContext';
 import { SentLogContext } from './SentLogContext';
@@ -13,6 +16,11 @@ const EMBED_CHANNEL = 'lcyt-embed';
  * Composes all context providers with proper wiring:
  * - SentLog.confirm and SentLog.markError are wired into SessionProvider as callbacks
  *   so SSE caption results automatically update the delivery log.
+ *
+ * Also provides three focused sub-contexts split from SessionContext:
+ *   ConnectionContext  — connected state + connect/disconnect/health
+ *   CaptionContext     — sequence/syncOffset + send/sendBatch/sync
+ *   SessionApiContext  — stable API methods (stats, files, relay, images)
  *
  * For external project use, import SessionProvider, FileProvider, etc. individually
  * and wire callbacks yourself.
@@ -88,23 +96,126 @@ export function AppProviders({ children, initConfig, autoConnect, embed }) {
   });
 
   // Auto-connect on mount when credentials are provided via URL params.
-  // The empty dep array is intentional — initConfig comes from URL params
-  // and will not change after the component mounts.
   useEffect(() => {
     if (autoConnect && initConfig?.backendUrl && initConfig?.apiKey) {
       session.connect(initConfig).catch(() => {});
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // ─── Unsaved work protection (P0 6c) ────────────────────────────────────────
+  // Warn before page unload if there is a pending batch queue.
+  // (STT active state is checked separately in AppLayout / AudioPage.)
+  useEffect(() => {
+    function onBeforeUnload(e) {
+      const pending = session.getQueuedCount();
+      if (pending > 0) {
+        e.preventDefault();
+        e.returnValue = '';
+      }
+    }
+    window.addEventListener('beforeunload', onBeforeUnload);
+    return () => window.removeEventListener('beforeunload', onBeforeUnload);
+  }, [session.getQueuedCount]); // getQueuedCount is stable (useCallback [])
+
+  // ─── Split contexts (P2 7b) ─────────────────────────────────────────────────
+  //
+  // Each slice is memoized so that changing one type of state (e.g. sequence on
+  // every caption send) does not cause re-renders in consumers of the other contexts.
+  //
+  // All functions in each slice are stable (useCallback in useSession), so they
+  // do NOT appear in the useMemo dependency arrays — they never change.
+  // Only the state values that may change are listed as deps.
+
+  const connectionValue = useMemo(() => ({
+    // State
+    connected:       session.connected,
+    backendUrl:      session.backendUrl,
+    apiKey:          session.apiKey,
+    streamKey:       session.streamKey,
+    startedAt:       session.startedAt,
+    micHolder:       session.micHolder,
+    clientId:        session.clientId,
+    graphicsEnabled: session.graphicsEnabled,
+    healthStatus:    session.healthStatus,
+    latencyMs:       session.latencyMs,
+    reconnecting:    session.reconnecting,
+    // Methods (stable via useCallback)
+    connect:              session.connect,
+    disconnect:           session.disconnect,
+    reconnectNow:         session.reconnectNow,
+    checkHealth:          session.checkHealth,
+    claimMic:             session.claimMic,
+    releaseMic:           session.releaseMic,
+    getPersistedConfig:   session.getPersistedConfig,
+    getAutoConnect:       session.getAutoConnect,
+    setAutoConnect:       session.setAutoConnect,
+    clearPersistedConfig: session.clearPersistedConfig,
+  }), [ // eslint-disable-line react-hooks/exhaustive-deps
+    session.connected, session.backendUrl, session.apiKey, session.streamKey,
+    session.startedAt, session.micHolder, session.graphicsEnabled,
+    session.healthStatus, session.latencyMs, session.reconnecting,
+    // Functions omitted from deps — they are stable (useCallback []) in useSession
+  ]);
+
+  const captionValue = useMemo(() => ({
+    // State
+    sequence:    session.sequence,
+    syncOffset:  session.syncOffset,
+    // Methods (stable via useCallback)
+    send:            session.send,
+    sendBatch:       session.sendBatch,
+    construct:       session.construct,
+    flushBatch:      session.flushBatch,
+    sync:            session.sync,
+    heartbeat:       session.heartbeat,
+    updateSequence:  session.updateSequence,
+    updateTargets:   session.updateTargets,
+    getQueuedCount:  session.getQueuedCount,
+  }), [ // eslint-disable-line react-hooks/exhaustive-deps
+    session.sequence, session.syncOffset,
+    // Functions omitted — stable via useCallback
+  ]);
+
+  // SessionApiContext: all methods are stable, so this object never changes.
+  const sessionApiValue = useMemo(() => ({
+    getStats:         session.getStats,
+    eraseSelf:        session.eraseSelf,
+    listFiles:        session.listFiles,
+    getFileDownloadUrl: session.getFileDownloadUrl,
+    deleteFile:       session.deleteFile,
+    uploadImage:      session.uploadImage,
+    listImages:       session.listImages,
+    deleteImage:      session.deleteImage,
+    getImageViewUrl:  session.getImageViewUrl,
+    getDskUrl:        session.getDskUrl,
+    listIcons:        session.listIcons,
+    uploadIcon:       session.uploadIcon,
+    deleteIcon:       session.deleteIcon,
+    configureRelay:   session.configureRelay,
+    updateRelay:      session.updateRelay,
+    stopRelaySlot:    session.stopRelaySlot,
+    stopRelay:        session.stopRelay,
+    getRelayStatus:   session.getRelayStatus,
+    getRelayHistory:  session.getRelayHistory,
+    setRelayActive:   session.setRelayActive,
+    getYouTubeConfig: session.getYouTubeConfig,
+  }), []); // eslint-disable-line react-hooks/exhaustive-deps -- all methods are stable
+
   return (
     <LangProvider>
       <SentLogContext.Provider value={sentLog}>
         <SessionContext.Provider value={session}>
-          <FileProvider>
-            <ToastProvider>
-              {children}
-            </ToastProvider>
-          </FileProvider>
+          <ConnectionContext.Provider value={connectionValue}>
+            <CaptionContext.Provider value={captionValue}>
+              <SessionApiContext.Provider value={sessionApiValue}>
+                <FileProvider>
+                  <ToastProvider>
+                    {children}
+                  </ToastProvider>
+                </FileProvider>
+              </SessionApiContext.Provider>
+            </CaptionContext.Provider>
+          </ConnectionContext.Provider>
         </SessionContext.Provider>
       </SentLogContext.Provider>
     </LangProvider>

--- a/packages/lcyt-web/src/contexts/CaptionContext.jsx
+++ b/packages/lcyt-web/src/contexts/CaptionContext.jsx
@@ -1,0 +1,19 @@
+import { createContext, useContext } from 'react';
+
+/**
+ * CaptionContext — provides caption-sending state and methods.
+ *
+ * Split from SessionContext so that components that only deal with sending
+ * (sequence counter, sync offset) re-render independently of connection state.
+ *
+ * Slice: sequence, syncOffset,
+ *        send, sendBatch, construct, flushBatch, sync, heartbeat,
+ *        updateSequence, updateTargets, getQueuedCount
+ */
+export const CaptionContext = createContext(null);
+
+export function useCaptionContext() {
+  const ctx = useContext(CaptionContext);
+  if (!ctx) throw new Error('useCaptionContext must be used within AppProviders');
+  return ctx;
+}

--- a/packages/lcyt-web/src/contexts/ConnectionContext.jsx
+++ b/packages/lcyt-web/src/contexts/ConnectionContext.jsx
@@ -1,0 +1,20 @@
+import { createContext, useContext } from 'react';
+
+/**
+ * ConnectionContext — provides connection state and connect/disconnect methods.
+ *
+ * Split from SessionContext to prevent caption-send re-renders (sequence updates)
+ * from triggering UI components that only care about connection status.
+ *
+ * Slice: connected, backendUrl, apiKey, streamKey, startedAt, micHolder, clientId,
+ *        graphicsEnabled, healthStatus, latencyMs, reconnecting,
+ *        connect, disconnect, reconnectNow, checkHealth, claimMic, releaseMic,
+ *        getPersistedConfig, getAutoConnect, setAutoConnect, clearPersistedConfig
+ */
+export const ConnectionContext = createContext(null);
+
+export function useConnectionContext() {
+  const ctx = useContext(ConnectionContext);
+  if (!ctx) throw new Error('useConnectionContext must be used within AppProviders');
+  return ctx;
+}

--- a/packages/lcyt-web/src/contexts/SessionApiContext.jsx
+++ b/packages/lcyt-web/src/contexts/SessionApiContext.jsx
@@ -1,0 +1,26 @@
+import { createContext, useContext } from 'react';
+
+/**
+ * SessionApiContext — provides stable API methods that don't change with session state.
+ *
+ * Split from SessionContext so that components doing API calls (stats, files, RTMP,
+ * images, icons, relay) are not affected by connection or caption state changes.
+ *
+ * All methods in this slice access internal refs and are stable across renders
+ * (wrapped with useCallback(fn, []) in useSession).
+ *
+ * Slice: getStats, eraseSelf,
+ *        listFiles, getFileDownloadUrl, deleteFile,
+ *        uploadImage, listImages, deleteImage, getImageViewUrl, getDskUrl,
+ *        listIcons, uploadIcon, deleteIcon,
+ *        configureRelay, updateRelay, stopRelaySlot, stopRelay,
+ *        getRelayStatus, getRelayHistory, setRelayActive,
+ *        getYouTubeConfig
+ */
+export const SessionApiContext = createContext(null);
+
+export function useSessionApiContext() {
+  const ctx = useContext(SessionApiContext);
+  if (!ctx) throw new Error('useSessionApiContext must be used within AppProviders');
+  return ctx;
+}

--- a/packages/lcyt-web/src/hooks/useSession.js
+++ b/packages/lcyt-web/src/hooks/useSession.js
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
 import { BackendCaptionSender } from 'lcyt/backend';
 import { getEnabledTargets } from '../lib/targetConfig';
 import { createApi } from '../lib/api';
@@ -44,11 +44,18 @@ export function useSession({
   // 'unknown' | 'checking' | 'ok' | 'unreachable'
   const [healthStatus, setHealthStatus] = useState('unknown');
   const [latencyMs, setLatencyMs] = useState(null);
+  // Auto-reconnect state
+  const [reconnecting, setReconnecting] = useState(false);
 
   const senderRef = useRef(null);
   const esRef = useRef(null);
   // Keep backendUrl in a ref so claimMic/releaseMic always have the current value
   const backendUrlRef = useRef('');
+
+  // Reconnect state (all mutable, stored in refs to avoid stale closures in timers)
+  const reconnectTimerRef    = useRef(null);
+  const reconnectAttemptsRef = useRef(0);
+  const reconnectConfigRef   = useRef(null); // stores last successful connect config
 
   // Authenticated fetch helper — always reads current token + URL from refs
   const api = createApi(senderRef, backendUrlRef);
@@ -57,12 +64,13 @@ export function useSession({
   const cbs = useRef({});
   cbs.current = { onConnected, onDisconnected, onCaptionSent, onCaptionResult, onCaptionError, onSyncUpdated, onError, onBatchSent };
 
-  // Close EventSource on unmount
-  useEffect(() => () => { esRef.current?.close(); }, []);
+  // Close EventSource + cancel reconnect on unmount
+  useEffect(() => () => {
+    esRef.current?.close();
+    if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current);
+  }, []);
 
   // Periodic health poll while connected.
-  // checkHealth only accesses refs and stable setState functions, so omitting it
-  // from the dependency array is safe — the interval always calls the current version.
   useEffect(() => {
     if (!connected) return;
     const id = setInterval(() => { checkHealth().catch(() => {}); }, 30_000);
@@ -71,33 +79,100 @@ export function useSession({
 
   // ─── Persistence ────────────────────────────────────────
 
-  function getPersistedConfig() {
+  const getPersistedConfig = useCallback(function getPersistedConfig() {
     try {
       const raw = localStorage.getItem(CONFIG_KEY);
       return raw ? JSON.parse(raw) : {};
     } catch { return {}; }
-  }
+  }, []);
 
-  function saveConfig(cfg) {
+  const saveConfig = useCallback(function saveConfig(cfg) {
     try { localStorage.setItem(CONFIG_KEY, JSON.stringify(cfg)); } catch {}
-  }
+  }, []);
 
-  function getAutoConnect() {
+  const getAutoConnect = useCallback(function getAutoConnect() {
     try { return localStorage.getItem(AUTO_CONNECT_KEY) === 'true'; } catch { return false; }
-  }
+  }, []);
 
-  function setAutoConnect(value) {
+  const setAutoConnect = useCallback(function setAutoConnect(value) {
     try { localStorage.setItem(AUTO_CONNECT_KEY, value ? 'true' : 'false'); } catch {}
-  }
+  }, []);
 
-  function clearPersistedConfig() {
+  const clearPersistedConfig = useCallback(function clearPersistedConfig() {
     try { localStorage.removeItem(CONFIG_KEY); } catch {}
     try { localStorage.removeItem(AUTO_CONNECT_KEY); } catch {}
-  }
+  }, []);
+
+  // ─── Auto-reconnect helpers ──────────────────────────────
+
+  const _cancelReconnect = useCallback(function _cancelReconnect() {
+    if (reconnectTimerRef.current) {
+      clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+    }
+    reconnectAttemptsRef.current = 0;
+    setReconnecting(false);
+  }, []);
+
+  // Internal disconnect (does NOT cancel pending reconnect).
+  // Called by session_closed SSE event and by _scheduleReconnect on failure.
+  const _disconnectInternal = useCallback(async function _disconnectInternal() {
+    esRef.current?.close();
+    esRef.current = null;
+
+    if (senderRef.current) {
+      try { await senderRef.current.end(); } catch {}
+      senderRef.current = null;
+    }
+    backendUrlRef.current = '';
+
+    setConnected(false);
+    setSequence(0);
+    setSyncOffset(0);
+    setStartedAt(null);
+    setMicHolder(null);
+    setGraphicsEnabled(false);
+
+    cbs.current.onDisconnected?.();
+  }, []);
+
+  // Ref to the latest connect function — avoids stale closure in reconnect timer
+  const connectRef = useRef(null);
+
+  // Ref to the latest _scheduleReconnect — used for recursive retry in timer callback
+  const scheduleReconnectRef = useRef(null);
+
+  const _scheduleReconnect = useCallback(function _scheduleReconnect(cfg) {
+    if (!cfg) return;
+    if (reconnectTimerRef.current) {
+      clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+    }
+    // Exponential backoff: 2s → 4s → 8s → 16s → 30s max
+    const delay = Math.min(30_000, 2_000 * Math.pow(2, reconnectAttemptsRef.current));
+    reconnectConfigRef.current = cfg;
+    setReconnecting(true);
+    reconnectTimerRef.current = setTimeout(function () {
+      reconnectTimerRef.current = null;
+      connectRef.current(reconnectConfigRef.current)
+        .then(function () {
+          reconnectAttemptsRef.current = 0;
+          // reconnectConfigRef is kept for future reconnects (set again on connect success)
+          setReconnecting(false);
+        })
+        .catch(function () {
+          reconnectAttemptsRef.current++;
+          scheduleReconnectRef.current(reconnectConfigRef.current);
+        });
+    }, delay);
+  }, []); // stable: all state accessed via refs
+
+  // Keep the refs up to date on every render
+  scheduleReconnectRef.current = _scheduleReconnect;
 
   // ─── SSE ────────────────────────────────────────────────
 
-  function openEventSource(url, token) {
+  const openEventSource = useCallback(function openEventSource(url, token) {
     esRef.current?.close();
     const es = new EventSource(`${url}/events?token=${encodeURIComponent(token)}`);
     esRef.current = es;
@@ -127,13 +202,17 @@ export function useSession({
     });
 
     es.addEventListener('session_closed', () => {
-      disconnect();
+      // Server terminated the session — disconnect internally then attempt reconnect
+      _disconnectInternal().then(() => {
+        const cfg = reconnectConfigRef.current;
+        if (cfg) scheduleReconnectRef.current(cfg);
+      });
     });
-  }
+  }, [_disconnectInternal]);
 
   // ─── Health check ────────────────────────────────────────
 
-  async function checkHealth(url) {
+  const checkHealth = useCallback(async function checkHealth(url) {
     const target = url ?? backendUrlRef.current;
     if (!target) { setHealthStatus('unknown'); setLatencyMs(null); return false; }
     setHealthStatus('checking');
@@ -157,18 +236,18 @@ export function useSession({
       setLatencyMs(null);
       return false;
     }
-  }
+  }, []);
 
   // ─── Connect / Disconnect ───────────────────────────────
 
-  async function connect({ backendUrl: url, apiKey: key, streamKey: sk } = {}) {
-    if (senderRef.current) await disconnect();
+  const connect = useCallback(async function connect({ backendUrl: url, apiKey: key, streamKey: sk } = {}) {
+    // Disconnect any existing session (internally, without canceling reconnect state)
+    if (senderRef.current) await _disconnectInternal();
 
     // streamKey is optional in the new target-array architecture.
-    // When omitted, the backend uses the targets array for all caption delivery.
     const sender = new BackendCaptionSender({ backendUrl: url, apiKey: key, streamKey: sk ?? null });
 
-    // Build the targets list: parse headers JSON strings into objects for the backend.
+    // Build the targets list
     const rawTargets = getEnabledTargets();
     const targets = rawTargets.map(t => {
       if (t.type === 'youtube') {
@@ -184,24 +263,24 @@ export function useSession({
 
     await sender.start(targets.length > 0 ? { targets } : {});
 
-    // Ensure we received a server token; rehydrated sessions may yield no
-    // token if the backend didn't re-issue one. Fail fast and surface a
-    // helpful error so the UI can prompt the user to re-open settings.
     if (!sender._token) {
-      try { await sender.end(); } catch {} // best-effort cleanup
+      try { await sender.end(); } catch {}
       const msg = 'No session token received from server; open Settings to re-register.';
       cbs.current.onError?.(msg);
       throw new Error(msg);
     }
 
     // Auto-sync clock with YouTube immediately after connecting.
-    // Failure is non-fatal — connection proceeds with syncOffset=0.
     try { await sender.sync(); } catch {}
 
     senderRef.current = sender;
     backendUrlRef.current = url;
 
+    // Store config for auto-reconnect (cleared on manual disconnect)
+    reconnectConfigRef.current = { backendUrl: url, apiKey: key, streamKey: sk ?? null };
+
     setConnected(true);
+    setReconnecting(false);
     setHealthStatus('ok');
     setBackendUrl(url);
     setApiKey(key);
@@ -211,8 +290,6 @@ export function useSession({
     setStartedAt(sender.startedAt);
     setGraphicsEnabled(sender.graphicsEnabled === true);
 
-    // Persist backendUrl and apiKey; streamKey is omitted when not provided
-    // since targets are now managed in the CC modal.
     const cfg = { backendUrl: url, apiKey: key };
     if (sk) cfg.streamKey = sk;
     saveConfig(cfg);
@@ -224,27 +301,29 @@ export function useSession({
       backendUrl: url,
       token: sender._token,
     });
-  }
+  }, [_disconnectInternal, openEventSource, saveConfig]);
 
-  async function disconnect() {
+  // Keep connectRef current for the reconnect timer callback
+  connectRef.current = connect;
+
+  // Public disconnect — cancels any pending auto-reconnect
+  const disconnect = useCallback(async function disconnect() {
+    _cancelReconnect();
+    reconnectConfigRef.current = null;
     if (!senderRef.current) return;
+    await _disconnectInternal();
+  }, [_cancelReconnect, _disconnectInternal]);
 
-    esRef.current?.close();
-    esRef.current = null;
-
-    try { await senderRef.current.end(); } catch {}
-    senderRef.current = null;
-    backendUrlRef.current = '';
-
-    setConnected(false);
-    setSequence(0);
-    setSyncOffset(0);
-    setStartedAt(null);
-    setMicHolder(null);
-    setGraphicsEnabled(false);
-
-    cbs.current.onDisconnected?.();
-  }
+  // Manual "reconnect now" — used by the ReconnectBanner button
+  const reconnectNow = useCallback(function reconnectNow() {
+    const cfg = reconnectConfigRef.current;
+    if (!cfg) return;
+    _cancelReconnect();
+    connect(cfg).catch(function () {
+      reconnectAttemptsRef.current++;
+      scheduleReconnectRef.current(cfg);
+    });
+  }, [_cancelReconnect, connect]);
 
   // ─── Caption sending ────────────────────────────────────
 
@@ -260,43 +339,43 @@ export function useSession({
     return { hasTranslations, captionLang, captionTranslationText, showOriginal, otherTranslations };
   }
 
-  async function send(text, timestamp, opts) {
+  const send = useCallback(async function send(text, timestamp, opts) {
     if (!senderRef.current) throw new Error('Not connected');
     const data = await senderRef.current.send(text, timestamp, opts);
     const meta = _translationMeta(opts);
     cbs.current.onCaptionSent?.({ requestId: data.requestId, text, pending: true, ...meta });
     return data;
-  }
+  }, []);
 
-  async function sendBatch(texts) {
+  const sendBatch = useCallback(async function sendBatch(texts) {
     if (!senderRef.current) throw new Error('Not connected');
     const data = await senderRef.current.sendBatch(texts.map(text => ({ text })));
     texts.forEach(text => cbs.current.onCaptionSent?.({ requestId: data.requestId, text, pending: true }));
     return data;
-  }
+  }, []);
 
   // ─── Sync / Heartbeat ───────────────────────────────────
 
-  async function sync() {
+  const sync = useCallback(async function sync() {
     if (!senderRef.current) throw new Error('Not connected');
     const data = await senderRef.current.sync();
     setSyncOffset(senderRef.current.syncOffset);
     return data;
-  }
+  }, []);
 
   // ─── Batch/Construct Logic ──────────────────────────────
 
   const batchBufferRef = useRef([]); // [{ text, requestId }]
-  const batchTimerRef = useRef(null);
+  const batchTimerRef  = useRef(null);
 
-  function getBatchIntervalMs() {
+  const getBatchIntervalMs = useCallback(function getBatchIntervalMs() {
     try {
       const v = parseInt(localStorage.getItem(KEYS.captions.batchInterval) || '0', 10);
       return Math.min(20, Math.max(0, v)) * 1000;
     } catch { return 0; }
-  }
+  }, []);
 
-  async function flushBatch() {
+  const flushBatch = useCallback(async function flushBatch() {
     const items = batchBufferRef.current.slice();
     batchBufferRef.current = [];
     if (batchTimerRef.current) { clearTimeout(batchTimerRef.current); batchTimerRef.current = null; }
@@ -306,50 +385,53 @@ export function useSession({
 
     try {
       const data = await senderRef.current.sendBatch(); // drains sender queue
-      // Notify host that the temp ids now map to the real requestId
       cbs.current.onBatchSent?.({ tempIds: items.map(i => i.requestId), requestId: data.requestId, count: data.count });
       return data;
     } catch (err) {
-      // Mark entries as errored via callback
       items.forEach(i => cbs.current.onCaptionError?.({ requestId: i.requestId, error: err.message }));
       throw err;
     }
-  }
+  }, []);
 
-  // Add a caption to the server-side batch queue (sender.construct)
-  async function construct(text, timestamp, opts) {
+  // Keep a ref to the latest flushBatch so construct's timer callback always calls the current version
+  const flushBatchRef = useRef(flushBatch);
+  flushBatchRef.current = flushBatch;
+
+  const construct = useCallback(async function construct(text, timestamp, opts) {
     if (!text || typeof text !== 'string') return 0;
     if (!senderRef.current) throw new Error('Not connected');
 
     const intervalMs = getBatchIntervalMs();
-    // Immediate send if batching is disabled
     if (intervalMs === 0) {
-      const data = await send(text, timestamp, opts);
+      // Immediate send if batching is disabled
+      const data = await sendRef.current(text, timestamp, opts);
       return data;
     }
 
     const tempId = 'q-' + Math.random().toString(36).slice(2);
     const meta = _translationMeta(opts);
-    // Tell host a pending item exists
     cbs.current.onCaptionSent?.({ requestId: tempId, text, pending: true, ...meta });
-    // Push into sender queue
     senderRef.current.construct(text, timestamp);
     batchBufferRef.current.push({ text, requestId: tempId });
 
     if (!batchTimerRef.current) {
-      batchTimerRef.current = setTimeout(() => { flushBatch().catch(() => {}); }, intervalMs);
+      batchTimerRef.current = setTimeout(() => { flushBatchRef.current().catch(() => {}); }, intervalMs);
     }
 
     return { tempId };
-  }
+  }, [getBatchIntervalMs]);
 
-  function getQueuedCount() {
+  // Keep a ref so construct's timer callback always gets the latest send
+  const sendRef = useRef(send);
+  sendRef.current = send;
+
+  const getQueuedCount = useCallback(function getQueuedCount() {
     return batchBufferRef.current.length;
-  }
+  }, []);
 
   // ─── Mic soft lock ──────────────────────────────────────
 
-  async function _postMic(action) {
+  const _postMic = useCallback(async function _postMic(action) {
     const token = senderRef.current?._token;
     const url = backendUrlRef.current;
     if (!token || !url) return;
@@ -363,12 +445,12 @@ export function useSession({
         body: JSON.stringify({ action, clientId: CLIENT_ID }),
       });
     } catch { /* soft lock — ignore network errors */ }
-  }
+  }, []);
 
-  function claimMic() { return _postMic('claim'); }
-  function releaseMic() { return _postMic('release'); }
+  const claimMic   = useCallback(function claimMic()   { return _postMic('claim');   }, [_postMic]);
+  const releaseMic = useCallback(function releaseMic() { return _postMic('release'); }, [_postMic]);
 
-  async function heartbeat() {
+  const heartbeat = useCallback(async function heartbeat() {
     if (!senderRef.current) throw new Error('Not connected');
     const t0 = Date.now();
     const data = await senderRef.current.heartbeat();
@@ -376,26 +458,16 @@ export function useSession({
     setSequence(senderRef.current.sequence);
     setSyncOffset(senderRef.current.syncOffset);
     return { ...data, roundTripTime };
-  }
+  }, []);
 
-  // Update session fields on the backend (e.g. sequence)
-  async function updateSequence(seq) {
+  const updateSequence = useCallback(async function updateSequence(seq) {
     if (!senderRef.current) throw new Error('Not connected');
     await senderRef.current.updateSession({ sequence: seq });
-    // Mirror locally
     setSequence(Number(seq));
-  }
+  }, []);
 
-  /**
-   * Push an updated targets list to the backend session.
-   * Each entry from localStorage has headers as a raw JSON string;
-   * we parse them here before sending to the backend.
-   *
-   * @param {Array} rawTargets - Array from getEnabledTargets() (headers as JSON string)
-   * @returns {Promise<void>}
-   */
-  async function updateTargets(rawTargets) {
-    if (!senderRef.current) return; // not connected — localStorage already has the new config
+  const updateTargets = useCallback(async function updateTargets(rawTargets) {
+    if (!senderRef.current) return;
     const targets = rawTargets.map(t => {
       if (t.type === 'youtube') {
         return { id: t.id, type: 'youtube', streamKey: t.streamKey };
@@ -404,8 +476,6 @@ export function useSession({
         return { id: t.id, type: 'viewer', viewerKey: t.viewerKey };
       }
       let headers = {};
-      // headers is stored as a raw JSON string in localStorage; parse it here.
-      // Invalid JSON falls back to empty headers (backend ignores unrecognised keys).
       if (t.headers) {
         try { headers = JSON.parse(t.headers); } catch (err) {
           if (import.meta.env.DEV) console.warn('[updateTargets] Could not parse headers JSON for target', t.id, err?.message);
@@ -414,11 +484,11 @@ export function useSession({
       return { id: t.id, type: 'generic', url: t.url, headers };
     });
     await senderRef.current.updateSession({ targets });
-  }
-
+  }, []);
 
   // ─── Image / graphics management ────────────────────────
-  async function uploadImage(file, shorthand) {
+
+  const uploadImage = useCallback(async function uploadImage(file, shorthand) {
     const token = senderRef.current?._token;
     if (!token) throw new Error('Not connected');
     const url = backendUrlRef.current;
@@ -435,18 +505,18 @@ export function useSession({
       throw new Error(err.error || `Upload failed (${res.status})`);
     }
     return res.json();
-  }
+  }, []);
 
-  async function listImages() {
+  const listImages = useCallback(async function listImages() {
     const token = senderRef.current?._token;
     if (!token) throw new Error('Not connected');
     const url = backendUrlRef.current;
     const res = await fetch(`${url}/images`, { headers: { Authorization: `Bearer ${token}` } });
     if (!res.ok) throw new Error(`Failed to list images (${res.status})`);
     return res.json();
-  }
+  }, []);
 
-  async function deleteImage(id) {
+  const deleteImage = useCallback(async function deleteImage(id) {
     const token = senderRef.current?._token;
     if (!token) throw new Error('Not connected');
     const url = backendUrlRef.current;
@@ -456,15 +526,15 @@ export function useSession({
     });
     if (!res.ok) throw new Error(`Failed to delete image (${res.status})`);
     return res.json();
-  }
+  }, []);
 
-  function getImageViewUrl(id) {
+  const getImageViewUrl = useCallback(function getImageViewUrl(id) {
     const url = backendUrlRef.current;
     if (!url) return null;
     return `${url}/images/${id}`;
-  }
+  }, []);
 
-  function getDskUrl(opts = {}) {
+  const getDskUrl = useCallback(function getDskUrl(opts = {}) {
     const key = senderRef.current?.apiKey;
     const serverUrl = backendUrlRef.current;
     if (!key || !serverUrl) return null;
@@ -472,86 +542,56 @@ export function useSession({
     if (opts.cc) params.set('cc', '1');
     if (opts.bg) params.set('bg', opts.bg);
     return `/dsk/${key}?${params}`;
-  }
+  }, []);
 
   // ─── Self-service account management ────────────────────
 
-  async function getStats() {
+  const getStats = useCallback(async function getStats() {
     return api.get('/stats');
-  }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  /**
-   * List backend caption files for the current session's API key.
-   */
-  async function listFiles() {
+  const eraseSelf = useCallback(async function eraseSelf() {
+    const data = await api.del('/stats');
+    await disconnect();
+    clearPersistedConfig();
+    return data;
+  }, [disconnect, clearPersistedConfig]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const listFiles = useCallback(async function listFiles() {
     return api.get('/file');
-  }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  /**
-   * Get the download URL for a backend caption file.
-   */
-  function getFileDownloadUrl(fileId) {
+  const getFileDownloadUrl = useCallback(function getFileDownloadUrl(fileId) {
     const token = senderRef.current?._token;
     const url = backendUrlRef.current;
     if (!token || !url) return null;
     return `${url}/file/${fileId}?token=${encodeURIComponent(token)}`;
-  }
+  }, []);
 
-  /**
-   * Delete a backend caption file.
-   */
-  async function deleteFile(fileId) {
+  const deleteFile = useCallback(async function deleteFile(fileId) {
     return api.del(`/file/${fileId}`);
-  }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // ─── Icons ──────────────────────────────────────────────
 
-  /**
-   * List icons uploaded for the current API key.
-   * @returns {Promise<{ icons: object[] }>}
-   */
-  async function listIcons() {
+  const listIcons = useCallback(async function listIcons() {
     return api.get('/icons');
-  }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  /**
-   * Upload a PNG or SVG icon.
-   * @param {{ filename: string, mimeType: string, data: string }} opts
-   *   data is a base64-encoded string of the file contents.
-   * @returns {Promise<{ ok: boolean, id: number, filename: string, mimeType: string, sizeBytes: number }>}
-   */
-  async function uploadIcon({ filename, mimeType, data }) {
+  const uploadIcon = useCallback(async function uploadIcon({ filename, mimeType, data }) {
     return api.post('/icons', { filename, mimeType, data });
-  }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  /**
-   * Delete an icon by id.
-   * @param {number} iconId
-   */
-  async function deleteIcon(iconId) {
+  const deleteIcon = useCallback(async function deleteIcon(iconId) {
     return api.del(`/icons/${iconId}`, { parseErrorBody: true });
-  }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  /**
-   * GDPR right-to-erasure: anonymises the API key on the backend, disconnects locally,
-   * and clears all persisted config from localStorage.
-   */
-  async function eraseSelf() {
-    const data = await api.del('/stats');
-    // Disconnect locally (SSE already closed by server) and clear saved credentials
-    await disconnect();
-    clearPersistedConfig();
-    return data;
-  }
+  const eraseSelfRef = useRef(eraseSelf);
+  eraseSelfRef.current = eraseSelf;
 
   // ─── RTMP relay ─────────────────────────────────────────
 
-  /**
-   * Configure (create / replace) the relay target.
-   * Requires relay_allowed on the API key.
-   * @param {{ slot?: number, targetUrl: string, targetName?: string|null, captionMode?: string, scale?: string, fps?: number, videoBitrate?: string, audioBitrate?: string }} opts
-   */
-  async function configureRelay({ slot = 1, targetUrl, targetName = null, captionMode = 'http', scale, fps, videoBitrate, audioBitrate } = {}) {
+  const configureRelay = useCallback(async function configureRelay({ slot = 1, targetUrl, targetName = null, captionMode = 'http', scale, fps, videoBitrate, audioBitrate } = {}) {
     if (!targetUrl) throw new Error('targetUrl is required');
     const body = { slot, targetUrl, targetName, captionMode };
     if (scale) body.scale = scale;
@@ -559,13 +599,9 @@ export function useSession({
     if (videoBitrate) body.videoBitrate = videoBitrate;
     if (audioBitrate) body.audioBitrate = audioBitrate;
     return api.post('/stream', body);
-  }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  /**
-   * Update an existing relay slot.
-   * @param {{ slot: number, targetUrl: string, targetName?: string|null, captionMode?: string, scale?: string, fps?: number, videoBitrate?: string, audioBitrate?: string }} opts
-   */
-  async function updateRelay({ slot = 1, targetUrl, targetName = null, captionMode = 'http', scale, fps, videoBitrate, audioBitrate } = {}) {
+  const updateRelay = useCallback(async function updateRelay({ slot = 1, targetUrl, targetName = null, captionMode = 'http', scale, fps, videoBitrate, audioBitrate } = {}) {
     if (!targetUrl) throw new Error('targetUrl is required');
     const body = { targetUrl, targetName, captionMode };
     if (scale) body.scale = scale;
@@ -573,62 +609,37 @@ export function useSession({
     if (videoBitrate) body.videoBitrate = videoBitrate;
     if (audioBitrate) body.audioBitrate = audioBitrate;
     return api.put(`/stream/${slot}`, body);
-  }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  /**
-   * Stop and remove a specific relay slot.
-   * @param {{ slot: number }} opts
-   */
-  async function stopRelaySlot({ slot = 1 } = {}) {
+  const stopRelaySlot = useCallback(async function stopRelaySlot({ slot = 1 } = {}) {
     return api.del(`/stream/${slot}`, { parseErrorBody: true });
-  }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  /**
-   * Stop all relay slots and drop the nginx publisher.
-   */
-  async function stopRelay() {
+  const stopRelay = useCallback(async function stopRelay() {
     return api.del('/stream', { parseErrorBody: true });
-  }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  /**
-   * Fetch the YouTube OAuth client ID configured on the backend.
-   * @returns {Promise<{ clientId: string }>}
-   */
-  async function getYouTubeConfig() {
+  const getYouTubeConfig = useCallback(async function getYouTubeConfig() {
     return api.get('/youtube/config');
-  }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  /**
-   * Get all configured relay slots and which are running.
-   * @returns {{ relays: object[], runningSlots: number[], active: boolean }}
-   */
-  async function getRelayStatus() {
+  const getRelayStatus = useCallback(async function getRelayStatus() {
     return api.get('/stream');
-  }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  /**
-   * Get per-stream RTMP usage history for this API key.
-   * @returns {{ streams: object[] }}
-   */
-  async function getRelayHistory() {
+  const getRelayHistory = useCallback(async function getRelayHistory() {
     return api.get('/stream/history');
-  }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  /**
-   * Set the relay active state for this API key.
-   * When active=true and nginx is currently publishing, fan-out starts immediately.
-   * When active=false, all running ffmpeg processes are stopped.
-   * @param {boolean} active
-   * @returns {Promise<{ ok: boolean, active: boolean }>}
-   */
-  async function setRelayActive(active) {
+  const setRelayActive = useCallback(async function setRelayActive(active) {
     return api.put('/stream/active', { active });
-  }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   return {
     connected, sequence, syncOffset, backendUrl, apiKey, streamKey, startedAt,
     micHolder, clientId: CLIENT_ID, graphicsEnabled,
     healthStatus, latencyMs, checkHealth,
+    reconnecting, reconnectNow,
     connect, disconnect, send, sendBatch, construct, flushBatch, sync, heartbeat, updateSequence, updateTargets,
     claimMic, releaseMic,
     getStats, eraseSelf,
@@ -638,5 +649,6 @@ export function useSession({
     configureRelay, updateRelay, stopRelaySlot, stopRelay, getRelayStatus, getRelayHistory, setRelayActive,
     getYouTubeConfig,
     getPersistedConfig, getAutoConnect, setAutoConnect, clearPersistedConfig,
+    getQueuedCount,
   };
 }

--- a/packages/lcyt-web/src/main.jsx
+++ b/packages/lcyt-web/src/main.jsx
@@ -9,24 +9,15 @@ import './styles/components.css';
 import { AppLayout } from './App';
 import { AppProviders } from './contexts/AppProviders';
 import { SidebarLayout } from './components/SidebarLayout';
-import { DashboardPage } from './components/DashboardPage';
 import { AudioPage } from './components/AudioPage';
-import { SettingsPage } from './components/SettingsPage';
-import { EmbedAudioPage } from './components/EmbedAudioPage';
-import { EmbedInputPage } from './components/EmbedInputPage';
-import { EmbedSentLogPage } from './components/EmbedSentLogPage';
-import { EmbedFileDropPage } from './components/EmbedFileDropPage';
-import { EmbedFilesPage } from './components/EmbedFilesPage';
-import { EmbedSettingsPage } from './components/EmbedSettingsPage';
-import { EmbedRtmpPage } from './components/EmbedRtmpPage';
-import { EmbedViewerPage } from './components/EmbedViewerPage';
-import { LoginPage } from './components/LoginPage';
-import { RegisterPage } from './components/RegisterPage';
-import { ProjectsPage } from './components/ProjectsPage';
-import { AccountPage } from './components/AccountPage';
 
 // --- Lazy-loaded pages (heavy or path-gated) ----------------------------------
 
+// Sidebar routes
+const DashboardPage          = lazy(() => import('./components/DashboardPage').then(m => ({ default: m.DashboardPage })));
+const SettingsPage           = lazy(() => import('./components/SettingsPage').then(m => ({ default: m.SettingsPage })));
+const ProjectsPage           = lazy(() => import('./components/ProjectsPage').then(m => ({ default: m.ProjectsPage })));
+const AccountPage            = lazy(() => import('./components/AccountPage').then(m => ({ default: m.AccountPage })));
 const BroadcastPage          = lazy(() => import('./components/BroadcastPage').then(m => ({ default: m.BroadcastPage })));
 const DskEditorPage          = lazy(() => import('./components/DskEditorPage').then(m => ({ default: m.DskEditorPage })));
 const DskViewportsPage       = lazy(() => import('./components/DskViewportsPage').then(m => ({ default: m.DskViewportsPage })));
@@ -35,10 +26,22 @@ const ProductionCamerasPage  = lazy(() => import('./components/ProductionCameras
 const ProductionMixersPage   = lazy(() => import('./components/ProductionMixersPage').then(m => ({ default: m.ProductionMixersPage })));
 const ProductionBridgesPage  = lazy(() => import('./components/ProductionBridgesPage').then(m => ({ default: m.ProductionBridgesPage })));
 const PlannerPage            = lazy(() => import('./components/PlannerPage').then(m => ({ default: m.PlannerPage })));
+
+// Standalone / path-gated pages
 const SpeechCapturePage      = lazy(() => import('./components/SpeechCapturePage').then(m => ({ default: m.SpeechCapturePage })));
 const DskPage                = lazy(() => import('./components/DskPage').then(m => ({ default: m.DskPage })));
 const DskControlPage         = lazy(() => import('./components/DskControlPage').then(m => ({ default: m.DskControlPage })));
 const ViewerPage             = lazy(() => import('./components/ViewerPage').then(m => ({ default: m.ViewerPage })));
+const LoginPage              = lazy(() => import('./components/LoginPage').then(m => ({ default: m.LoginPage })));
+const RegisterPage           = lazy(() => import('./components/RegisterPage').then(m => ({ default: m.RegisterPage })));
+const EmbedAudioPage         = lazy(() => import('./components/EmbedAudioPage').then(m => ({ default: m.EmbedAudioPage })));
+const EmbedInputPage         = lazy(() => import('./components/EmbedInputPage').then(m => ({ default: m.EmbedInputPage })));
+const EmbedSentLogPage       = lazy(() => import('./components/EmbedSentLogPage').then(m => ({ default: m.EmbedSentLogPage })));
+const EmbedFileDropPage      = lazy(() => import('./components/EmbedFileDropPage').then(m => ({ default: m.EmbedFileDropPage })));
+const EmbedFilesPage         = lazy(() => import('./components/EmbedFilesPage').then(m => ({ default: m.EmbedFilesPage })));
+const EmbedSettingsPage      = lazy(() => import('./components/EmbedSettingsPage').then(m => ({ default: m.EmbedSettingsPage })));
+const EmbedRtmpPage          = lazy(() => import('./components/EmbedRtmpPage').then(m => ({ default: m.EmbedRtmpPage })));
+const EmbedViewerPage        = lazy(() => import('./components/EmbedViewerPage').then(m => ({ default: m.EmbedViewerPage })));
 
 const path = window.location.pathname;
 

--- a/packages/lcyt-web/src/main.jsx
+++ b/packages/lcyt-web/src/main.jsx
@@ -25,24 +25,24 @@ import { RegisterPage } from './components/RegisterPage';
 import { ProjectsPage } from './components/ProjectsPage';
 import { AccountPage } from './components/AccountPage';
 
-// ─── Lazy-loaded pages (heavy or path-gated) ──────────────────────────────────
+// --- Lazy-loaded pages (heavy or path-gated) ----------------------------------
 
-const BroadcastPage        = lazy(() => import('./components/BroadcastPage').then(m => ({ default: m.BroadcastPage })));
-const DskEditorPage        = lazy(() => import('./components/DskEditorPage').then(m => ({ default: m.DskEditorPage })));
-const DskViewportsPage     = lazy(() => import('./components/DskViewportsPage').then(m => ({ default: m.DskViewportsPage })));
+const BroadcastPage          = lazy(() => import('./components/BroadcastPage').then(m => ({ default: m.BroadcastPage })));
+const DskEditorPage          = lazy(() => import('./components/DskEditorPage').then(m => ({ default: m.DskEditorPage })));
+const DskViewportsPage       = lazy(() => import('./components/DskViewportsPage').then(m => ({ default: m.DskViewportsPage })));
 const ProductionOperatorPage = lazy(() => import('./components/ProductionOperatorPage').then(m => ({ default: m.ProductionOperatorPage })));
 const ProductionCamerasPage  = lazy(() => import('./components/ProductionCamerasPage').then(m => ({ default: m.ProductionCamerasPage })));
 const ProductionMixersPage   = lazy(() => import('./components/ProductionMixersPage').then(m => ({ default: m.ProductionMixersPage })));
 const ProductionBridgesPage  = lazy(() => import('./components/ProductionBridgesPage').then(m => ({ default: m.ProductionBridgesPage })));
-const PlannerPage          = lazy(() => import('./components/PlannerPage').then(m => ({ default: m.PlannerPage })));
-const SpeechCapturePage    = lazy(() => import('./components/SpeechCapturePage').then(m => ({ default: m.SpeechCapturePage })));
-const DskPage              = lazy(() => import('./components/DskPage').then(m => ({ default: m.DskPage })));
-const DskControlPage       = lazy(() => import('./components/DskControlPage').then(m => ({ default: m.DskControlPage })));
-const ViewerPage           = lazy(() => import('./components/ViewerPage').then(m => ({ default: m.ViewerPage })));
+const PlannerPage            = lazy(() => import('./components/PlannerPage').then(m => ({ default: m.PlannerPage })));
+const SpeechCapturePage      = lazy(() => import('./components/SpeechCapturePage').then(m => ({ default: m.SpeechCapturePage })));
+const DskPage                = lazy(() => import('./components/DskPage').then(m => ({ default: m.DskPage })));
+const DskControlPage         = lazy(() => import('./components/DskControlPage').then(m => ({ default: m.DskControlPage })));
+const ViewerPage             = lazy(() => import('./components/ViewerPage').then(m => ({ default: m.ViewerPage })));
 
 const path = window.location.pathname;
 
-// ─── Standalone pages (no sidebar, no shared session context) ─────────────────
+// --- Standalone pages (no sidebar, no shared session context) -----------------
 
 function isStandalonePath(p) {
   return (
@@ -62,23 +62,23 @@ function getStandalonePage() {
     const sessionId = path.split('/')[2];
     page = <SpeechCapturePage sessionId={sessionId} />;
   } else if (path.startsWith('/embed/audio'))     page = <EmbedAudioPage />;
-  else if (path.startsWith('/embed/input'))     page = <EmbedInputPage />;
-  else if (path.startsWith('/embed/sentlog'))   page = <EmbedSentLogPage />;
-  else if (path.startsWith('/embed/file-drop')) page = <EmbedFileDropPage />;
-  else if (path.startsWith('/embed/files'))     page = <EmbedFilesPage />;
-  else if (path.startsWith('/embed/settings'))  page = <EmbedSettingsPage />;
-  else if (path.startsWith('/embed/rtmp'))      page = <EmbedRtmpPage />;
-  else if (path.startsWith('/embed/viewer'))    page = <EmbedViewerPage />;
-  else if (path.startsWith('/dsk-control/'))    page = <DskControlPage />;
-  else if (path.startsWith('/dsk/'))            page = <DskPage />;
-  else if (path.startsWith('/view/'))           page = <ViewerPage />;
-  else if (path.startsWith('/login'))           page = <LoginPage />;
-  else if (path.startsWith('/register'))        page = <RegisterPage />;
+  else if (path.startsWith('/embed/input'))        page = <EmbedInputPage />;
+  else if (path.startsWith('/embed/sentlog'))      page = <EmbedSentLogPage />;
+  else if (path.startsWith('/embed/file-drop'))    page = <EmbedFileDropPage />;
+  else if (path.startsWith('/embed/files'))        page = <EmbedFilesPage />;
+  else if (path.startsWith('/embed/settings'))     page = <EmbedSettingsPage />;
+  else if (path.startsWith('/embed/rtmp'))         page = <EmbedRtmpPage />;
+  else if (path.startsWith('/embed/viewer'))       page = <EmbedViewerPage />;
+  else if (path.startsWith('/dsk-control/'))       page = <DskControlPage />;
+  else if (path.startsWith('/dsk/'))               page = <DskPage />;
+  else if (path.startsWith('/view/'))              page = <ViewerPage />;
+  else if (path.startsWith('/login'))              page = <LoginPage />;
+  else if (path.startsWith('/register'))           page = <RegisterPage />;
   else page = <SidebarApp />;
   return <Suspense fallback={null}>{page}</Suspense>;
 }
 
-// ─── Stub page for routes not yet fully implemented ───────────────────────────
+// --- Stub page for routes not yet fully implemented ---------------------------
 
 function StubPage({ icon, title, description }) {
   return (
@@ -90,7 +90,7 @@ function StubPage({ icon, title, description }) {
   );
 }
 
-// ─── Main sidebar app ─────────────────────────────────────────────────────────
+// --- Main sidebar app ---------------------------------------------------------
 
 function SidebarApp() {
   return (
@@ -114,7 +114,7 @@ function SidebarApp() {
             <Route path="/projects" component={ProjectsPage} />
             <Route path="/account" component={AccountPage} />
             <Route path="/settings" component={SettingsPage} />
-            {/* Legacy URL aliases — redirect to sidebar equivalents */}
+            {/* Legacy URL aliases */}
             <Route path="/dsk-editor"><Redirect to="/graphics/editor" /></Route>
             <Route path="/dsk-viewports"><Redirect to="/graphics/viewports" /></Route>
             {/* Fallback */}
@@ -127,7 +127,7 @@ function SidebarApp() {
   );
 }
 
-// ─── Entry point ──────────────────────────────────────────────────────────────
+// --- Entry point --------------------------------------------------------------
 
 migrateStorageKeys();
 
@@ -140,4 +140,3 @@ createRoot(document.getElementById('app')).render(
     {root}
   </StrictMode>
 );
-

--- a/packages/lcyt-web/src/styles/sidebar.css
+++ b/packages/lcyt-web/src/styles/sidebar.css
@@ -309,6 +309,39 @@
   display: flex;
 }
 
+/* ─── Reconnect banner ───────────────────────────────────── */
+
+.reconnect-banner {
+  background: color-mix(in srgb, var(--color-warning) 12%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-warning) 30%, transparent);
+  color: var(--color-warning);
+  padding: 7px 16px;
+  font-size: 12px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+  z-index: 10;
+}
+
+.reconnect-banner__icon { flex-shrink: 0; }
+
+.reconnect-banner__msg { flex: 1; }
+
+.reconnect-banner__btn {
+  background: none;
+  border: 1px solid currentColor;
+  color: inherit;
+  border-radius: 4px;
+  padding: 3px 10px;
+  font-size: 12px;
+  font-family: var(--font-ui);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 0.12s;
+}
+.reconnect-banner__btn:hover { background: rgba(255, 255, 255, 0.1); }
+
 /* ─── Placeholder / stub pages ───────────────────────────── */
 
 .stub-page {


### PR DESCRIPTION
P0 6b — Auto-reconnect with exponential backoff (2s→30s max):
- useSession: _disconnectInternal (no reconnect cancel), _scheduleReconnect,
  _cancelReconnect, reconnectNow; connectRef/scheduleReconnectRef keep timer
  callbacks stable; reconnecting state exposed; session_closed SSE triggers
  reconnect instead of permanent disconnect; connect stores reconnectConfigRef
- SidebarLayout: ReconnectBanner shown when session.reconnecting, with
  "Reconnect now" button; CSS added to sidebar.css

P0 6c — Unsaved-work beforeunload protection:
- AppProviders: warns before unload when batch queue (getQueuedCount) is non-empty
- App.jsx (AppLayout): warns before unload when STT mic is active (micListening)

P2 7b — SessionContext split into three focused contexts:
- ConnectionContext: connection state + connect/disconnect/health methods
- CaptionContext: sequence/syncOffset + send/sendBatch/sync methods
- SessionApiContext: stable API methods (stats, files, relay, images, icons)
- AppProviders provides all three via useMemo with proper state-only deps;
  all methods are now useCallback-stable in useSession, so useMemo works
  correctly and consumers only re-render when their relevant state changes
- SessionContext unchanged for backwards compatibility

P3 7c — Lazy-load heavy pages:
- BroadcastPage, DskEditorPage, ProductionOperatorPage loaded via React.lazy
  + Suspense; each splits to its own JS chunk at build time (~6–37 kB each)

https://claude.ai/code/session_01G5uGdNtYBUdjth8GBUgpW7