### PR TITLE
Add advanced mode toggle and legacy page access to sidebar

### DIFF
--- a/packages/lcyt-web/src/App.jsx
+++ b/packages/lcyt-web/src/App.jsx
@@ -50,7 +50,7 @@ function NetworkBanner({ privacyPending }) {
 const DEFAULT_RIGHT_PANEL_W = 400; // px — initial right-panel width on first load
 const MIN_PANEL_W = 200;           // px — minimum width for either panel
 
-export function AppLayout() {
+export function AppLayout({ standalone = true }) {
   const session = useSessionContext();
   const fileStore = useFileContext();
 
@@ -276,10 +276,12 @@ export function AppLayout() {
 
   return (
     <div className="captions-page">
-      <StatusBar
-        onControlsOpen={() => setControlsOpen(true)}
-        onPrivacyOpen={handlePrivacyOpen}
-      />
+      {standalone && (
+        <StatusBar
+          onControlsOpen={() => setControlsOpen(true)}
+          onPrivacyOpen={handlePrivacyOpen}
+        />
+      )}
       <NetworkBanner privacyPending={privacyOpen && privacyRequireAcceptance} />
 
       <main id="main">

--- a/packages/lcyt-web/src/components/SidebarLayout.jsx
+++ b/packages/lcyt-web/src/components/SidebarLayout.jsx
@@ -7,10 +7,19 @@ import { COMMON_LANGUAGES } from '../lib/sttConfig';
 import { getActiveCodes, setActiveCode, clearActiveCode } from '../lib/activeCodes';
 import { readInputLang, writeInputLang, INPUT_LANG_EVENT } from '../lib/inputLang';
 import { KEYS } from '../lib/storageKeys.js';
+import { ControlsPanel } from './ControlsPanel';
 
 // ─── Mobile breakpoint ───────────────────────────────────────────────────────
 
 const MOBILE_BREAKPOINT = 768;
+
+function getShowAdvanced() {
+  try { return localStorage.getItem('lcyt.sidebar.showAdvanced') === 'true'; } catch { return false; }
+}
+
+function setShowAdvanced(val) {
+  try { localStorage.setItem('lcyt.sidebar.showAdvanced', String(val)); } catch { /* ignore */ }
+}
 
 function getSidebarExpanded() {
   try {
@@ -252,6 +261,7 @@ function QuickActionsPopover() {
   const { showToast } = useToastContext();
   const { t } = useLang();
   const [open, setOpen] = useState(false);
+  const [controlsOpen, setControlsOpen] = useState(false);
   const [customSequence, setCustomSequence] = useState(0);
   const [hbResult, setHbResult] = useState(null);
   const [syncResult, setSyncResult] = useState(null);
@@ -353,8 +363,15 @@ function QuickActionsPopover() {
         ⚡{hasActiveCodes ? <span className="quick-actions__code-dot" /> : null}
       </button>
 
+      {controlsOpen && <ControlsPanel onClose={() => setControlsOpen(false)} />}
+
       {open && (
         <div className="quick-actions__panel" role="menu">
+          <div className="quick-actions__row">
+            <button className="btn btn--secondary btn--sm" onClick={() => { setOpen(false); setControlsOpen(true); }}>
+              ⚙ Controls
+            </button>
+          </div>
           <div className="quick-actions__section-label">Session</div>
           <div className="quick-actions__row">
             <button className="btn btn--secondary btn--sm" onClick={handleSync} disabled={!session.connected}>
@@ -560,6 +577,14 @@ function SidebarGroup({ group, expanded, onNavigate }) {
 // ─── Sidebar ──────────────────────────────────────────────────────────────────
 
 function Sidebar({ expanded, onNavigate }) {
+  const [showAdvanced, setShowAdvancedState] = useState(getShowAdvanced);
+
+  function toggleAdvanced() {
+    const next = !showAdvanced;
+    setShowAdvancedState(next);
+    setShowAdvanced(next);
+  }
+
   return (
     <nav className={['sidebar', expanded ? 'sidebar--expanded' : 'sidebar--collapsed'].join(' ')} aria-label="Main navigation">
       <div className="sidebar__main">
@@ -569,12 +594,30 @@ function Sidebar({ expanded, onNavigate }) {
         {NAV_GROUPS.map(group => (
           <SidebarGroup key={group.id} group={group} expanded={expanded} onNavigate={onNavigate} />
         ))}
+        {showAdvanced && (
+          <a
+            href="/legacy"
+            className="sidebar__item"
+            title={!expanded ? 'Legacy' : undefined}
+          >
+            <span className="sidebar__item-icon" aria-hidden="true">⏮</span>
+            {expanded && <span className="sidebar__item-label">Legacy</span>}
+          </a>
+        )}
       </div>
       <div className="sidebar__divider" role="separator" />
       <div className="sidebar__bottom">
         {NAV_BOTTOM.map(item => (
           <SidebarItem key={item.id} {...item} expanded={expanded} onClick={onNavigate ? () => onNavigate(item.path) : undefined} />
         ))}
+        <button
+          className="sidebar__item sidebar__item--btn"
+          onClick={toggleAdvanced}
+          title={expanded ? undefined : (showAdvanced ? 'Hide advanced' : 'Show advanced')}
+        >
+          <span className="sidebar__item-icon" aria-hidden="true">{showAdvanced ? '▴' : '▾'}</span>
+          {expanded && <span className="sidebar__item-label sidebar__item-label--dim">{showAdvanced ? 'Less' : 'Advanced'}</span>}
+        </button>
       </div>
     </nav>
   );

--- a/packages/lcyt-web/src/main.jsx
+++ b/packages/lcyt-web/src/main.jsx
@@ -55,7 +55,8 @@ function isStandalonePath(p) {
     p.startsWith('/dsk-control/') ||
     p.startsWith('/view/') ||
     p.startsWith('/login') ||
-    p.startsWith('/register')
+    p.startsWith('/register') ||
+    p.startsWith('/legacy')
   );
 }
 
@@ -77,6 +78,7 @@ function getStandalonePage() {
   else if (path.startsWith('/view/'))              page = <ViewerPage />;
   else if (path.startsWith('/login'))              page = <LoginPage />;
   else if (path.startsWith('/register'))           page = <RegisterPage />;
+  else if (path.startsWith('/legacy'))             page = <App />;
   else page = <SidebarApp />;
   return <Suspense fallback={null}>{page}</Suspense>;
 }
@@ -103,7 +105,7 @@ function SidebarApp() {
           <Suspense fallback={null}>
           <Switch>
             <Route path="/" component={DashboardPage} />
-            <Route path="/captions" component={AppLayout} />
+            <Route path="/captions">{() => <AppLayout standalone={false} />}</Route>
             <Route path="/audio" component={AudioPage} />
             <Route path="/broadcast" component={BroadcastPage} />
             <Route path="/graphics/editor" component={DskEditorPage} />

--- a/packages/lcyt-web/src/styles/sidebar.css
+++ b/packages/lcyt-web/src/styles/sidebar.css
@@ -196,6 +196,19 @@
   white-space: nowrap;
 }
 
+/* button variant of sidebar item (no default button styles) */
+.sidebar__item--btn {
+  width: 100%;
+  background: none;
+  border: none;
+  text-align: left;
+}
+
+.sidebar__item-label--dim {
+  color: var(--color-text-muted);
+  font-size: 11px;
+}
+
 /* ─── Sidebar group ──────────────────────────────────────── */
 
 .sidebar__group-header {


### PR DESCRIPTION
## Summary
This PR adds an "Advanced" mode toggle to the sidebar that allows users to show/hide advanced features, including access to a legacy page. It also introduces a new ControlsPanel component and refactors the AppLayout to support both standalone and embedded modes.

## Key Changes

- **Advanced Mode Toggle**: Added `getShowAdvanced()` and `setShowAdvanced()` functions to persist the advanced mode state in localStorage
- **Sidebar Enhancement**: 
  - Added a toggle button in the sidebar footer to show/hide advanced features
  - Conditionally displays a "Legacy" link when advanced mode is enabled
  - New styling for button-variant sidebar items and dimmed labels
- **ControlsPanel Integration**: Imported and integrated the new `ControlsPanel` component into the QuickActionsPopover with a dedicated button
- **AppLayout Refactoring**: 
  - Added `standalone` prop (defaults to `true`) to control StatusBar visibility
  - Allows AppLayout to be used in both standalone and embedded contexts
- **Routing Updates**:
  - Added `/legacy` to the list of standalone paths
  - Routes `/legacy` to the legacy App component
  - Updated `/captions` route to pass `standalone={false}` to AppLayout

## Implementation Details

- Advanced mode state is persisted in `localStorage` with key `lcyt.sidebar.showAdvanced`
- The toggle button displays different icons (▴/▾) and labels based on the current state
- The ControlsPanel is rendered conditionally and can be opened via the Quick Actions menu
- CSS updates include new styles for button-variant sidebar items and muted text labels

https://claude.ai/code/session_012qtAHTeKP5V9GaV8oomAxo