### PR TITLE
fix: replace type="url" with type="text" on Server URL fields to prevent mobile browser native validation popup

### DIFF
--- a/packages/lcyt-web/src/components/LoginPage.jsx
+++ b/packages/lcyt-web/src/components/LoginPage.jsx
@@ -26,6 +26,7 @@ export function LoginPage() {
   async function handleSubmit(e) {
     e.preventDefault();
     if (!backendUrl.trim() || !email.trim() || !password) return;
+    try { new URL(backendUrl.trim()); } catch { setError('Please enter a valid server URL (e.g. https://api.lcyt.fi)'); return; }
     setError(null);
     setLoading(true);
     try {
@@ -57,7 +58,8 @@ export function LoginPage() {
             <input
               id="login-backend-url"
               className="settings-field__input"
-              type="url"
+              type="text"
+              inputMode="url"
               value={backendUrl}
               onChange={e => setBackendUrl(e.target.value)}
               placeholder="https://api.lcyt.fi"

--- a/packages/lcyt-web/src/components/RegisterPage.jsx
+++ b/packages/lcyt-web/src/components/RegisterPage.jsx
@@ -27,6 +27,7 @@ export function RegisterPage() {
   async function handleSubmit(e) {
     e.preventDefault();
     if (!backendUrl.trim() || !email.trim() || !password) return;
+    try { new URL(backendUrl.trim()); } catch { setError('Please enter a valid server URL (e.g. https://api.lcyt.fi)'); return; }
     if (password !== confirm) {
       setError('Passwords do not match');
       return;
@@ -66,7 +67,8 @@ export function RegisterPage() {
             <input
               id="reg-backend-url"
               className="settings-field__input"
-              type="url"
+              type="text"
+              inputMode="url"
               value={backendUrl}
               onChange={e => setBackendUrl(e.target.value)}
               placeholder="https://api.lcyt.fi"


### PR DESCRIPTION
Mobile browsers show an unhelpful "Please enter a URL." tooltip when the
input type is "url". Switch to type="text" with inputMode="url" (keeps
the URL keyboard on mobile) and validate with new URL() in handleSubmit
instead, showing the error in the form's own error area.

https://claude.ai/code/session_011c2AFgJELrpXxv8fRbRL42