### PR TITLE
docs: add server-side STT plan (plan/server-stt)

### DIFF
--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -49,7 +49,7 @@ All planning documents live in [`docs/plans/`](plans/). This index lists each pl
 
 | File | Title | Summary | Supersedes |
 |---|---|---|---|
-| [plan_server_stt.md](plans/plan_server_stt.md) | Server-side Speech-to-Text (STT) | Server-side audio capture from MediaMTX (RTMP or HLS) piped through ffmpeg into pluggable STT provider adapters (whisper.cpp, Deepgram, Google, OpenAI); transcripts delivered into the existing caption pipeline without browser involvement. | |
+| [plan_server_stt.md](plans/plan_server_stt.md) | Server-side Speech-to-Text (STT) | Server-side audio capture from MediaMTX (RTMP, HLS, or WebRTC/WHEP) piped through ffmpeg into pluggable STT provider adapters (whisper.cpp, Google Cloud STT, OpenAI-compatible Whisper); transcripts delivered into the existing caption pipeline without browser involvement. | |
 | [plan_cea.md](plans/plan_cea.md) | CEA-708 SEI NAL Caption Embedding in RTMP Relay | Embed closed captions as H.264 SEI NAL units in the RTMP relay stream using ffmpeg tee muxer with PTS-anchored payloads. | |
 | [plan_front.md](plans/plan_front.md) | Frontend Flow Improvement | Targeted UI improvements for lcyt-web: sidebar navigation, hybrid settings page, improved information architecture for the multi-feature platform. | relates to `plan/ui` |
 

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -49,6 +49,7 @@ All planning documents live in [`docs/plans/`](plans/). This index lists each pl
 
 | File | Title | Summary | Supersedes |
 |---|---|---|---|
+| [plan_server_stt.md](plans/plan_server_stt.md) | Server-side Speech-to-Text (STT) | Server-side audio capture from MediaMTX (RTMP or HLS) piped through ffmpeg into pluggable STT provider adapters (whisper.cpp, Deepgram, Google, OpenAI); transcripts delivered into the existing caption pipeline without browser involvement. | |
 | [plan_cea.md](plans/plan_cea.md) | CEA-708 SEI NAL Caption Embedding in RTMP Relay | Embed closed captions as H.264 SEI NAL units in the RTMP relay stream using ffmpeg tee muxer with PTS-anchored payloads. | |
 | [plan_front.md](plans/plan_front.md) | Frontend Flow Improvement | Targeted UI improvements for lcyt-web: sidebar navigation, hybrid settings page, improved information architecture for the multi-feature platform. | relates to `plan/ui` |
 

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -49,7 +49,7 @@ All planning documents live in [`docs/plans/`](plans/). This index lists each pl
 
 | File | Title | Summary | Supersedes |
 |---|---|---|---|
-| [plan_server_stt.md](plans/plan_server_stt.md) | Server-side Speech-to-Text (STT) | Server-side audio capture from MediaMTX (RTMP, HLS, or WebRTC/WHEP) piped through ffmpeg into pluggable STT provider adapters (whisper.cpp, Google Cloud STT, OpenAI-compatible Whisper); transcripts delivered into the existing caption pipeline without browser involvement. | |
+| [plan_server_stt.md](plans/plan_server_stt.md) | Server-side Speech-to-Text (STT) | Server-side STT by fetching HLS audio segments directly from MediaMTX and posting them to pluggable STT providers (whisper.cpp, Google Cloud STT, OpenAI-compatible Whisper); segment timestamps from the HLS playlist drive caption timing with no ffmpeg required for the default path. | |
 | [plan_cea.md](plans/plan_cea.md) | CEA-708 SEI NAL Caption Embedding in RTMP Relay | Embed closed captions as H.264 SEI NAL units in the RTMP relay stream using ffmpeg tee muxer with PTS-anchored payloads. | |
 | [plan_front.md](plans/plan_front.md) | Frontend Flow Improvement | Targeted UI improvements for lcyt-web: sidebar navigation, hybrid settings page, improved information architecture for the multi-feature platform. | relates to `plan/ui` |
 

--- a/docs/plans/plan_server_stt.md
+++ b/docs/plans/plan_server_stt.md
@@ -2,79 +2,88 @@
 id: plan/server-stt
 title: "Server-side Speech-to-Text (STT)"
 status: draft
-summary: "Server-side STT by fetching HLS audio segments directly from MediaMTX and posting them to pluggable STT provider adapters (whisper.cpp, Google Cloud STT, OpenAI-compatible Whisper); segment timestamps from the HLS playlist drive caption timing with no ffmpeg required for the default path."
+summary: "Server-side STT by fetching fMP4 HLS audio segments directly from MediaMTX and posting them to pluggable STT provider adapters (Google Cloud STT, whisper.cpp, OpenAI-compatible Whisper); segment timestamps from the HLS playlist drive caption timing with no ffmpeg required for the default path."
 ---
 
 # Server-side Speech-to-Text (STT)
 
-**Scope:** New `SttManager` and `HlsSegmentFetcher` classes in `packages/plugins/lcyt-rtmp`; new `/stt` routes in `packages/lcyt-backend`; optional UI controls in `packages/lcyt-web`.
+**Scope:** New `HlsSegmentFetcher` and `SttManager` in `packages/plugins/lcyt-rtmp`; new `/stt` routes in `packages/lcyt-backend`; UI additions in `packages/lcyt-web`.
 
 ---
 
 ## Motivation
 
-The existing STT integration is entirely browser-based — the browser captures the microphone, runs recognition, and POSTs final transcripts to the backend. Server-side STT removes the browser dependency entirely:
+The existing STT is entirely browser-based. Server-side STT removes the browser dependency:
 
-- The audio source is a live stream already flowing through MediaMTX.
-- HLS segments are fetched directly and posted to the STT provider — no ffmpeg decode pipeline required.
-- Timestamps come from the HLS playlist itself, not from a PCM buffer.
-- Transcripts are delivered into the existing caption-send pipeline just like browser-originated text.
-- Useful for: automated captioning of hardware streams (cameras, mixers, broadcast hardware), headless/unattended deployments, and scenarios where no operator browser is available.
+- Audio source is a live fMP4 HLS stream already flowing through MediaMTX.
+- Segments are fetched directly as HTTP requests and posted to the STT provider — no ffmpeg decode pipeline.
+- Timestamps come from the HLS playlist itself (`#EXT-X-PROGRAM-DATE-TIME`).
+- HLS segment duration is the natural utterance boundary — no VAD, no manual chunk sizing.
+- Transcripts are delivered into the existing caption-send pipeline like any other caption source.
+- Useful for: automated captioning of hardware streams, headless deployments, unattended operation.
 
 ---
 
 ## Architecture Overview
 
 ```
-MediaMTX HLS
-  /{streamKey}/index.m3u8   ←── HlsSegmentFetcher (polls playlist)
-  /{streamKey}/seg001.ts         │
-  /{streamKey}/seg002.ts         │  segment buffer + timestamp from #EXT-X-PROGRAM-DATE-TIME
-                                 ▼
-                            SttAdapter (pluggable)
-                            ├─ WhisperHttpAdapter  (whisper.cpp HTTP server)
-                            ├─ GoogleSttAdapter    (Google Cloud STT REST/gRPC)
-                            └─ OpenAiAdapter       (OpenAI-compatible chunked REST)
-                                 │
-                            transcript events { text, timestamp }
-                                 │
-                                 ▼
-                            session._sendQueue    (existing caption delivery)
-                            ├─ YouTube targets
-                            ├─ viewer targets
-                            └─ generic targets
+MediaMTX (fMP4 HLS output)
+  /{streamKey}/index.m3u8        ←── HlsSegmentFetcher (polls playlist)
+  /{streamKey}/init.mp4               │
+  /{streamKey}/seg001.mp4             │  Buffer + timestamp (from EXT-X-PROGRAM-DATE-TIME)
+  /{streamKey}/seg002.mp4             │
+                                      ▼
+                                 SttAdapter
+                                 ├─ GoogleSttAdapter  [Phase 1]
+                                 ├─ WhisperHttpAdapter [Phase 2]
+                                 └─ OpenAiAdapter      [Phase 2]
+                                      │
+                                 { text, timestamp }
+                                      │
+                                      ▼
+                                 session._sendQueue
+                                 ├─ YouTube targets
+                                 ├─ viewer targets
+                                 └─ generic targets
 ```
 
-For non-HLS sources (RTMP, WHEP), `SttManager` falls back to an ffmpeg PCM pipe — see [Fallback: ffmpeg pipe](#fallback-ffmpeg-pipe).
+RTMP and WHEP sources use an ffmpeg PCM pipe fallback — see [Phase 3](#phase-3--rtmpwhep-fallback).
 
 ---
 
-## HLS Segment Fetcher
+## MediaMTX Configuration
+
+MediaMTX must be configured to output **fMP4 HLS segments** (`.mp4` instead of `.ts`). fMP4 is accepted directly by Google Cloud STT, OpenAI, and whisper.cpp.
+
+In `mediamtx.yml`:
+
+```yaml
+hlsVariant: fmp4          # produce .mp4 segments instead of .ts
+hlsSegmentDuration: 6s    # adjust to taste; longer = more context per STT call
+```
+
+The segment duration is the only tuning knob for utterance granularity.
+
+---
+
+## HlsSegmentFetcher
 
 **File:** `packages/plugins/lcyt-rtmp/src/hls-segment-fetcher.js`
 
-The core of the HLS path. Polls the MediaMTX playlist, detects new segments, fetches their raw bytes, and extracts the wall-clock timestamp for each.
+Polls the MediaMTX HLS playlist, detects new segments, and emits them with accurate wall-clock timestamps.
 
-### Playlist polling
+### Behaviour
 
-- GET `{hlsBase}/{streamKey}/index.m3u8` every ~2 s (or half the segment duration).
+- GET `{hlsBase}/{streamKey}/index.m3u8` at a configurable interval (default: half the segment duration, minimum 1 s).
 - Track `#EXT-X-MEDIA-SEQUENCE` to identify new segments since the last poll.
-- On each new segment:
-  - Determine its wall-clock start time:
-    - If `#EXT-X-PROGRAM-DATE-TIME` is present, use it for the first segment in the window; subsequent segments' timestamps = programDateTime + accumulated `#EXTINF` durations.
-    - If absent, fall back to `Date.now()` at fetch time.
-  - GET the segment URL and collect the response body as a `Buffer`.
-  - Emit `segment` event: `{ buffer, timestamp, duration, url, index }`.
+- Timestamp derivation:
+  - `#EXT-X-PROGRAM-DATE-TIME` gives the wall-clock time of the first segment in the window.
+  - Each subsequent segment's timestamp = programDateTime + sum of preceding `#EXTINF` durations.
+  - If `#EXT-X-PROGRAM-DATE-TIME` is absent, fall back to `Date.now()` at fetch time.
+- For each new segment: GET the URL, collect body as a `Buffer`, emit `segment`.
+- Handles playlist gaps (stream offline) by retrying with exponential backoff.
 
-### Why this is better than ffmpeg piping
-
-- No ffmpeg process, no PCM decode, no WAV encoding in memory, no stdout pipe.
-- Timestamps come from the HLS playlist — the most accurate source available.
-- HLS segment duration is the natural utterance boundary. No VAD, no `vadSilenceMs`, no `chunkDurationMs` config.
-- Segment duration is set in MediaMTX's config (`hlsSegmentDuration`), not in LCYT code.
-- The fetcher is a plain Node.js HTTP client loop — simple, testable, no native deps.
-
-### Events (EventEmitter)
+### Events
 
 ```js
 fetcher.on('segment', ({ buffer, timestamp, duration, url, index }))
@@ -88,48 +97,30 @@ fetcher.on('stopped', ())
 
 **File:** `packages/plugins/lcyt-rtmp/src/stt-manager.js`
 
-One `SttManager` instance is shared across all API keys (singleton, created by `initRtmpControl`). It manages per-key STT sessions internally.
+Singleton created by `initRtmpControl`. Manages one STT session per API key.
 
 ### Public API
 
 ```js
 await sttManager.start(apiKey, {
-  provider,     // 'whisper_http' | 'google' | 'openai'
+  provider,     // 'google' | 'whisper_http' | 'openai'
   language,     // BCP-47 (default: 'en-US')
   audioSource,  // 'hls' | 'rtmp' | 'whep'  (default: 'hls')
   streamKey,    // MediaMTX path (default: apiKey)
 })
 
 await sttManager.stop(apiKey)
-sttManager.isRunning(apiKey)   // → boolean
-sttManager.getStatus(apiKey)   // → { running, provider, language, startedAt, segmentsSent, lastTranscript }
+sttManager.isRunning(apiKey)
+sttManager.getStatus(apiKey)  // → { running, provider, language, startedAt, segmentsSent, lastTranscript }
 await sttManager.stopAll()
 ```
 
-### Events (EventEmitter)
+### Events
 
 ```js
 sttManager.on('transcript', ({ apiKey, text, confidence, timestamp, provider }))
 sttManager.on('error',      ({ apiKey, error }))
 sttManager.on('stopped',    ({ apiKey }))
-```
-
-### Per-key session state (internal)
-
-```js
-{
-  apiKey,
-  provider,
-  language,
-  audioSource,
-  streamKey,
-  fetcher,        // HlsSegmentFetcher instance (HLS path)
-  ffmpegHandle,   // FfmpegRunner handle (RTMP/WHEP path only)
-  adapter,        // SttAdapter instance
-  startedAt,      // ISO timestamp
-  segmentsSent,   // counter
-  lastTranscript, // { text, timestamp }
-}
 ```
 
 ---
@@ -138,16 +129,16 @@ sttManager.on('stopped',    ({ apiKey }))
 
 **Directory:** `packages/plugins/lcyt-rtmp/src/stt-adapters/`
 
-All adapters implement the same interface. For the HLS path, `sendSegment` is called once per HLS segment. For the ffmpeg fallback path, `write` is called with PCM chunks and the adapter handles its own buffering.
+Common interface:
 
 ```js
 class SttAdapter extends EventEmitter {
   async start({ language, ...opts }) {}
 
-  // HLS path: called once per segment with raw audio buffer and its playlist timestamp.
+  // HLS path: called once per fMP4 segment.
   async sendSegment(buffer, { timestamp, duration }) {}
 
-  // ffmpeg fallback path: called with raw PCM chunks (s16le 16kHz mono).
+  // ffmpeg fallback path (RTMP/WHEP): called with raw PCM chunks (s16le 16kHz mono).
   write(pcmChunk) {}
 
   async stop() {}
@@ -158,96 +149,55 @@ class SttAdapter extends EventEmitter {
 }
 ```
 
-### WhisperHttpAdapter (`stt-adapters/whisper-http.js`)
+### GoogleSttAdapter
 
-Connects to a running [whisper.cpp HTTP server](https://github.com/ggerganov/whisper.cpp/tree/master/examples/server).
+[Phase 1] Google Cloud Speech-to-Text v1. Supports Finnish (`fi-FI`) and 125+ languages.
 
-**HLS path:**
-- `POST {WHISPER_HTTP_URL}/inference` with the raw `.ts` segment buffer as `multipart/form-data`.
-- whisper.cpp uses ffmpeg internally and accepts MPEG-TS directly.
-- Uses the segment's playlist timestamp as the caption timestamp.
+**HLS path:** POST the fMP4 segment buffer to `https://speech.googleapis.com/v1/speech:recognize` as base64-encoded audio with `encoding: MP4` (or `encoding: LINEAR16` after a ffmpeg-free remux is confirmed unnecessary — to be verified against the API). The `#EXT-X-PROGRAM-DATE-TIME`-derived timestamp is used directly.
 
-**ffmpeg fallback path:**
-- Accumulates PCM into a rolling buffer.
-- Encodes each filled buffer as a WAV in memory and POSTs it.
-
-Supports Finnish (`fi`) and all other Whisper-supported languages.
+**gRPC streaming mode** (Phase 4): bidirectional stream via `@google-cloud/speech`; auto-restarts at the 5-minute API limit.
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `WHISPER_HTTP_URL` | — | whisper.cpp server base URL (e.g. `http://localhost:8080`) |
-| `WHISPER_HTTP_MODEL` | (server default) | Model name sent in request (optional) |
-
-### GoogleSttAdapter (`stt-adapters/google-stt.js`)
-
-Uses Google Cloud Speech-to-Text v1. Supports Finnish (`fi-FI`) and 125+ languages.
-
-**HLS path:**
-
-Google STT does not accept MPEG-TS directly. Options:
-
-1. **ffmpeg per-segment remux** (simplest): spawn a short-lived ffmpeg to extract AAC from the `.ts` buffer to an in-memory `.m4a` or raw `flac`/`wav`, then POST. Single-segment ffmpeg invocations are fast (~100 ms) and stateless.
-2. **fMP4 output from MediaMTX**: configure MediaMTX to produce fMP4 segments (`.m4s`). fMP4 audio (`mp4a`) is accepted by Google as `mp4`/`m4a`. Eliminates per-segment ffmpeg.
-
-The adapter supports both; option 2 is preferred when MediaMTX is configured for fMP4.
-
-**REST mode:** `POST https://speech.googleapis.com/v1/speech:recognize` with base64 audio.
-
-**gRPC streaming mode:** bidirectional stream via `@google-cloud/speech`; restarts automatically at the 5-minute API limit.
-
-| Variable | Default | Purpose |
-|---|---|---|
-| `GOOGLE_APPLICATION_CREDENTIALS` | — | Path to service account JSON |
+| `GOOGLE_APPLICATION_CREDENTIALS` | — | Service account JSON path |
 | `GOOGLE_STT_KEY` | — | API key for REST fallback |
 | `GOOGLE_STT_MODE` | `rest` | `rest` or `grpc` |
 
-`@google-cloud/speech` is an **optional peer dependency** — the adapter catches the import failure and throws a descriptive error rather than crashing the server.
+`@google-cloud/speech` is an optional peer dependency; the adapter fails with a clear message if not installed.
 
-### OpenAiAdapter (`stt-adapters/openai.js`)
+### WhisperHttpAdapter
 
-Uses OpenAI's [Whisper API](https://platform.openai.com/docs/guides/speech-to-text) (`/v1/audio/transcriptions`), or any OpenAI-compatible endpoint (local whisper-openai-server, Ollama, Azure OpenAI).
+[Phase 2] Connects to a running [whisper.cpp HTTP server](https://github.com/ggerganov/whisper.cpp/tree/master/examples/server).
 
-**HLS path:**
-- POST the raw `.ts` segment buffer as `multipart/form-data` with filename `segment.ts`.
-- OpenAI accepts `mp3`, `mp4`, `mpeg`, `mpga`, `m4a`, `wav`, `webm` — but `.ts` (MPEG-TS) is usually accepted in practice. If rejected, configure MediaMTX for fMP4 output (`segment.mp4`).
-- Uses the segment's playlist timestamp as the caption timestamp.
+**HLS path:** POST the fMP4 segment buffer to `{WHISPER_HTTP_URL}/inference` as `multipart/form-data` with filename `segment.mp4`. whisper.cpp accepts MP4 directly. Uses playlist timestamp.
 
-Supports Finnish (`fi`) via Whisper's multilingual models.
+**ffmpeg fallback path:** accumulate PCM → encode as WAV in memory → POST.
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `OPENAI_API_KEY` | — | OpenAI API key (or local server key) |
+| `WHISPER_HTTP_URL` | — | whisper.cpp server URL |
+| `WHISPER_HTTP_MODEL` | (server default) | Model name (optional) |
+
+### OpenAiAdapter
+
+[Phase 2] OpenAI Whisper API or any compatible endpoint (local whisper-openai-server, Ollama, Azure).
+
+**HLS path:** POST the fMP4 segment buffer to `/v1/audio/transcriptions` as `multipart/form-data` with filename `segment.mp4`. Uses playlist timestamp.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `OPENAI_API_KEY` | — | API key |
 | `OPENAI_STT_MODEL` | `whisper-1` | Model name |
-| `OPENAI_BASE_URL` | `https://api.openai.com/v1` | Override for local or Azure endpoints |
-
----
-
-## Fallback: ffmpeg pipe
-
-For `audioSource: 'rtmp'` or `audioSource: 'whep'`, there are no natural segments or playlist timestamps. `SttManager` falls back to the original ffmpeg PCM pipe approach:
-
-```sh
-# RTMP
-ffmpeg -i rtmp://127.0.0.1:1935/{app}/{streamKey} \
-  -vn -af "aresample=16000,aformat=sample_fmts=s16:channel_layouts=mono" \
-  -f s16le pipe:1
-
-# WHEP (ffmpeg ≥ 6.1)
-ffmpeg -i http://127.0.0.1:8889/{streamKey}/whep \
-  -vn -af "aresample=16000,aformat=sample_fmts=s16:channel_layouts=mono" \
-  -f s16le pipe:1
-```
-
-In this path, adapters use `write(pcmChunk)` instead of `sendSegment()`, and handle their own silence/chunk buffering. The HLS path is preferred for all deployments that have MediaMTX.
+| `OPENAI_BASE_URL` | `https://api.openai.com/v1` | Override for local/Azure endpoints |
 
 ---
 
 ## Transcript → Caption Delivery
 
 ```js
-// Inside SttManager._onTranscript()
+// SttManager._onTranscript()
 const session = store.getByApiKey(apiKey)
-if (!session) return  // no active session — discard
+if (!session) return
 
 const text = transcript.text.trim()
 if (!text) return
@@ -258,18 +208,18 @@ session._sendQueue.add(async () => {
 })
 ```
 
-Reuses the same `_sendQueue` serialisation as browser-originated captions, keeping sequence numbers monotonic.
+Reuses `_sendQueue` to keep sequence numbers monotonic alongside any concurrent browser-originated captions.
 
 ---
 
 ## Database
 
-New table `stt_config` (added to `packages/plugins/lcyt-rtmp/src/db.js` migrations):
+New table `stt_config` added to `packages/plugins/lcyt-rtmp/src/db.js` migrations:
 
 ```sql
 CREATE TABLE IF NOT EXISTS stt_config (
   api_key      TEXT PRIMARY KEY,
-  provider     TEXT NOT NULL DEFAULT 'whisper_http',
+  provider     TEXT NOT NULL DEFAULT 'google',
   language     TEXT NOT NULL DEFAULT 'en-US',
   audio_source TEXT NOT NULL DEFAULT 'hls',
   stream_key   TEXT,         -- NULL → use api_key as the MediaMTX path
@@ -279,8 +229,6 @@ CREATE TABLE IF NOT EXISTS stt_config (
 );
 ```
 
-`vad_silence_ms` and `chunk_duration_ms` are removed — segment boundaries replace them for the HLS path.
-
 ---
 
 ## API Routes
@@ -288,7 +236,7 @@ CREATE TABLE IF NOT EXISTS stt_config (
 Mounted at `/stt` in `packages/lcyt-backend/src/routes/stt.js`. All endpoints require the standard session Bearer token.
 
 ```
-GET  /stt/status    — current STT session state for the authenticated API key
+GET  /stt/status    — current STT state for the authenticated API key
 POST /stt/start     — start STT (body: { provider?, language?, audioSource?, streamKey? })
 POST /stt/stop      — stop STT
 GET  /stt/events    — SSE stream of transcript events (Bearer or ?token=)
@@ -296,7 +244,7 @@ GET  /stt/config    — get per-key STT config from DB
 PUT  /stt/config    — update per-key STT config
 ```
 
-### SSE events (on `GET /stt/events`)
+### SSE events (`GET /stt/events`)
 
 | Event | Payload |
 |---|---|
@@ -310,7 +258,7 @@ PUT  /stt/config    — update per-key STT config
 
 ## Auto-start on Publish
 
-The existing `on_publish` RTMP callback is extended:
+The `on_publish` RTMP callback is extended:
 
 ```js
 const cfg = db.getSttConfig(apiKey)
@@ -327,80 +275,180 @@ if (cfg?.auto_start) {
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `STT_PROVIDER` | `whisper_http` | Default provider: `whisper_http` \| `google` \| `openai` |
+| `STT_PROVIDER` | `google` | Default provider: `google` \| `whisper_http` \| `openai` |
 | `STT_DEFAULT_LANGUAGE` | `en-US` | Default recognition language (BCP-47) |
 | `STT_AUDIO_SOURCE` | `hls` | Default audio source: `hls` \| `rtmp` \| `whep` |
+| `GOOGLE_APPLICATION_CREDENTIALS` | — | Google service account JSON path |
+| `GOOGLE_STT_KEY` | — | Google API key (REST) |
+| `GOOGLE_STT_MODE` | `rest` | `rest` or `grpc` |
 | `WHISPER_HTTP_URL` | — | whisper.cpp HTTP server URL |
 | `WHISPER_HTTP_MODEL` | — | Whisper model name (optional) |
-| `GOOGLE_APPLICATION_CREDENTIALS` | — | Google service account JSON path |
-| `GOOGLE_STT_KEY` | — | Google API key (REST fallback) |
-| `GOOGLE_STT_MODE` | `rest` | `rest` or `grpc` |
 | `OPENAI_API_KEY` | — | OpenAI API key |
-| `OPENAI_STT_MODEL` | `whisper-1` | OpenAI Whisper model name |
+| `OPENAI_STT_MODEL` | `whisper-1` | Model name |
 | `OPENAI_BASE_URL` | `https://api.openai.com/v1` | OpenAI-compatible base URL |
 
 ---
 
-## Implementation Phases
-
-### Phase 1 — HLS segment fetch + Whisper (MVP)
-
-- `HlsSegmentFetcher`: playlist poll, new-segment detection, timestamp extraction, segment buffer fetch.
-- `SttManager` wiring fetcher → adapter → transcript → `_sendQueue`.
-- `WhisperHttpAdapter`: direct MPEG-TS segment POST to whisper.cpp server.
-- DB migration for `stt_config`.
-- `/stt` routes: `start`, `stop`, `status`, `config`.
-- `on_publish` auto-start hook.
-
-**Deliverable:** Fully headless Finnish/multilingual captioning from any MediaMTX stream with no ffmpeg in the hot path.
-
-### Phase 2 — Cloud providers + ffmpeg fallback
-
-- `GoogleSttAdapter` (REST + optional fMP4 path; gRPC streaming as follow-up).
-- `OpenAiAdapter` (chunked REST, OpenAI-compatible endpoints).
-- ffmpeg PCM pipe fallback for RTMP and WHEP sources.
-- WHEP: probe ffmpeg version on startup; warn if < 6.1.
-
-### Phase 3 — SSE transcript stream + UI
-
-- `GET /stt/events` SSE endpoint.
-- lcyt-web: Server STT status indicator in `StatusBar`.
-- lcyt-web: Server STT config section in `EmbedSettingsPage` CC tab (provider, language, audio source, auto-start toggle).
-
-### Phase 4 — Quality controls
-
-- Confidence threshold filtering (discard low-confidence segments).
-- Punctuation normalisation for providers that omit it.
-- Skip silent/empty segments before sending to the STT API (energy check on the buffer).
+## Phases
 
 ---
 
-## Key Files to Create / Modify
+### Phase 1 — HLS + Google STT
 
-| Action | File | Notes |
-|---|---|---|
-| Create | `packages/plugins/lcyt-rtmp/src/hls-segment-fetcher.js` | HLS playlist poll + segment fetch |
-| Create | `packages/plugins/lcyt-rtmp/src/stt-manager.js` | SttManager class |
-| Create | `packages/plugins/lcyt-rtmp/src/stt-adapters/whisper-http.js` | WhisperHttpAdapter |
-| Create | `packages/plugins/lcyt-rtmp/src/stt-adapters/google-stt.js` | GoogleSttAdapter |
-| Create | `packages/plugins/lcyt-rtmp/src/stt-adapters/openai.js` | OpenAiAdapter |
-| Create | `packages/lcyt-backend/src/routes/stt.js` | /stt Express router |
-| Modify | `packages/plugins/lcyt-rtmp/src/db.js` | Add stt_config migration |
-| Modify | `packages/plugins/lcyt-rtmp/src/api.js` | Export sttManager from initRtmpControl |
-| Modify | `packages/lcyt-backend/src/server.js` | Mount /stt router, pass sttManager |
-| Modify | `packages/lcyt-backend/src/routes/radio.js` | on_publish auto-start hook |
-| Modify | `packages/lcyt-web/src/components/StatusBar.jsx` | Server STT status indicator |
+**Goal:** Headless captioning from any MediaMTX stream using Google Cloud STT. No ffmpeg in the hot path.
+
+**Backend:**
+- `HlsSegmentFetcher`: playlist poll, EXT-X-MEDIA-SEQUENCE tracking, EXT-X-PROGRAM-DATE-TIME timestamp derivation, segment buffer fetch.
+- `SttManager`: wires fetcher → adapter → transcript → `_sendQueue`.
+- `GoogleSttAdapter`: REST mode, fMP4 segment POST, Finnish and multilingual support.
+- DB migration for `stt_config`.
+- `/stt` routes: `start`, `stop`, `status`, `config`.
+- `on_publish` / `on_publish_done` auto-start hook.
+
+**UI (lcyt-web):**
+- `StatusBar`: small server-STT chip — shows provider and language when active (e.g. "STT: google / fi-FI"), greyed out when inactive. No new page or modal.
+
+---
+
+### Phase 2 — Additional STT providers
+
+**Goal:** Support local/self-hosted STT without a Google dependency.
+
+**Backend:**
+- `WhisperHttpAdapter`: fMP4 segment POST to whisper.cpp HTTP server.
+- `OpenAiAdapter`: fMP4 segment POST to any OpenAI-compatible `/v1/audio/transcriptions` endpoint.
+
+**UI (lcyt-web):**
+- Server STT section in **Settings modal** (or `EmbedSettingsPage` CC tab):
+  - Provider dropdown: Google / Whisper / OpenAI-compatible.
+  - Language selector (reuse existing BCP-47 list from `sttConfig.js`).
+  - Auto-start toggle.
+  - Start / Stop button (if session is active).
+- StatusBar chip links/opens to this settings section.
+
+---
+
+### Phase 3 — RTMP / WHEP fallback
+
+**Goal:** Support audio sources where HLS is not available.
+
+**Backend:**
+- `SttManager` ffmpeg PCM pipe path for `audioSource: 'rtmp'` and `audioSource: 'whep'`.
+- WHEP requires ffmpeg ≥ 6.1; probe version on startup, log warning if unavailable.
+- All three adapters implement `write(pcmChunk)` for the fallback path, with internal silence-based buffering (energy threshold) and a max chunk duration cap.
+- DB: add `audio_source` selector and expose via `PUT /stt/config`.
+
+**UI (lcyt-web):**
+- Audio source selector in the Server STT settings section: HLS / RTMP / WHEP.
+- Show a warning badge next to WHEP if the backend reports ffmpeg < 6.1.
+
+---
+
+### Phase 4 — gRPC streaming + quality controls
+
+**Goal:** Lower recognition latency and filter low-quality output.
+
+**Backend:**
+- `GoogleSttAdapter` gRPC streaming mode (`GOOGLE_STT_MODE=grpc`): bidirectional stream, interim results discarded, finals emitted. Auto-restart at 5-minute API limit.
+- Confidence threshold filtering: configurable minimum confidence; segments below threshold are discarded and logged.
+- Empty-segment skip: lightweight energy check (RMS of decoded PCM, or segment file-size floor) before sending to the API, to avoid billing for silence.
+- Punctuation normalisation for providers that omit it.
+- `GET /stt/events` SSE endpoint for live transcript monitoring.
+
+**UI (lcyt-web):**
+- Live transcript panel (collapsible, in `SentPanel` area or a new tab) fed by `GET /stt/events` — shows rolling server-STT transcripts with timestamps.
+- Confidence threshold slider in settings.
+- Mode indicator in StatusBar chip: "STT: google/gRPC / fi-FI".
 
 ---
 
 ## Open Questions
 
-1. **MPEG-TS vs fMP4 segments**: MediaMTX can output either. fMP4 (`.m4s`) is more widely accepted by STT APIs. Should the plan recommend a specific MediaMTX `hlsVariant` setting, or handle both transparently by sniffing the segment URL extension?
+1. **Google STT fMP4 encoding label**: The REST API `encoding` field does not list `MP4` as a named value. In practice, fMP4 audio (AAC in MP4 container) is submitted with `encoding: MP4A` or by omitting the encoding field and letting the API auto-detect. Needs a quick test against the live API to confirm the correct value before Phase 1 ships.
 
-2. **Simultaneous browser + server STT**: Both write into the same `_sendQueue` — safe for ordering but could produce interleaved output. A mutex flag (`serverSttActive`) on the session could block browser sends while server STT is running.
+2. **Simultaneous browser + server STT**: Both write into the same `_sendQueue` — safe for ordering but could interleave output. A session flag `serverSttActive` could block browser sends while server STT is running. Defer decision to Phase 1 implementation.
 
-3. **streamKey vs apiKey for MediaMTX path**: `stt_config.stream_key` is nullable; when null, use `apiKey` as the MediaMTX HLS path. This matches the existing convention in `RadioManager`.
+3. **streamKey vs apiKey**: `stt_config.stream_key` is nullable; when null, `apiKey` is used as the MediaMTX HLS path. This matches the existing `RadioManager` convention.
 
-4. **Google gRPC dependency**: `@google-cloud/speech` pulls in native gRPC bindings. Optional peer dep — fail with a clear error message if not installed.
+4. **Google gRPC optional dep**: `@google-cloud/speech` pulls in native gRPC bindings. Dynamic import with a clear "install @google-cloud/speech to use grpc mode" error. Only required for Phase 4.
 
-5. **Empty segment handling**: Short silence periods still produce audio segments. A lightweight energy check (sum of absolute sample values) on the decoded PCM — or simply checking the segment file size against a threshold — can skip blank segments before sending to the STT API, saving cost and avoiding spurious transcripts.
+---
+
+## Todo
+
+### Phase 1 — HLS + Google STT
+
+**Backend**
+- [ ] Add `hlsVariant: fmp4` note to `docker/mediamtx.yml` and deployment docs
+- [ ] `packages/plugins/lcyt-rtmp/src/hls-segment-fetcher.js` — HlsSegmentFetcher class
+- [ ] `packages/plugins/lcyt-rtmp/src/stt-adapters/google-stt.js` — GoogleSttAdapter (REST, fMP4)
+- [ ] `packages/plugins/lcyt-rtmp/src/stt-manager.js` — SttManager (HLS path only)
+- [ ] `packages/plugins/lcyt-rtmp/src/db.js` — add `stt_config` migration
+- [ ] `packages/plugins/lcyt-rtmp/src/api.js` — export `sttManager` from `initRtmpControl`
+- [ ] `packages/lcyt-backend/src/routes/stt.js` — `/stt` Express router (start, stop, status, config)
+- [ ] `packages/lcyt-backend/src/server.js` — mount `/stt` router, inject `sttManager`
+- [ ] `packages/lcyt-backend/src/routes/radio.js` — `on_publish` / `on_publish_done` auto-start hooks
+- [ ] Verify Google STT fMP4 encoding label against live API (see open question 1)
+
+**Tests**
+- [ ] `HlsSegmentFetcher` unit tests: mock HTTP, playlist parsing, timestamp derivation, new-segment detection, retry on gap
+- [ ] `GoogleSttAdapter` unit tests: mock Google STT API, segment POST, transcript event
+- [ ] `SttManager` integration tests: start/stop, `_sendQueue` delivery, auto-start hook
+- [ ] `/stt` route tests: start/stop/status/config CRUD, auth
+
+**UI**
+- [ ] `packages/lcyt-web/src/components/StatusBar.jsx` — server-STT chip (provider / language / active state)
+
+---
+
+### Phase 2 — Additional STT providers
+
+**Backend**
+- [ ] `packages/plugins/lcyt-rtmp/src/stt-adapters/whisper-http.js` — WhisperHttpAdapter (fMP4 HLS path)
+- [ ] `packages/plugins/lcyt-rtmp/src/stt-adapters/openai.js` — OpenAiAdapter (fMP4 HLS path)
+- [ ] `SttManager` — add `whisper_http` and `openai` to provider dispatch
+
+**Tests**
+- [ ] `WhisperHttpAdapter` unit tests: mock whisper.cpp server, multipart POST, transcript
+- [ ] `OpenAiAdapter` unit tests: mock OpenAI endpoint, multipart POST, transcript
+
+**UI**
+- [ ] Server STT settings section in Settings modal: provider dropdown, language selector, auto-start toggle, Start/Stop button
+- [ ] `StatusBar` chip links to settings section
+
+---
+
+### Phase 3 — RTMP / WHEP fallback
+
+**Backend**
+- [ ] `SttManager` — ffmpeg PCM pipe path for `audioSource: 'rtmp'` and `'whep'`
+- [ ] All three adapters — implement `write(pcmChunk)` + internal silence-buffer logic
+- [ ] Probe ffmpeg version on `SttManager` init; warn if < 6.1 (WHEP unavailable)
+- [ ] DB: expose `audio_source` field via `PUT /stt/config`
+
+**Tests**
+- [ ] `SttManager` RTMP/WHEP path: mock ffmpeg runner, PCM chunk flow, stop/cleanup
+
+**UI**
+- [ ] Audio source selector in Server STT settings: HLS / RTMP / WHEP
+- [ ] Warning badge next to WHEP if backend reports ffmpeg < 6.1
+
+---
+
+### Phase 4 — gRPC streaming + quality controls
+
+**Backend**
+- [ ] `GoogleSttAdapter` — gRPC streaming mode (`GOOGLE_STT_MODE=grpc`), auto-restart at 5 min limit
+- [ ] Confidence threshold filtering (configurable minimum; discard + log below-threshold segments)
+- [ ] Empty-segment skip (energy / file-size floor check before API call)
+- [ ] Punctuation normalisation helper for providers that omit it
+- [ ] `GET /stt/events` SSE endpoint
+
+**Tests**
+- [ ] `GoogleSttAdapter` gRPC tests: mock `@google-cloud/speech` client, streaming flow, auto-restart
+- [ ] SSE `/stt/events` route tests
+
+**UI**
+- [ ] Live transcript panel in lcyt-web (fed by `GET /stt/events`): rolling server-STT transcripts with timestamps, collapsible
+- [ ] Confidence threshold slider in Server STT settings
+- [ ] StatusBar chip: show mode (rest/gRPC) alongside provider and language

--- a/docs/plans/plan_server_stt.md
+++ b/docs/plans/plan_server_stt.md
@@ -2,12 +2,12 @@
 id: plan/server-stt
 title: "Server-side Speech-to-Text (STT)"
 status: draft
-summary: "Server-side audio capture from MediaMTX (RTMP, HLS, or WebRTC/WHEP) piped through ffmpeg into pluggable STT provider adapters (whisper.cpp, Google Cloud STT, OpenAI-compatible Whisper); transcripts delivered into the existing caption pipeline without any browser involvement."
+summary: "Server-side STT by fetching HLS audio segments directly from MediaMTX and posting them to pluggable STT provider adapters (whisper.cpp, Google Cloud STT, OpenAI-compatible Whisper); segment timestamps from the HLS playlist drive caption timing with no ffmpeg required for the default path."
 ---
 
 # Server-side Speech-to-Text (STT)
 
-**Scope:** New `SttManager` class in `packages/plugins/lcyt-rtmp`; new `/stt` routes in `packages/lcyt-backend`; optional UI controls in `packages/lcyt-web`.
+**Scope:** New `SttManager` and `HlsSegmentFetcher` classes in `packages/plugins/lcyt-rtmp`; new `/stt` routes in `packages/lcyt-backend`; optional UI controls in `packages/lcyt-web`.
 
 ---
 
@@ -16,7 +16,8 @@ summary: "Server-side audio capture from MediaMTX (RTMP, HLS, or WebRTC/WHEP) pi
 The existing STT integration is entirely browser-based — the browser captures the microphone, runs recognition, and POSTs final transcripts to the backend. Server-side STT removes the browser dependency entirely:
 
 - The audio source is a live stream already flowing through MediaMTX.
-- The server captures, decodes, and recognises the audio using a pluggable provider.
+- HLS segments are fetched directly and posted to the STT provider — no ffmpeg decode pipeline required.
+- Timestamps come from the HLS playlist itself, not from a PCM buffer.
 - Transcripts are delivered into the existing caption-send pipeline just like browser-originated text.
 - Useful for: automated captioning of hardware streams (cameras, mixers, broadcast hardware), headless/unattended deployments, and scenarios where no operator browser is available.
 
@@ -25,72 +26,61 @@ The existing STT integration is entirely browser-based — the browser captures 
 ## Architecture Overview
 
 ```
-MediaMTX                  SttManager (per API key)
-  RTMP  ─┐
-  HLS   ─┼──► ffmpeg ──► PCM 16 kHz mono (stdout pipe)
-  WHEP  ─┘                    │
-                              ▼
-                         SttAdapter (pluggable)
-                         ├─ WhisperHttpAdapter  (whisper.cpp HTTP server)
-                         ├─ GoogleSttAdapter    (REST chunked or gRPC streaming)
-                         └─ OpenAiAdapter       (chunked REST, OpenAI-compatible)
-                              │
-                         transcript events
-                              │
-                              ▼
-                         session._sendQueue    (existing caption delivery)
-                         ├─ YouTube targets
-                         ├─ viewer targets
-                         └─ generic targets
+MediaMTX HLS
+  /{streamKey}/index.m3u8   ←── HlsSegmentFetcher (polls playlist)
+  /{streamKey}/seg001.ts         │
+  /{streamKey}/seg002.ts         │  segment buffer + timestamp from #EXT-X-PROGRAM-DATE-TIME
+                                 ▼
+                            SttAdapter (pluggable)
+                            ├─ WhisperHttpAdapter  (whisper.cpp HTTP server)
+                            ├─ GoogleSttAdapter    (Google Cloud STT REST/gRPC)
+                            └─ OpenAiAdapter       (OpenAI-compatible chunked REST)
+                                 │
+                            transcript events { text, timestamp }
+                                 │
+                                 ▼
+                            session._sendQueue    (existing caption delivery)
+                            ├─ YouTube targets
+                            ├─ viewer targets
+                            └─ generic targets
 ```
+
+For non-HLS sources (RTMP, WHEP), `SttManager` falls back to an ffmpeg PCM pipe — see [Fallback: ffmpeg pipe](#fallback-ffmpeg-pipe).
 
 ---
 
-## Audio Source
+## HLS Segment Fetcher
 
-MediaMTX exposes three egress protocols, all accessible to ffmpeg. Latency differences between them are **not a meaningful criterion** here: YouTube's live caption API already imposes a 30-second hold between the video stream and caption display, so any audio source that delivers audio within that window is equivalent. The real criterion is availability and simplicity.
+**File:** `packages/plugins/lcyt-rtmp/src/hls-segment-fetcher.js`
 
-### HLS (recommended default)
+The core of the HLS path. Polls the MediaMTX playlist, detects new segments, fetches their raw bytes, and extracts the wall-clock timestamp for each.
 
+### Playlist polling
+
+- GET `{hlsBase}/{streamKey}/index.m3u8` every ~2 s (or half the segment duration).
+- Track `#EXT-X-MEDIA-SEQUENCE` to identify new segments since the last poll.
+- On each new segment:
+  - Determine its wall-clock start time:
+    - If `#EXT-X-PROGRAM-DATE-TIME` is present, use it for the first segment in the window; subsequent segments' timestamps = programDateTime + accumulated `#EXTINF` durations.
+    - If absent, fall back to `Date.now()` at fetch time.
+  - GET the segment URL and collect the response body as a `Buffer`.
+  - Emit `segment` event: `{ buffer, timestamp, duration, url, index }`.
+
+### Why this is better than ffmpeg piping
+
+- No ffmpeg process, no PCM decode, no WAV encoding in memory, no stdout pipe.
+- Timestamps come from the HLS playlist — the most accurate source available.
+- HLS segment duration is the natural utterance boundary. No VAD, no `vadSilenceMs`, no `chunkDurationMs` config.
+- Segment duration is set in MediaMTX's config (`hlsSegmentDuration`), not in LCYT code.
+- The fetcher is a plain Node.js HTTP client loop — simple, testable, no native deps.
+
+### Events (EventEmitter)
+
+```js
+fetcher.on('segment', ({ buffer, timestamp, duration, url, index }))
+fetcher.on('error',   ({ error }))
+fetcher.on('stopped', ())
 ```
-http://127.0.0.1:8080/{streamKey}/index.m3u8
-```
-
-MediaMTX generates HLS natively for every active path, regardless of how the stream was ingested (RTMP, WHIP, SRT, etc.). This makes it the most universally available egress and the simplest default. ffmpeg pulls it with a standard `-i` flag, no special protocol support required.
-
-### RTMP
-
-```
-rtmp://127.0.0.1:1935/{RTMP_APP}/{streamKey}
-```
-
-Connects directly to the RTMP mux inside MediaMTX. Use when HLS is disabled in the MediaMTX config or when the stream is sourced directly from RTMP and HLS is not generated.
-
-### WebRTC / WHEP
-
-```
-http://127.0.0.1:8889/{streamKey}/whep
-```
-
-MediaMTX exposes a WHEP (WebRTC HTTP Egress Protocol) endpoint. ffmpeg 6.1+ includes a built-in WHEP input demuxer — no native Node.js WebRTC dependency is required:
-
-```sh
-ffmpeg -i 'http://127.0.0.1:8889/{streamKey}/whep' ...
-```
-
-Requires ffmpeg ≥ 6.1 and MediaMTX's WebRTC port accessible from the backend host. No practical latency advantage for this use case; include for completeness and deployments where HLS/RTMP are disabled.
-
-### ffmpeg decode command (all sources)
-
-```sh
-ffmpeg -i <source_url> \
-  -vn \
-  -af "aresample=16000,aformat=sample_fmts=s16:channel_layouts=mono" \
-  -f s16le \
-  pipe:1
-```
-
-Raw PCM output on stdout: 16-bit signed little-endian, 16 000 Hz, 1 channel. This is the universal format accepted by all major STT APIs.
 
 ---
 
@@ -103,33 +93,23 @@ One `SttManager` instance is shared across all API keys (singleton, created by `
 ### Public API
 
 ```js
-// Start STT for an API key. Config is per-key; falls back to global defaults.
 await sttManager.start(apiKey, {
-  provider,       // 'whisper_http' | 'google' | 'openai'
-  language,       // BCP-47 (default: 'en-US')
-  audioSource,    // 'hls' | 'rtmp' | 'whep'  (default: 'hls')
-  streamKey,      // MediaMTX path (default: apiKey)
-  vadSilenceMs,   // silence gap that ends an utterance (default: 1000)
-  chunkDurationMs // max audio chunk length for batch providers (default: 5000)
+  provider,     // 'whisper_http' | 'google' | 'openai'
+  language,     // BCP-47 (default: 'en-US')
+  audioSource,  // 'hls' | 'rtmp' | 'whep'  (default: 'hls')
+  streamKey,    // MediaMTX path (default: apiKey)
 })
 
-// Stop STT for an API key.
 await sttManager.stop(apiKey)
-
-// Check if STT is running for an API key.
-sttManager.isRunning(apiKey)    // → boolean
-
-// Status info for an API key.
-sttManager.getStatus(apiKey)    // → { running, provider, language, startedAt, segmentsSent, lastTranscript }
-
-// Stop all active STT sessions.
+sttManager.isRunning(apiKey)   // → boolean
+sttManager.getStatus(apiKey)   // → { running, provider, language, startedAt, segmentsSent, lastTranscript }
 await sttManager.stopAll()
 ```
 
 ### Events (EventEmitter)
 
 ```js
-sttManager.on('transcript', ({ apiKey, text, isFinal, confidence, timestamp, provider }))
+sttManager.on('transcript', ({ apiKey, text, confidence, timestamp, provider }))
 sttManager.on('error',      ({ apiKey, error }))
 sttManager.on('stopped',    ({ apiKey }))
 ```
@@ -143,12 +123,12 @@ sttManager.on('stopped',    ({ apiKey }))
   language,
   audioSource,
   streamKey,
-  ffmpegHandle,   // FfmpegRunner handle
+  fetcher,        // HlsSegmentFetcher instance (HLS path)
+  ffmpegHandle,   // FfmpegRunner handle (RTMP/WHEP path only)
   adapter,        // SttAdapter instance
   startedAt,      // ISO timestamp
   segmentsSent,   // counter
   lastTranscript, // { text, timestamp }
-  stopped,        // boolean
 }
 ```
 
@@ -158,21 +138,22 @@ sttManager.on('stopped',    ({ apiKey }))
 
 **Directory:** `packages/plugins/lcyt-rtmp/src/stt-adapters/`
 
-All adapters implement the same interface:
+All adapters implement the same interface. For the HLS path, `sendSegment` is called once per HLS segment. For the ffmpeg fallback path, `write` is called with PCM chunks and the adapter handles its own buffering.
 
 ```js
 class SttAdapter extends EventEmitter {
-  // Called once: adapter sets up connection, buffers, etc.
   async start({ language, ...opts }) {}
 
-  // Called with each raw PCM chunk (Buffer, s16le 16kHz mono).
+  // HLS path: called once per segment with raw audio buffer and its playlist timestamp.
+  async sendSegment(buffer, { timestamp, duration }) {}
+
+  // ffmpeg fallback path: called with raw PCM chunks (s16le 16kHz mono).
   write(pcmChunk) {}
 
-  // Flush any buffered audio, wait for final transcripts, then clean up.
   async stop() {}
 
-  // Events emitted:
-  // 'transcript' { text, isFinal, confidence, timestamp }
+  // Events:
+  // 'transcript' { text, confidence, timestamp }
   // 'error'      { error }
 }
 ```
@@ -181,14 +162,16 @@ class SttAdapter extends EventEmitter {
 
 Connects to a running [whisper.cpp HTTP server](https://github.com/ggerganov/whisper.cpp/tree/master/examples/server).
 
-- Accumulates PCM into a rolling buffer.
-- On silence detection (energy below threshold for `vadSilenceMs` ms) OR when buffer reaches `chunkDurationMs`, encodes the chunk as WAV in memory.
-- `POST {WHISPER_HTTP_URL}/inference` with `multipart/form-data` audio file + language param.
-- Parses response `{ text }` and emits `transcript`.
-- The server loads the model once and handles concurrent requests; the adapter retries connection on startup with exponential backoff.
-- Supports Finnish (`fi`) and all other Whisper-supported languages.
+**HLS path:**
+- `POST {WHISPER_HTTP_URL}/inference` with the raw `.ts` segment buffer as `multipart/form-data`.
+- whisper.cpp uses ffmpeg internally and accepts MPEG-TS directly.
+- Uses the segment's playlist timestamp as the caption timestamp.
 
-**Environment variables:**
+**ffmpeg fallback path:**
+- Accumulates PCM into a rolling buffer.
+- Encodes each filled buffer as a WAV in memory and POSTs it.
+
+Supports Finnish (`fi`) and all other Whisper-supported languages.
 
 | Variable | Default | Purpose |
 |---|---|---|
@@ -199,19 +182,18 @@ Connects to a running [whisper.cpp HTTP server](https://github.com/ggerganov/whi
 
 Uses Google Cloud Speech-to-Text v1. Supports Finnish (`fi-FI`) and 125+ languages.
 
-**REST mode (simpler, higher latency):**
+**HLS path:**
 
-- Same buffer/silence strategy as WhisperHttpAdapter.
-- `POST https://speech.googleapis.com/v1/speech:recognize` with inline base64 PCM audio.
+Google STT does not accept MPEG-TS directly. Options:
 
-**Streaming gRPC mode (low latency):**
+1. **ffmpeg per-segment remux** (simplest): spawn a short-lived ffmpeg to extract AAC from the `.ts` buffer to an in-memory `.m4a` or raw `flac`/`wav`, then POST. Single-segment ffmpeg invocations are fast (~100 ms) and stateless.
+2. **fMP4 output from MediaMTX**: configure MediaMTX to produce fMP4 segments (`.m4s`). fMP4 audio (`mp4a`) is accepted by Google as `mp4`/`m4a`. Eliminates per-segment ffmpeg.
 
-- Opens a bidirectional gRPC stream via the `@google-cloud/speech` Node.js client.
-- Sends `StreamingRecognizeRequest` with PCM audio as it arrives.
-- Emits `transcript` on `is_final: true` results.
-- Automatically restarts the stream on the 5-minute Google API limit.
+The adapter supports both; option 2 is preferred when MediaMTX is configured for fMP4.
 
-**Environment variables:**
+**REST mode:** `POST https://speech.googleapis.com/v1/speech:recognize` with base64 audio.
+
+**gRPC streaming mode:** bidirectional stream via `@google-cloud/speech`; restarts automatically at the 5-minute API limit.
 
 | Variable | Default | Purpose |
 |---|---|---|
@@ -219,17 +201,18 @@ Uses Google Cloud Speech-to-Text v1. Supports Finnish (`fi-FI`) and 125+ languag
 | `GOOGLE_STT_KEY` | — | API key for REST fallback |
 | `GOOGLE_STT_MODE` | `rest` | `rest` or `grpc` |
 
+`@google-cloud/speech` is an **optional peer dependency** — the adapter catches the import failure and throws a descriptive error rather than crashing the server.
+
 ### OpenAiAdapter (`stt-adapters/openai.js`)
 
 Uses OpenAI's [Whisper API](https://platform.openai.com/docs/guides/speech-to-text) (`/v1/audio/transcriptions`), or any OpenAI-compatible endpoint (local whisper-openai-server, Ollama, Azure OpenAI).
 
-- Batch-only (no true streaming).
-- Accumulates PCM to WAV; POSTs on silence or max chunk size.
-- `multipart/form-data` with `model`, `language`, audio file.
-- Emits `transcript` with `isFinal: true` for each response.
-- Supports Finnish (`fi`) via Whisper's multilingual models.
+**HLS path:**
+- POST the raw `.ts` segment buffer as `multipart/form-data` with filename `segment.ts`.
+- OpenAI accepts `mp3`, `mp4`, `mpeg`, `mpga`, `m4a`, `wav`, `webm` — but `.ts` (MPEG-TS) is usually accepted in practice. If rejected, configure MediaMTX for fMP4 output (`segment.mp4`).
+- Uses the segment's playlist timestamp as the caption timestamp.
 
-**Environment variables:**
+Supports Finnish (`fi`) via Whisper's multilingual models.
 
 | Variable | Default | Purpose |
 |---|---|---|
@@ -239,12 +222,30 @@ Uses OpenAI's [Whisper API](https://platform.openai.com/docs/guides/speech-to-te
 
 ---
 
+## Fallback: ffmpeg pipe
+
+For `audioSource: 'rtmp'` or `audioSource: 'whep'`, there are no natural segments or playlist timestamps. `SttManager` falls back to the original ffmpeg PCM pipe approach:
+
+```sh
+# RTMP
+ffmpeg -i rtmp://127.0.0.1:1935/{app}/{streamKey} \
+  -vn -af "aresample=16000,aformat=sample_fmts=s16:channel_layouts=mono" \
+  -f s16le pipe:1
+
+# WHEP (ffmpeg ≥ 6.1)
+ffmpeg -i http://127.0.0.1:8889/{streamKey}/whep \
+  -vn -af "aresample=16000,aformat=sample_fmts=s16:channel_layouts=mono" \
+  -f s16le pipe:1
+```
+
+In this path, adapters use `write(pcmChunk)` instead of `sendSegment()`, and handle their own silence/chunk buffering. The HLS path is preferred for all deployments that have MediaMTX.
+
+---
+
 ## Transcript → Caption Delivery
 
-When a `transcript` event fires, `SttManager` looks up the active backend session for the API key from the `SessionStore`:
-
 ```js
-// Pseudo-code inside SttManager._onTranscript()
+// Inside SttManager._onTranscript()
 const session = store.getByApiKey(apiKey)
 if (!session) return  // no active session — discard
 
@@ -257,44 +258,42 @@ session._sendQueue.add(async () => {
 })
 ```
 
-This reuses the same `_sendQueue` serialisation that browser-originated captions use, ensuring sequence numbers stay monotonic even when server STT and browser input are used simultaneously.
+Reuses the same `_sendQueue` serialisation as browser-originated captions, keeping sequence numbers monotonic.
 
 ---
 
 ## Database
 
-New table `stt_config` (in `packages/plugins/lcyt-rtmp/src/db.js` migrations):
+New table `stt_config` (added to `packages/plugins/lcyt-rtmp/src/db.js` migrations):
 
 ```sql
 CREATE TABLE IF NOT EXISTS stt_config (
-  api_key           TEXT PRIMARY KEY,
-  provider          TEXT NOT NULL DEFAULT 'whisper_http',
-  language          TEXT NOT NULL DEFAULT 'en-US',
-  audio_source      TEXT NOT NULL DEFAULT 'hls',
-  stream_key        TEXT,           -- NULL means use api_key as the MediaMTX path
-  auto_start        INTEGER NOT NULL DEFAULT 0,
-  vad_silence_ms    INTEGER NOT NULL DEFAULT 1000,
-  chunk_duration_ms INTEGER NOT NULL DEFAULT 5000,
-  created_at        INTEGER NOT NULL DEFAULT (strftime('%s','now')),
-  updated_at        INTEGER NOT NULL DEFAULT (strftime('%s','now'))
+  api_key      TEXT PRIMARY KEY,
+  provider     TEXT NOT NULL DEFAULT 'whisper_http',
+  language     TEXT NOT NULL DEFAULT 'en-US',
+  audio_source TEXT NOT NULL DEFAULT 'hls',
+  stream_key   TEXT,         -- NULL → use api_key as the MediaMTX path
+  auto_start   INTEGER NOT NULL DEFAULT 0,
+  created_at   INTEGER NOT NULL DEFAULT (strftime('%s','now')),
+  updated_at   INTEGER NOT NULL DEFAULT (strftime('%s','now'))
 );
 ```
 
-`auto_start = 1`: when MediaMTX fires the `on_publish` callback for this key, the backend automatically calls `sttManager.start()`.
+`vad_silence_ms` and `chunk_duration_ms` are removed — segment boundaries replace them for the HLS path.
 
 ---
 
 ## API Routes
 
-Mounted at `/stt` in `packages/lcyt-backend/src/routes/stt.js`. All endpoints require the standard session Bearer token (`Authorization: Bearer <session-token>`).
+Mounted at `/stt` in `packages/lcyt-backend/src/routes/stt.js`. All endpoints require the standard session Bearer token.
 
 ```
-GET  /stt/status           — current STT session state for the authenticated API key
-POST /stt/start            — start STT (body: { provider?, language?, audioSource?, streamKey? })
-POST /stt/stop             — stop STT
-GET  /stt/events           — SSE stream of transcript events (Bearer or ?token=)
-GET  /stt/config           — get per-key STT config from DB
-PUT  /stt/config           — update per-key STT config (body: any stt_config fields)
+GET  /stt/status    — current STT session state for the authenticated API key
+POST /stt/start     — start STT (body: { provider?, language?, audioSource?, streamKey? })
+POST /stt/stop      — stop STT
+GET  /stt/events    — SSE stream of transcript events (Bearer or ?token=)
+GET  /stt/config    — get per-key STT config from DB
+PUT  /stt/config    — update per-key STT config
 ```
 
 ### SSE events (on `GET /stt/events`)
@@ -302,7 +301,7 @@ PUT  /stt/config           — update per-key STT config (body: any stt_config f
 | Event | Payload |
 |---|---|
 | `connected` | `{ apiKey, provider, language }` |
-| `transcript` | `{ text, isFinal, confidence, timestamp, provider }` |
+| `transcript` | `{ text, confidence, timestamp, provider }` |
 | `stt_started` | `{ provider, language, audioSource }` |
 | `stt_stopped` | `{ apiKey }` |
 | `stt_error` | `{ error }` |
@@ -314,28 +313,23 @@ PUT  /stt/config           — update per-key STT config (body: any stt_config f
 The existing `on_publish` RTMP callback is extended:
 
 ```js
-// After registering the publisher in the DB / managers:
 const cfg = db.getSttConfig(apiKey)
 if (cfg?.auto_start) {
   await sttManager.start(apiKey, cfg)
 }
 ```
 
-Similarly, `on_publish_done` calls `sttManager.stop(apiKey)`.
+`on_publish_done` calls `sttManager.stop(apiKey)`.
 
 ---
 
 ## Environment Variables
-
-Global defaults (overridden per key via `PUT /stt/config`):
 
 | Variable | Default | Purpose |
 |---|---|---|
 | `STT_PROVIDER` | `whisper_http` | Default provider: `whisper_http` \| `google` \| `openai` |
 | `STT_DEFAULT_LANGUAGE` | `en-US` | Default recognition language (BCP-47) |
 | `STT_AUDIO_SOURCE` | `hls` | Default audio source: `hls` \| `rtmp` \| `whep` |
-| `STT_CHUNK_DURATION_MS` | `5000` | Max audio chunk length for batch providers |
-| `STT_VAD_SILENCE_MS` | `1000` | Silence gap (ms) that ends an utterance |
 | `WHISPER_HTTP_URL` | — | whisper.cpp HTTP server URL |
 | `WHISPER_HTTP_MODEL` | — | Whisper model name (optional) |
 | `GOOGLE_APPLICATION_CREDENTIALS` | — | Google service account JSON path |
@@ -349,35 +343,35 @@ Global defaults (overridden per key via `PUT /stt/config`):
 
 ## Implementation Phases
 
-### Phase 1 — Core pipeline (MVP)
+### Phase 1 — HLS segment fetch + Whisper (MVP)
 
-- `SttManager` with RTMP pull via ffmpeg.
-- `WhisperHttpAdapter` (silence-based chunking, WAV encoding in memory, HTTP POST).
+- `HlsSegmentFetcher`: playlist poll, new-segment detection, timestamp extraction, segment buffer fetch.
+- `SttManager` wiring fetcher → adapter → transcript → `_sendQueue`.
+- `WhisperHttpAdapter`: direct MPEG-TS segment POST to whisper.cpp server.
 - DB migration for `stt_config`.
-- `/stt` routes: `status`, `start`, `stop`, `config`.
-- Integration with `_sendQueue` for transcript delivery.
+- `/stt` routes: `start`, `stop`, `status`, `config`.
 - `on_publish` auto-start hook.
 
-**Deliverable:** Fully headless Finnish/multilingual captioning from an RTMP stream using a local whisper.cpp server.
+**Deliverable:** Fully headless Finnish/multilingual captioning from any MediaMTX stream with no ffmpeg in the hot path.
 
-### Phase 2 — All three audio sources + cloud providers
+### Phase 2 — Cloud providers + ffmpeg fallback
 
-- HLS and WHEP audio sources in `SttManager` (ffmpeg WHEP input requires ffmpeg ≥ 6.1; probe version on startup and warn if unavailable).
-- `GoogleSttAdapter` (REST mode first; gRPC streaming as a follow-up).
-- `OpenAiAdapter` (chunked REST, OpenAI-compatible endpoint support).
+- `GoogleSttAdapter` (REST + optional fMP4 path; gRPC streaming as follow-up).
+- `OpenAiAdapter` (chunked REST, OpenAI-compatible endpoints).
+- ffmpeg PCM pipe fallback for RTMP and WHEP sources.
+- WHEP: probe ffmpeg version on startup; warn if < 6.1.
 
 ### Phase 3 — SSE transcript stream + UI
 
 - `GET /stt/events` SSE endpoint.
-- lcyt-web: STT status indicator in `StatusBar` (shows "Server STT: whisper / fi-FI").
-- lcyt-web: `EmbedSettingsPage` CC tab — new "Server STT" section for provider, language, audio source, and auto-start toggle.
-- lcyt-web: `GET /stt/status` polled or SSE-driven for real-time state.
+- lcyt-web: Server STT status indicator in `StatusBar`.
+- lcyt-web: Server STT config section in `EmbedSettingsPage` CC tab (provider, language, audio source, auto-start toggle).
 
 ### Phase 4 — Quality controls
 
 - Confidence threshold filtering (discard low-confidence segments).
-- Punctuation normalisation for providers that don't punctuate.
-- Per-key silence sensitivity and chunk duration configurable at runtime via `PUT /stt/config`.
+- Punctuation normalisation for providers that omit it.
+- Skip silent/empty segments before sending to the STT API (energy check on the buffer).
 
 ---
 
@@ -385,6 +379,7 @@ Global defaults (overridden per key via `PUT /stt/config`):
 
 | Action | File | Notes |
 |---|---|---|
+| Create | `packages/plugins/lcyt-rtmp/src/hls-segment-fetcher.js` | HLS playlist poll + segment fetch |
 | Create | `packages/plugins/lcyt-rtmp/src/stt-manager.js` | SttManager class |
 | Create | `packages/plugins/lcyt-rtmp/src/stt-adapters/whisper-http.js` | WhisperHttpAdapter |
 | Create | `packages/plugins/lcyt-rtmp/src/stt-adapters/google-stt.js` | GoogleSttAdapter |
@@ -400,12 +395,12 @@ Global defaults (overridden per key via `PUT /stt/config`):
 
 ## Open Questions
 
-1. **Simultaneous browser + server STT**: Should they be allowed to co-exist on the same session? Currently both would write into the same `_sendQueue`, which is safe but could produce interleaved output. A mutex flag (`serverSttActive`) on the session could prevent browser sends while server STT is running.
+1. **MPEG-TS vs fMP4 segments**: MediaMTX can output either. fMP4 (`.m4s`) is more widely accepted by STT APIs. Should the plan recommend a specific MediaMTX `hlsVariant` setting, or handle both transparently by sniffing the segment URL extension?
 
-2. **streamKey vs apiKey for MediaMTX path**: In the current radio/HLS flow the MediaMTX path is derived from `apiKey`. For RTMP relay scenarios the user configures an explicit `streamKey`. The `stt_config.stream_key` column is nullable; when null, use `apiKey` as the MediaMTX path.
+2. **Simultaneous browser + server STT**: Both write into the same `_sendQueue` — safe for ordering but could produce interleaved output. A mutex flag (`serverSttActive`) on the session could block browser sends while server STT is running.
 
-3. **VAD strategy**: Simple energy-based silence detection inside the adapter is sufficient for phase 1. A more sophisticated approach (e.g. Silero VAD via onnxruntime) could be added later for noisy environments.
+3. **streamKey vs apiKey for MediaMTX path**: `stt_config.stream_key` is nullable; when null, use `apiKey` as the MediaMTX HLS path. This matches the existing convention in `RadioManager`.
 
-4. **ffmpeg WHEP availability**: The WHEP input demuxer (`-f rtc` / `whep://`) was added in ffmpeg 6.1 as an experimental feature. `SttManager` should probe the ffmpeg version and enabled protocols at startup and log a warning (not an error) if WHEP is unavailable, falling back to RTMP or HLS for that session.
+4. **Google gRPC dependency**: `@google-cloud/speech` pulls in native gRPC bindings. Optional peer dep — fail with a clear error message if not installed.
 
-5. **Google gRPC dependency**: `@google-cloud/speech` pulls in gRPC native bindings. Make this an optional peer dependency — the adapter catches the `require()` failure and throws a clear error ("install @google-cloud/speech to use the google provider") rather than crashing the server.
+5. **Empty segment handling**: Short silence periods still produce audio segments. A lightweight energy check (sum of absolute sample values) on the decoded PCM — or simply checking the segment file size against a threshold — can skip blank segments before sending to the STT API, saving cost and avoiding spurious transcripts.

--- a/docs/plans/plan_server_stt.md
+++ b/docs/plans/plan_server_stt.md
@@ -2,7 +2,7 @@
 id: plan/server-stt
 title: "Server-side Speech-to-Text (STT)"
 status: draft
-summary: "Server-side audio capture from MediaMTX (HLS or RTMP) piped through ffmpeg into pluggable STT provider adapters; transcripts delivered into the existing caption pipeline without any browser involvement."
+summary: "Server-side audio capture from MediaMTX (RTMP, HLS, or WebRTC/WHEP) piped through ffmpeg into pluggable STT provider adapters (whisper.cpp, Google Cloud STT, OpenAI-compatible Whisper); transcripts delivered into the existing caption pipeline without any browser involvement."
 ---
 
 # Server-side Speech-to-Text (STT)
@@ -15,7 +15,7 @@ summary: "Server-side audio capture from MediaMTX (HLS or RTMP) piped through ff
 
 The existing STT integration is entirely browser-based — the browser captures the microphone, runs recognition, and POSTs final transcripts to the backend. Server-side STT removes the browser dependency entirely:
 
-- The audio source is a live RTMP/HLS stream already flowing through MediaMTX.
+- The audio source is a live stream already flowing through MediaMTX.
 - The server captures, decodes, and recognises the audio using a pluggable provider.
 - Transcripts are delivered into the existing caption-send pipeline just like browser-originated text.
 - Useful for: automated captioning of hardware streams (cameras, mixers, broadcast hardware), headless/unattended deployments, and scenarios where no operator browser is available.
@@ -26,47 +26,61 @@ The existing STT integration is entirely browser-based — the browser captures 
 
 ```
 MediaMTX                  SttManager (per API key)
-  RTMP  ──► ffmpeg ──► PCM 16 kHz mono (stdout pipe)
-  HLS   ──► (pull)       │
-                         ▼
-                    SttAdapter (pluggable)
-                    ├─ WhisperHttpAdapter  (whisper.cpp HTTP server)
-                    ├─ DeepgramAdapter     (WebSocket streaming)
-                    ├─ GoogleSttAdapter    (REST chunked or gRPC streaming)
-                    └─ OpenAiAdapter       (chunked REST)
-                         │
-                    transcript events
-                         │
-                         ▼
-                    session._sendQueue    (existing caption delivery)
-                    ├─ YouTube targets
-                    ├─ viewer targets
-                    └─ generic targets
+  RTMP  ─┐
+  HLS   ─┼──► ffmpeg ──► PCM 16 kHz mono (stdout pipe)
+  WHEP  ─┘                    │
+                              ▼
+                         SttAdapter (pluggable)
+                         ├─ WhisperHttpAdapter  (whisper.cpp HTTP server)
+                         ├─ GoogleSttAdapter    (REST chunked or gRPC streaming)
+                         └─ OpenAiAdapter       (chunked REST, OpenAI-compatible)
+                              │
+                         transcript events
+                              │
+                              ▼
+                         session._sendQueue    (existing caption delivery)
+                         ├─ YouTube targets
+                         ├─ viewer targets
+                         └─ generic targets
 ```
 
 ---
 
 ## Audio Source
 
-### RTMP pull (preferred — lowest latency)
+MediaMTX exposes three egress protocols, all accessible to ffmpeg. The choice is a deployment configuration decision — there is no preferred or fallback hierarchy; all three are first-class options.
 
-ffmpeg connects to MediaMTX's internal RTMP endpoint and reads audio directly from the mux:
+### RTMP
 
 ```
 rtmp://127.0.0.1:1935/{RTMP_APP}/{streamKey}
 ```
 
-No segment buffering. Latency matches the RTMP ingest latency (~1–3 s end-to-end).
+Connects directly to the RTMP mux inside MediaMTX. Latency matches the ingest latency (~1–3 s end-to-end). Works as long as the stream is publishing to MediaMTX over RTMP.
 
-### HLS pull (fallback — simpler, higher latency)
+### HLS
 
 ```
 http://127.0.0.1:8080/{streamKey}/index.m3u8
 ```
 
-Adds one HLS segment duration of latency (typically 2–6 s). Use when RTMP pull is not available (e.g. MediaMTX is configured for HLS-only egress).
+MediaMTX generates HLS segments natively. Standard HLS adds one segment duration of latency (typically 2–6 s). MediaMTX also supports **Low-Latency HLS (LL-HLS)**, which reduces this to ~1–2 s. Use when RTMP is not available or when HLS is the only egress configured.
 
-### ffmpeg decode command (both sources)
+### WebRTC / WHEP
+
+```
+http://127.0.0.1:8889/{streamKey}/whep
+```
+
+MediaMTX exposes a WHEP (WebRTC HTTP Egress Protocol) endpoint. ffmpeg 6.1+ includes a built-in WHEP input demuxer — no native Node.js WebRTC dependency is required:
+
+```sh
+ffmpeg -i 'http://127.0.0.1:8889/{streamKey}/whep' ...
+```
+
+WHEP gives the lowest end-to-end latency (~200–500 ms). Requires ffmpeg ≥ 6.1 and MediaMTX's WebRTC port to be accessible from the backend host.
+
+### ffmpeg decode command (all sources)
 
 ```sh
 ffmpeg -i <source_url> \
@@ -91,10 +105,10 @@ One `SttManager` instance is shared across all API keys (singleton, created by `
 ```js
 // Start STT for an API key. Config is per-key; falls back to global defaults.
 await sttManager.start(apiKey, {
-  provider,       // 'whisper_http' | 'deepgram' | 'google' | 'openai'
+  provider,       // 'whisper_http' | 'google' | 'openai'
   language,       // BCP-47 (default: 'en-US')
-  audioSource,    // 'rtmp' | 'hls'  (default: 'rtmp')
-  streamKey,      // RTMP/HLS path in MediaMTX (default: apiKey)
+  audioSource,    // 'rtmp' | 'hls' | 'whep'  (default: 'rtmp')
+  streamKey,      // MediaMTX path (default: apiKey)
   vadSilenceMs,   // silence gap that ends an utterance (default: 1000)
   chunkDurationMs // max audio chunk length for batch providers (default: 5000)
 })
@@ -171,6 +185,8 @@ Connects to a running [whisper.cpp HTTP server](https://github.com/ggerganov/whi
 - On silence detection (energy below threshold for `vadSilenceMs` ms) OR when buffer reaches `chunkDurationMs`, encodes the chunk as WAV in memory.
 - `POST {WHISPER_HTTP_URL}/inference` with `multipart/form-data` audio file + language param.
 - Parses response `{ text }` and emits `transcript`.
+- The server loads the model once and handles concurrent requests; the adapter retries connection on startup with exponential backoff.
+- Supports Finnish (`fi`) and all other Whisper-supported languages.
 
 **Environment variables:**
 
@@ -179,23 +195,9 @@ Connects to a running [whisper.cpp HTTP server](https://github.com/ggerganov/whi
 | `WHISPER_HTTP_URL` | — | whisper.cpp server base URL (e.g. `http://localhost:8080`) |
 | `WHISPER_HTTP_MODEL` | (server default) | Model name sent in request (optional) |
 
-### DeepgramAdapter (`stt-adapters/deepgram.js`)
-
-Uses Deepgram's [live streaming API](https://developers.deepgram.com/docs/getting-started-with-live-streaming-audio).
-
-- Opens a WebSocket to `wss://api.deepgram.com/v1/listen` with query params for language, encoding (`linear16`), `sample_rate=16000`, `channels=1`.
-- Pipes PCM chunks directly to the WebSocket.
-- Receives interim and final `Results` messages; emits `transcript` for finals.
-
-**Environment variables:**
-
-| Variable | Default | Purpose |
-|---|---|---|
-| `DEEPGRAM_API_KEY` | — | Deepgram API key |
-
 ### GoogleSttAdapter (`stt-adapters/google-stt.js`)
 
-Uses Google Cloud Speech-to-Text v1 [streaming recognition](https://cloud.google.com/speech-to-text/docs/streaming-recognize) via the Node.js client library, or falls back to chunked REST if gRPC is not available.
+Uses Google Cloud Speech-to-Text v1. Supports Finnish (`fi-FI`) and 125+ languages.
 
 **REST mode (simpler, higher latency):**
 
@@ -204,9 +206,10 @@ Uses Google Cloud Speech-to-Text v1 [streaming recognition](https://cloud.google
 
 **Streaming gRPC mode (low latency):**
 
-- Opens a bidirectional gRPC stream.
+- Opens a bidirectional gRPC stream via the `@google-cloud/speech` Node.js client.
 - Sends `StreamingRecognizeRequest` with PCM audio as it arrives.
 - Emits `transcript` on `is_final: true` results.
+- Automatically restarts the stream on the 5-minute Google API limit.
 
 **Environment variables:**
 
@@ -218,20 +221,21 @@ Uses Google Cloud Speech-to-Text v1 [streaming recognition](https://cloud.google
 
 ### OpenAiAdapter (`stt-adapters/openai.js`)
 
-Uses OpenAI's [Whisper API](https://platform.openai.com/docs/guides/speech-to-text) (`/v1/audio/transcriptions`).
+Uses OpenAI's [Whisper API](https://platform.openai.com/docs/guides/speech-to-text) (`/v1/audio/transcriptions`), or any OpenAI-compatible endpoint (local whisper-openai-server, Ollama, Azure OpenAI).
 
-- Batch-only (no streaming).
+- Batch-only (no true streaming).
 - Accumulates PCM to WAV; POSTs on silence or max chunk size.
-- `multipart/form-data` with `model=whisper-1`, `language`, audio file.
+- `multipart/form-data` with `model`, `language`, audio file.
 - Emits `transcript` with `isFinal: true` for each response.
+- Supports Finnish (`fi`) via Whisper's multilingual models.
 
 **Environment variables:**
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `OPENAI_API_KEY` | — | OpenAI API key |
+| `OPENAI_API_KEY` | — | OpenAI API key (or local server key) |
 | `OPENAI_STT_MODEL` | `whisper-1` | Model name |
-| `OPENAI_BASE_URL` | `https://api.openai.com/v1` | Override for compatible endpoints (e.g. local Ollama or Azure) |
+| `OPENAI_BASE_URL` | `https://api.openai.com/v1` | Override for local or Azure endpoints |
 
 ---
 
@@ -242,7 +246,7 @@ When a `transcript` event fires, `SttManager` looks up the active backend sessio
 ```js
 // Pseudo-code inside SttManager._onTranscript()
 const session = store.getByApiKey(apiKey)
-if (!session) return  // no active session — discard or buffer
+if (!session) return  // no active session — discard
 
 const text = transcript.text.trim()
 if (!text) return
@@ -263,16 +267,16 @@ New table `stt_config` (in `packages/plugins/lcyt-rtmp/src/db.js` migrations):
 
 ```sql
 CREATE TABLE IF NOT EXISTS stt_config (
-  api_key         TEXT PRIMARY KEY,
-  provider        TEXT NOT NULL DEFAULT 'whisper_http',
-  language        TEXT NOT NULL DEFAULT 'en-US',
-  audio_source    TEXT NOT NULL DEFAULT 'rtmp',
-  stream_key      TEXT,           -- NULL means use api_key as the MediaMTX path
-  auto_start      INTEGER NOT NULL DEFAULT 0,
-  vad_silence_ms  INTEGER NOT NULL DEFAULT 1000,
+  api_key           TEXT PRIMARY KEY,
+  provider          TEXT NOT NULL DEFAULT 'whisper_http',
+  language          TEXT NOT NULL DEFAULT 'en-US',
+  audio_source      TEXT NOT NULL DEFAULT 'rtmp',
+  stream_key        TEXT,           -- NULL means use api_key as the MediaMTX path
+  auto_start        INTEGER NOT NULL DEFAULT 0,
+  vad_silence_ms    INTEGER NOT NULL DEFAULT 1000,
   chunk_duration_ms INTEGER NOT NULL DEFAULT 5000,
-  created_at      INTEGER NOT NULL DEFAULT (strftime('%s','now')),
-  updated_at      INTEGER NOT NULL DEFAULT (strftime('%s','now'))
+  created_at        INTEGER NOT NULL DEFAULT (strftime('%s','now')),
+  updated_at        INTEGER NOT NULL DEFAULT (strftime('%s','now'))
 );
 ```
 
@@ -299,7 +303,7 @@ PUT  /stt/config           — update per-key STT config (body: any stt_config f
 |---|---|
 | `connected` | `{ apiKey, provider, language }` |
 | `transcript` | `{ text, isFinal, confidence, timestamp, provider }` |
-| `stt_started` | `{ provider, language }` |
+| `stt_started` | `{ provider, language, audioSource }` |
 | `stt_stopped` | `{ apiKey }` |
 | `stt_error` | `{ error }` |
 
@@ -307,7 +311,7 @@ PUT  /stt/config           — update per-key STT config (body: any stt_config f
 
 ## Auto-start on Publish
 
-The existing `on_publish` RTMP callback (`POST /rtmp/on_publish` or `/radio-rtmp/on_publish`) is extended:
+The existing `on_publish` RTMP callback is extended:
 
 ```js
 // After registering the publisher in the DB / managers:
@@ -327,14 +331,13 @@ Global defaults (overridden per key via `PUT /stt/config`):
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `STT_PROVIDER` | `whisper_http` | Default provider: `whisper_http` \| `deepgram` \| `google` \| `openai` |
+| `STT_PROVIDER` | `whisper_http` | Default provider: `whisper_http` \| `google` \| `openai` |
 | `STT_DEFAULT_LANGUAGE` | `en-US` | Default recognition language (BCP-47) |
-| `STT_AUDIO_SOURCE` | `rtmp` | Default audio source: `rtmp` \| `hls` |
+| `STT_AUDIO_SOURCE` | `rtmp` | Default audio source: `rtmp` \| `hls` \| `whep` |
 | `STT_CHUNK_DURATION_MS` | `5000` | Max audio chunk length for batch providers |
 | `STT_VAD_SILENCE_MS` | `1000` | Silence gap (ms) that ends an utterance |
 | `WHISPER_HTTP_URL` | — | whisper.cpp HTTP server URL |
 | `WHISPER_HTTP_MODEL` | — | Whisper model name (optional) |
-| `DEEPGRAM_API_KEY` | — | Deepgram API key |
 | `GOOGLE_APPLICATION_CREDENTIALS` | — | Google service account JSON path |
 | `GOOGLE_STT_KEY` | — | Google API key (REST fallback) |
 | `GOOGLE_STT_MODE` | `rest` | `rest` or `grpc` |
@@ -355,27 +358,26 @@ Global defaults (overridden per key via `PUT /stt/config`):
 - Integration with `_sendQueue` for transcript delivery.
 - `on_publish` auto-start hook.
 
-**Deliverable:** Fully headless captioning from an RTMP stream using a local whisper.cpp server.
+**Deliverable:** Fully headless Finnish/multilingual captioning from an RTMP stream using a local whisper.cpp server.
 
-### Phase 2 — Streaming providers
+### Phase 2 — All three audio sources + cloud providers
 
-- `DeepgramAdapter` (WebSocket, true streaming, low latency).
+- HLS and WHEP audio sources in `SttManager` (ffmpeg WHEP input requires ffmpeg ≥ 6.1; probe version on startup and warn if unavailable).
 - `GoogleSttAdapter` (REST mode first; gRPC streaming as a follow-up).
-- `OpenAiAdapter` (chunked REST, OpenAI-compatible endpoint support for local Ollama).
+- `OpenAiAdapter` (chunked REST, OpenAI-compatible endpoint support).
 
 ### Phase 3 — SSE transcript stream + UI
 
 - `GET /stt/events` SSE endpoint.
-- lcyt-web: STT status indicator in `StatusBar` (shows "Server STT active: deepgram / en-US").
-- lcyt-web: `EmbedSettingsPage` CC tab — new "Server STT" section for provider/language/auto-start toggle.
+- lcyt-web: STT status indicator in `StatusBar` (shows "Server STT: whisper / fi-FI").
+- lcyt-web: `EmbedSettingsPage` CC tab — new "Server STT" section for provider, language, audio source, and auto-start toggle.
 - lcyt-web: `GET /stt/status` polled or SSE-driven for real-time state.
 
-### Phase 4 — HLS source + quality controls
+### Phase 4 — Quality controls
 
-- HLS pull fallback in `SttManager` (when `audioSource: 'hls'`).
 - Confidence threshold filtering (discard low-confidence segments).
 - Punctuation normalisation for providers that don't punctuate.
-- Per-key silence sensitivity and chunk duration configurable at runtime.
+- Per-key silence sensitivity and chunk duration configurable at runtime via `PUT /stt/config`.
 
 ---
 
@@ -385,7 +387,6 @@ Global defaults (overridden per key via `PUT /stt/config`):
 |---|---|---|
 | Create | `packages/plugins/lcyt-rtmp/src/stt-manager.js` | SttManager class |
 | Create | `packages/plugins/lcyt-rtmp/src/stt-adapters/whisper-http.js` | WhisperHttpAdapter |
-| Create | `packages/plugins/lcyt-rtmp/src/stt-adapters/deepgram.js` | DeepgramAdapter |
 | Create | `packages/plugins/lcyt-rtmp/src/stt-adapters/google-stt.js` | GoogleSttAdapter |
 | Create | `packages/plugins/lcyt-rtmp/src/stt-adapters/openai.js` | OpenAiAdapter |
 | Create | `packages/lcyt-backend/src/routes/stt.js` | /stt Express router |
@@ -401,10 +402,10 @@ Global defaults (overridden per key via `PUT /stt/config`):
 
 1. **Simultaneous browser + server STT**: Should they be allowed to co-exist on the same session? Currently both would write into the same `_sendQueue`, which is safe but could produce interleaved output. A mutex flag (`serverSttActive`) on the session could prevent browser sends while server STT is running.
 
-2. **streamKey vs apiKey for MediaMTX path**: In the current radio/HLS flow the MediaMTX path is derived from `apiKey`. For RTMP relay scenarios the user configures an explicit `streamKey` (the RTMP stream name). The `stt_config.stream_key` column is nullable; when null, use `apiKey` as the MediaMTX path.
+2. **streamKey vs apiKey for MediaMTX path**: In the current radio/HLS flow the MediaMTX path is derived from `apiKey`. For RTMP relay scenarios the user configures an explicit `streamKey`. The `stt_config.stream_key` column is nullable; when null, use `apiKey` as the MediaMTX path.
 
-3. **VAD strategy**: Simple energy-based silence detection inside the adapter is sufficient for phase 1. A more sophisticated approach (e.g. Silero VAD via onnxruntime) could be added in a later phase for noisy environments.
+3. **VAD strategy**: Simple energy-based silence detection inside the adapter is sufficient for phase 1. A more sophisticated approach (e.g. Silero VAD via onnxruntime) could be added later for noisy environments.
 
-4. **Whisper.cpp server vs CLI**: The HTTP server mode (`./server`) is preferred over spawning the CLI (`./main`) per chunk because it loads the model once and handles concurrent requests. The adapter should retry connection on startup with exponential backoff.
+4. **ffmpeg WHEP availability**: The WHEP input demuxer (`-f rtc` / `whep://`) was added in ffmpeg 6.1 as an experimental feature. `SttManager` should probe the ffmpeg version and enabled protocols at startup and log a warning (not an error) if WHEP is unavailable, falling back to RTMP or HLS for that session.
 
-5. **WHEP audio pull**: MediaMTX exposes a WHEP endpoint (`/whep/{key}`) for WebRTC egress. Pulling audio over WebRTC from Node.js (e.g. via `node-datachannel` or `wrtc`) is significantly more complex than RTMP/HLS pull and adds a native dependency. Deferred to a potential Phase 5.
+5. **Google gRPC dependency**: `@google-cloud/speech` pulls in gRPC native bindings. Make this an optional peer dependency — the adapter catches the `require()` failure and throws a clear error ("install @google-cloud/speech to use the google provider") rather than crashing the server.

--- a/docs/plans/plan_server_stt.md
+++ b/docs/plans/plan_server_stt.md
@@ -1,0 +1,410 @@
+---
+id: plan/server-stt
+title: "Server-side Speech-to-Text (STT)"
+status: draft
+summary: "Server-side audio capture from MediaMTX (HLS or RTMP) piped through ffmpeg into pluggable STT provider adapters; transcripts delivered into the existing caption pipeline without any browser involvement."
+---
+
+# Server-side Speech-to-Text (STT)
+
+**Scope:** New `SttManager` class in `packages/plugins/lcyt-rtmp`; new `/stt` routes in `packages/lcyt-backend`; optional UI controls in `packages/lcyt-web`.
+
+---
+
+## Motivation
+
+The existing STT integration is entirely browser-based — the browser captures the microphone, runs recognition, and POSTs final transcripts to the backend. Server-side STT removes the browser dependency entirely:
+
+- The audio source is a live RTMP/HLS stream already flowing through MediaMTX.
+- The server captures, decodes, and recognises the audio using a pluggable provider.
+- Transcripts are delivered into the existing caption-send pipeline just like browser-originated text.
+- Useful for: automated captioning of hardware streams (cameras, mixers, broadcast hardware), headless/unattended deployments, and scenarios where no operator browser is available.
+
+---
+
+## Architecture Overview
+
+```
+MediaMTX                  SttManager (per API key)
+  RTMP  ──► ffmpeg ──► PCM 16 kHz mono (stdout pipe)
+  HLS   ──► (pull)       │
+                         ▼
+                    SttAdapter (pluggable)
+                    ├─ WhisperHttpAdapter  (whisper.cpp HTTP server)
+                    ├─ DeepgramAdapter     (WebSocket streaming)
+                    ├─ GoogleSttAdapter    (REST chunked or gRPC streaming)
+                    └─ OpenAiAdapter       (chunked REST)
+                         │
+                    transcript events
+                         │
+                         ▼
+                    session._sendQueue    (existing caption delivery)
+                    ├─ YouTube targets
+                    ├─ viewer targets
+                    └─ generic targets
+```
+
+---
+
+## Audio Source
+
+### RTMP pull (preferred — lowest latency)
+
+ffmpeg connects to MediaMTX's internal RTMP endpoint and reads audio directly from the mux:
+
+```
+rtmp://127.0.0.1:1935/{RTMP_APP}/{streamKey}
+```
+
+No segment buffering. Latency matches the RTMP ingest latency (~1–3 s end-to-end).
+
+### HLS pull (fallback — simpler, higher latency)
+
+```
+http://127.0.0.1:8080/{streamKey}/index.m3u8
+```
+
+Adds one HLS segment duration of latency (typically 2–6 s). Use when RTMP pull is not available (e.g. MediaMTX is configured for HLS-only egress).
+
+### ffmpeg decode command (both sources)
+
+```sh
+ffmpeg -i <source_url> \
+  -vn \
+  -af "aresample=16000,aformat=sample_fmts=s16:channel_layouts=mono" \
+  -f s16le \
+  pipe:1
+```
+
+Raw PCM output on stdout: 16-bit signed little-endian, 16 000 Hz, 1 channel. This is the universal format accepted by all major STT APIs.
+
+---
+
+## SttManager
+
+**File:** `packages/plugins/lcyt-rtmp/src/stt-manager.js`
+
+One `SttManager` instance is shared across all API keys (singleton, created by `initRtmpControl`). It manages per-key STT sessions internally.
+
+### Public API
+
+```js
+// Start STT for an API key. Config is per-key; falls back to global defaults.
+await sttManager.start(apiKey, {
+  provider,       // 'whisper_http' | 'deepgram' | 'google' | 'openai'
+  language,       // BCP-47 (default: 'en-US')
+  audioSource,    // 'rtmp' | 'hls'  (default: 'rtmp')
+  streamKey,      // RTMP/HLS path in MediaMTX (default: apiKey)
+  vadSilenceMs,   // silence gap that ends an utterance (default: 1000)
+  chunkDurationMs // max audio chunk length for batch providers (default: 5000)
+})
+
+// Stop STT for an API key.
+await sttManager.stop(apiKey)
+
+// Check if STT is running for an API key.
+sttManager.isRunning(apiKey)    // → boolean
+
+// Status info for an API key.
+sttManager.getStatus(apiKey)    // → { running, provider, language, startedAt, segmentsSent, lastTranscript }
+
+// Stop all active STT sessions.
+await sttManager.stopAll()
+```
+
+### Events (EventEmitter)
+
+```js
+sttManager.on('transcript', ({ apiKey, text, isFinal, confidence, timestamp, provider }))
+sttManager.on('error',      ({ apiKey, error }))
+sttManager.on('stopped',    ({ apiKey }))
+```
+
+### Per-key session state (internal)
+
+```js
+{
+  apiKey,
+  provider,
+  language,
+  audioSource,
+  streamKey,
+  ffmpegHandle,   // FfmpegRunner handle
+  adapter,        // SttAdapter instance
+  startedAt,      // ISO timestamp
+  segmentsSent,   // counter
+  lastTranscript, // { text, timestamp }
+  stopped,        // boolean
+}
+```
+
+---
+
+## STT Provider Adapters
+
+**Directory:** `packages/plugins/lcyt-rtmp/src/stt-adapters/`
+
+All adapters implement the same interface:
+
+```js
+class SttAdapter extends EventEmitter {
+  // Called once: adapter sets up connection, buffers, etc.
+  async start({ language, ...opts }) {}
+
+  // Called with each raw PCM chunk (Buffer, s16le 16kHz mono).
+  write(pcmChunk) {}
+
+  // Flush any buffered audio, wait for final transcripts, then clean up.
+  async stop() {}
+
+  // Events emitted:
+  // 'transcript' { text, isFinal, confidence, timestamp }
+  // 'error'      { error }
+}
+```
+
+### WhisperHttpAdapter (`stt-adapters/whisper-http.js`)
+
+Connects to a running [whisper.cpp HTTP server](https://github.com/ggerganov/whisper.cpp/tree/master/examples/server).
+
+- Accumulates PCM into a rolling buffer.
+- On silence detection (energy below threshold for `vadSilenceMs` ms) OR when buffer reaches `chunkDurationMs`, encodes the chunk as WAV in memory.
+- `POST {WHISPER_HTTP_URL}/inference` with `multipart/form-data` audio file + language param.
+- Parses response `{ text }` and emits `transcript`.
+
+**Environment variables:**
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `WHISPER_HTTP_URL` | — | whisper.cpp server base URL (e.g. `http://localhost:8080`) |
+| `WHISPER_HTTP_MODEL` | (server default) | Model name sent in request (optional) |
+
+### DeepgramAdapter (`stt-adapters/deepgram.js`)
+
+Uses Deepgram's [live streaming API](https://developers.deepgram.com/docs/getting-started-with-live-streaming-audio).
+
+- Opens a WebSocket to `wss://api.deepgram.com/v1/listen` with query params for language, encoding (`linear16`), `sample_rate=16000`, `channels=1`.
+- Pipes PCM chunks directly to the WebSocket.
+- Receives interim and final `Results` messages; emits `transcript` for finals.
+
+**Environment variables:**
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `DEEPGRAM_API_KEY` | — | Deepgram API key |
+
+### GoogleSttAdapter (`stt-adapters/google-stt.js`)
+
+Uses Google Cloud Speech-to-Text v1 [streaming recognition](https://cloud.google.com/speech-to-text/docs/streaming-recognize) via the Node.js client library, or falls back to chunked REST if gRPC is not available.
+
+**REST mode (simpler, higher latency):**
+
+- Same buffer/silence strategy as WhisperHttpAdapter.
+- `POST https://speech.googleapis.com/v1/speech:recognize` with inline base64 PCM audio.
+
+**Streaming gRPC mode (low latency):**
+
+- Opens a bidirectional gRPC stream.
+- Sends `StreamingRecognizeRequest` with PCM audio as it arrives.
+- Emits `transcript` on `is_final: true` results.
+
+**Environment variables:**
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `GOOGLE_APPLICATION_CREDENTIALS` | — | Path to service account JSON |
+| `GOOGLE_STT_KEY` | — | API key for REST fallback |
+| `GOOGLE_STT_MODE` | `rest` | `rest` or `grpc` |
+
+### OpenAiAdapter (`stt-adapters/openai.js`)
+
+Uses OpenAI's [Whisper API](https://platform.openai.com/docs/guides/speech-to-text) (`/v1/audio/transcriptions`).
+
+- Batch-only (no streaming).
+- Accumulates PCM to WAV; POSTs on silence or max chunk size.
+- `multipart/form-data` with `model=whisper-1`, `language`, audio file.
+- Emits `transcript` with `isFinal: true` for each response.
+
+**Environment variables:**
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `OPENAI_API_KEY` | — | OpenAI API key |
+| `OPENAI_STT_MODEL` | `whisper-1` | Model name |
+| `OPENAI_BASE_URL` | `https://api.openai.com/v1` | Override for compatible endpoints (e.g. local Ollama or Azure) |
+
+---
+
+## Transcript → Caption Delivery
+
+When a `transcript` event fires, `SttManager` looks up the active backend session for the API key from the `SessionStore`:
+
+```js
+// Pseudo-code inside SttManager._onTranscript()
+const session = store.getByApiKey(apiKey)
+if (!session) return  // no active session — discard or buffer
+
+const text = transcript.text.trim()
+if (!text) return
+
+session._sendQueue.add(async () => {
+  const seq = ++session.sequence
+  await fanOutToTargets(session, seq, text, transcript.timestamp, {})
+})
+```
+
+This reuses the same `_sendQueue` serialisation that browser-originated captions use, ensuring sequence numbers stay monotonic even when server STT and browser input are used simultaneously.
+
+---
+
+## Database
+
+New table `stt_config` (in `packages/plugins/lcyt-rtmp/src/db.js` migrations):
+
+```sql
+CREATE TABLE IF NOT EXISTS stt_config (
+  api_key         TEXT PRIMARY KEY,
+  provider        TEXT NOT NULL DEFAULT 'whisper_http',
+  language        TEXT NOT NULL DEFAULT 'en-US',
+  audio_source    TEXT NOT NULL DEFAULT 'rtmp',
+  stream_key      TEXT,           -- NULL means use api_key as the MediaMTX path
+  auto_start      INTEGER NOT NULL DEFAULT 0,
+  vad_silence_ms  INTEGER NOT NULL DEFAULT 1000,
+  chunk_duration_ms INTEGER NOT NULL DEFAULT 5000,
+  created_at      INTEGER NOT NULL DEFAULT (strftime('%s','now')),
+  updated_at      INTEGER NOT NULL DEFAULT (strftime('%s','now'))
+);
+```
+
+`auto_start = 1`: when MediaMTX fires the `on_publish` callback for this key, the backend automatically calls `sttManager.start()`.
+
+---
+
+## API Routes
+
+Mounted at `/stt` in `packages/lcyt-backend/src/routes/stt.js`. All endpoints require the standard session Bearer token (`Authorization: Bearer <session-token>`).
+
+```
+GET  /stt/status           — current STT session state for the authenticated API key
+POST /stt/start            — start STT (body: { provider?, language?, audioSource?, streamKey? })
+POST /stt/stop             — stop STT
+GET  /stt/events           — SSE stream of transcript events (Bearer or ?token=)
+GET  /stt/config           — get per-key STT config from DB
+PUT  /stt/config           — update per-key STT config (body: any stt_config fields)
+```
+
+### SSE events (on `GET /stt/events`)
+
+| Event | Payload |
+|---|---|
+| `connected` | `{ apiKey, provider, language }` |
+| `transcript` | `{ text, isFinal, confidence, timestamp, provider }` |
+| `stt_started` | `{ provider, language }` |
+| `stt_stopped` | `{ apiKey }` |
+| `stt_error` | `{ error }` |
+
+---
+
+## Auto-start on Publish
+
+The existing `on_publish` RTMP callback (`POST /rtmp/on_publish` or `/radio-rtmp/on_publish`) is extended:
+
+```js
+// After registering the publisher in the DB / managers:
+const cfg = db.getSttConfig(apiKey)
+if (cfg?.auto_start) {
+  await sttManager.start(apiKey, cfg)
+}
+```
+
+Similarly, `on_publish_done` calls `sttManager.stop(apiKey)`.
+
+---
+
+## Environment Variables
+
+Global defaults (overridden per key via `PUT /stt/config`):
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `STT_PROVIDER` | `whisper_http` | Default provider: `whisper_http` \| `deepgram` \| `google` \| `openai` |
+| `STT_DEFAULT_LANGUAGE` | `en-US` | Default recognition language (BCP-47) |
+| `STT_AUDIO_SOURCE` | `rtmp` | Default audio source: `rtmp` \| `hls` |
+| `STT_CHUNK_DURATION_MS` | `5000` | Max audio chunk length for batch providers |
+| `STT_VAD_SILENCE_MS` | `1000` | Silence gap (ms) that ends an utterance |
+| `WHISPER_HTTP_URL` | — | whisper.cpp HTTP server URL |
+| `WHISPER_HTTP_MODEL` | — | Whisper model name (optional) |
+| `DEEPGRAM_API_KEY` | — | Deepgram API key |
+| `GOOGLE_APPLICATION_CREDENTIALS` | — | Google service account JSON path |
+| `GOOGLE_STT_KEY` | — | Google API key (REST fallback) |
+| `GOOGLE_STT_MODE` | `rest` | `rest` or `grpc` |
+| `OPENAI_API_KEY` | — | OpenAI API key |
+| `OPENAI_STT_MODEL` | `whisper-1` | OpenAI Whisper model name |
+| `OPENAI_BASE_URL` | `https://api.openai.com/v1` | OpenAI-compatible base URL |
+
+---
+
+## Implementation Phases
+
+### Phase 1 — Core pipeline (MVP)
+
+- `SttManager` with RTMP pull via ffmpeg.
+- `WhisperHttpAdapter` (silence-based chunking, WAV encoding in memory, HTTP POST).
+- DB migration for `stt_config`.
+- `/stt` routes: `status`, `start`, `stop`, `config`.
+- Integration with `_sendQueue` for transcript delivery.
+- `on_publish` auto-start hook.
+
+**Deliverable:** Fully headless captioning from an RTMP stream using a local whisper.cpp server.
+
+### Phase 2 — Streaming providers
+
+- `DeepgramAdapter` (WebSocket, true streaming, low latency).
+- `GoogleSttAdapter` (REST mode first; gRPC streaming as a follow-up).
+- `OpenAiAdapter` (chunked REST, OpenAI-compatible endpoint support for local Ollama).
+
+### Phase 3 — SSE transcript stream + UI
+
+- `GET /stt/events` SSE endpoint.
+- lcyt-web: STT status indicator in `StatusBar` (shows "Server STT active: deepgram / en-US").
+- lcyt-web: `EmbedSettingsPage` CC tab — new "Server STT" section for provider/language/auto-start toggle.
+- lcyt-web: `GET /stt/status` polled or SSE-driven for real-time state.
+
+### Phase 4 — HLS source + quality controls
+
+- HLS pull fallback in `SttManager` (when `audioSource: 'hls'`).
+- Confidence threshold filtering (discard low-confidence segments).
+- Punctuation normalisation for providers that don't punctuate.
+- Per-key silence sensitivity and chunk duration configurable at runtime.
+
+---
+
+## Key Files to Create / Modify
+
+| Action | File | Notes |
+|---|---|---|
+| Create | `packages/plugins/lcyt-rtmp/src/stt-manager.js` | SttManager class |
+| Create | `packages/plugins/lcyt-rtmp/src/stt-adapters/whisper-http.js` | WhisperHttpAdapter |
+| Create | `packages/plugins/lcyt-rtmp/src/stt-adapters/deepgram.js` | DeepgramAdapter |
+| Create | `packages/plugins/lcyt-rtmp/src/stt-adapters/google-stt.js` | GoogleSttAdapter |
+| Create | `packages/plugins/lcyt-rtmp/src/stt-adapters/openai.js` | OpenAiAdapter |
+| Create | `packages/lcyt-backend/src/routes/stt.js` | /stt Express router |
+| Modify | `packages/plugins/lcyt-rtmp/src/db.js` | Add stt_config migration |
+| Modify | `packages/plugins/lcyt-rtmp/src/api.js` | Export sttManager from initRtmpControl |
+| Modify | `packages/lcyt-backend/src/server.js` | Mount /stt router, pass sttManager |
+| Modify | `packages/lcyt-backend/src/routes/radio.js` | on_publish auto-start hook |
+| Modify | `packages/lcyt-web/src/components/StatusBar.jsx` | Server STT status indicator |
+
+---
+
+## Open Questions
+
+1. **Simultaneous browser + server STT**: Should they be allowed to co-exist on the same session? Currently both would write into the same `_sendQueue`, which is safe but could produce interleaved output. A mutex flag (`serverSttActive`) on the session could prevent browser sends while server STT is running.
+
+2. **streamKey vs apiKey for MediaMTX path**: In the current radio/HLS flow the MediaMTX path is derived from `apiKey`. For RTMP relay scenarios the user configures an explicit `streamKey` (the RTMP stream name). The `stt_config.stream_key` column is nullable; when null, use `apiKey` as the MediaMTX path.
+
+3. **VAD strategy**: Simple energy-based silence detection inside the adapter is sufficient for phase 1. A more sophisticated approach (e.g. Silero VAD via onnxruntime) could be added in a later phase for noisy environments.
+
+4. **Whisper.cpp server vs CLI**: The HTTP server mode (`./server`) is preferred over spawning the CLI (`./main`) per chunk because it loads the model once and handles concurrent requests. The adapter should retry connection on startup with exponential backoff.
+
+5. **WHEP audio pull**: MediaMTX exposes a WHEP endpoint (`/whep/{key}`) for WebRTC egress. Pulling audio over WebRTC from Node.js (e.g. via `node-datachannel` or `wrtc`) is significantly more complex than RTMP/HLS pull and adds a native dependency. Deferred to a potential Phase 5.

--- a/docs/plans/plan_server_stt.md
+++ b/docs/plans/plan_server_stt.md
@@ -48,7 +48,15 @@ MediaMTX                  SttManager (per API key)
 
 ## Audio Source
 
-MediaMTX exposes three egress protocols, all accessible to ffmpeg. The choice is a deployment configuration decision — there is no preferred or fallback hierarchy; all three are first-class options.
+MediaMTX exposes three egress protocols, all accessible to ffmpeg. Latency differences between them are **not a meaningful criterion** here: YouTube's live caption API already imposes a 30-second hold between the video stream and caption display, so any audio source that delivers audio within that window is equivalent. The real criterion is availability and simplicity.
+
+### HLS (recommended default)
+
+```
+http://127.0.0.1:8080/{streamKey}/index.m3u8
+```
+
+MediaMTX generates HLS natively for every active path, regardless of how the stream was ingested (RTMP, WHIP, SRT, etc.). This makes it the most universally available egress and the simplest default. ffmpeg pulls it with a standard `-i` flag, no special protocol support required.
 
 ### RTMP
 
@@ -56,15 +64,7 @@ MediaMTX exposes three egress protocols, all accessible to ffmpeg. The choice is
 rtmp://127.0.0.1:1935/{RTMP_APP}/{streamKey}
 ```
 
-Connects directly to the RTMP mux inside MediaMTX. Latency matches the ingest latency (~1–3 s end-to-end). Works as long as the stream is publishing to MediaMTX over RTMP.
-
-### HLS
-
-```
-http://127.0.0.1:8080/{streamKey}/index.m3u8
-```
-
-MediaMTX generates HLS segments natively. Standard HLS adds one segment duration of latency (typically 2–6 s). MediaMTX also supports **Low-Latency HLS (LL-HLS)**, which reduces this to ~1–2 s. Use when RTMP is not available or when HLS is the only egress configured.
+Connects directly to the RTMP mux inside MediaMTX. Use when HLS is disabled in the MediaMTX config or when the stream is sourced directly from RTMP and HLS is not generated.
 
 ### WebRTC / WHEP
 
@@ -78,7 +78,7 @@ MediaMTX exposes a WHEP (WebRTC HTTP Egress Protocol) endpoint. ffmpeg 6.1+ incl
 ffmpeg -i 'http://127.0.0.1:8889/{streamKey}/whep' ...
 ```
 
-WHEP gives the lowest end-to-end latency (~200–500 ms). Requires ffmpeg ≥ 6.1 and MediaMTX's WebRTC port to be accessible from the backend host.
+Requires ffmpeg ≥ 6.1 and MediaMTX's WebRTC port accessible from the backend host. No practical latency advantage for this use case; include for completeness and deployments where HLS/RTMP are disabled.
 
 ### ffmpeg decode command (all sources)
 
@@ -107,7 +107,7 @@ One `SttManager` instance is shared across all API keys (singleton, created by `
 await sttManager.start(apiKey, {
   provider,       // 'whisper_http' | 'google' | 'openai'
   language,       // BCP-47 (default: 'en-US')
-  audioSource,    // 'rtmp' | 'hls' | 'whep'  (default: 'rtmp')
+  audioSource,    // 'hls' | 'rtmp' | 'whep'  (default: 'hls')
   streamKey,      // MediaMTX path (default: apiKey)
   vadSilenceMs,   // silence gap that ends an utterance (default: 1000)
   chunkDurationMs // max audio chunk length for batch providers (default: 5000)
@@ -270,7 +270,7 @@ CREATE TABLE IF NOT EXISTS stt_config (
   api_key           TEXT PRIMARY KEY,
   provider          TEXT NOT NULL DEFAULT 'whisper_http',
   language          TEXT NOT NULL DEFAULT 'en-US',
-  audio_source      TEXT NOT NULL DEFAULT 'rtmp',
+  audio_source      TEXT NOT NULL DEFAULT 'hls',
   stream_key        TEXT,           -- NULL means use api_key as the MediaMTX path
   auto_start        INTEGER NOT NULL DEFAULT 0,
   vad_silence_ms    INTEGER NOT NULL DEFAULT 1000,
@@ -333,7 +333,7 @@ Global defaults (overridden per key via `PUT /stt/config`):
 |---|---|---|
 | `STT_PROVIDER` | `whisper_http` | Default provider: `whisper_http` \| `google` \| `openai` |
 | `STT_DEFAULT_LANGUAGE` | `en-US` | Default recognition language (BCP-47) |
-| `STT_AUDIO_SOURCE` | `rtmp` | Default audio source: `rtmp` \| `hls` \| `whep` |
+| `STT_AUDIO_SOURCE` | `hls` | Default audio source: `hls` \| `rtmp` \| `whep` |
 | `STT_CHUNK_DURATION_MS` | `5000` | Max audio chunk length for batch providers |
 | `STT_VAD_SILENCE_MS` | `1000` | Silence gap (ms) that ends an utterance |
 | `WHISPER_HTTP_URL` | — | whisper.cpp HTTP server URL |


### PR DESCRIPTION
Plan for capturing audio from MediaMTX (RTMP or HLS pull via ffmpeg)
and piping it through pluggable STT provider adapters — whisper.cpp HTTP,
Deepgram WebSocket, Google Cloud STT, and OpenAI Whisper — with transcripts
delivered directly into the existing session caption pipeline.

https://claude.ai/code/session_01SAErej14Wg3jStkT5Z8GEx