### PR TITLE
Fix lcyt-bridge executable build + add project status report

### DIFF
--- a/.claude/session-start-npm-install.sh
+++ b/.claude/session-start-npm-install.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# SessionStart hook: warm up node_modules in the background so workspace
+# installs are ready without making the user wait at session start.
+# Backgrounded + disowned + nohup'd so the hook returns immediately and the
+# install survives the hook script's shell exiting.
+cd "$(dirname "$0")/.." || exit 0
+
+if [[ -f package.json ]] && command -v npm >/dev/null 2>&1; then
+  nohup npm install --no-audit --no-fund \
+    > /tmp/lcyt-session-start-npm-install.log 2>&1 < /dev/null &
+  disown
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/session-start-npm-install.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -1,0 +1,126 @@
+# LCYT Project Status
+
+*Compiled 2026-06-29. Sources: `docs/PLANS.md`, `docs/plans/*.md`, `TODO.md`, package.json versions, and a repo-wide grep for TODO/FIXME/WIP/stub markers.*
+
+This is a point-in-time snapshot, not a maintained changelog. The repo has no `CHANGELOG.md`, `HISTORY.md`, or git tags — `docs/PLANS.md` (summarized below) is the closest thing to a living project history, alongside git log itself.
+
+---
+
+## 1. Plan Index (from `docs/PLANS.md`)
+
+27 plans total: 20 implemented, 5 in-progress, 1 pending, 1 draft, 2 reference artifacts.
+
+### Implemented (20)
+
+| Plan | Title | Notes |
+|---|---|---|
+| plan_sync | YouTube Heartbeat Sync | NTP-style clock sync for `YoutubeLiveCaptionSender` |
+| plan_backend | lcyt-backend Express Relay | JWT auth, SQLite, multi-user sessions, admin CLI |
+| plan_client | Web GUI Client (lcyt-web) | Full React SPA |
+| plan_mcp | MCP Tools | stdio + SSE transports |
+| plan_hls_sidecar | HLS Multilingual Caption Sidecar | WebVTT rolling segments + HLS.js player |
+| plan_mediamtx | MediaMTX Integration | Alternative RTMP/HLS broker, NginxManager |
+| plan_prod | Production Control | Cameras, mixers, bridge agent, MCP tools |
+| plan_rtmp | RTMP Processing Pipeline | ffmpeg orchestration for HLS/relay/DSK/thumbnails |
+| plan_stt | Browser STT Integration | Web Speech API + Google Cloud STT, VAD, translation |
+| plan_captions | Caption Sending Pipeline | Target fan-out, sequencing, SSE results |
+| plan_translations | Caption Translation Pipeline | Vendor abstraction, multi-target, subtitle sidecar |
+| plan_cea | CEA-708 SEI NAL Embedding | eia608 encoder + SRT pipe in RtmpRelayManager |
+| plan_pyback | Python Backend Scope Reduction | Minimal unauthenticated relay |
+| plan_cache | HTTP Caching Strategy | Cache-Control tiers, nginx proxy_cache, ETag |
+| plan_setup_wizard | Setup Wizard | `/setup` guided flow, fully implemented |
+| plan_userprojects | Feature Flags, Membership, Device Roles | Phases 1-3 done; Phase 4 (QR codes, tally light, time-limited sessions) future work |
+| plan_cloudfleet | Hosting Modes & Cloudfleet Deployment | All 3 tiers done; optional Helm/Litestream/Postgres/ServiceMonitor pending |
+| plan_dsk | DSK Graphics Editor (Phases 2-4) | Canvas editing, multi-select, media library; Phase 5 (Animations) remains |
+| plan_files3 | lcyt-files Storage Adapters | local/S3/WebDAV done; CDN URL field, S3 mock tests, migration script remain low-priority |
+| plan_admin | Admin Panel | Phases 1-2 done: CRUD, audit log, import/export |
+| plan_ui | Frontend & UI Plans | All backlog items done (command palette, shortcuts, reconnect, etc.) |
+
+### In Progress (5, + TODO follow-through)
+
+| Plan | Done | Remaining |
+|---|---|---|
+| plan_cues (Cue Engine) | Phases 1-7: phrase/fuzzy/semantic/event cues, music-state triggers | Phase 8: multi-modal scene understanding |
+| plan_agent (AI Agent) | Phases 1-3, 5-6: config, embeddings, context window, event-cue LLM eval, AI template/rundown generation | Phase 4: video/image inference (`analyseImage()` is a stub — see §3); Phase 7: multi-modal scene understanding; Phase 8: local Ollama support |
+| plan_server_stt (Server-side STT) | Phase 1: HlsSegmentFetcher, Google/Whisper/OpenAI adapters, SttManager, `/stt` routes | Phases 2-4: gRPC streaming hardening, RTMP/WHEP fallback enhancements |
+| plan_dock_ffmpeg (FFmpeg Compute Containers) | Phases 1-3: runner abstraction (`FFMPEG_RUNNER`), local/docker/worker runners; orchestrator + worker-daemon packages scaffolded | Phases 4-7: full distributed Hetzner architecture (orchestrator/worker-daemon hardening, S3 wiring, Hetzner autoscaling, runbooks) — **biggest structural gap** |
+| plan_music (Music Detection) | Phase 1: client-side Web Audio API path, `lcyt-music` plugin, hooks/components | Phase 2: `music_config` DB table, backend routes, server-side HLS analysis |
+| TODO_plan | — | Resolve TODO.md items (see §2) |
+
+### Pending (1)
+
+- **plan_help** — Help Page Screenshot Capture: programmatic Playwright screenshots of lcyt-web UI views for the help page. Accepted, not started.
+
+### Draft (1)
+
+- **plan_translate** — `lcyt-translate`: exploratory server-side translation plugin (vendor adapters, per-key DB config, injection into captions.js/SttManager) to close the gap where translation currently only happens client-side. Not yet accepted/scheduled.
+
+### Reference (2)
+
+- **PR_phase6-7_hetzner** — PR artifact for plan_dock_ffmpeg phases 6-7 (Hetzner provisioning, snapshot boot, autoscaling scaffolding, operator runbook).
+- **plan_backend_split** — Structural assessment: plugin extraction (lcyt-rtmp, lcyt-dsk, lcyt-production, lcyt-files) complete; lcyt-translate proposal remains exploratory.
+
+---
+
+## 2. `TODO.md` Contents
+
+The entire file, verbatim:
+
+> Timestamp parsing relies on ISO strings without trailing `Z` — behavior is consistent across Node versions but keep tests for edge cases.
+
+A single note, not an outstanding work item — more of a documented design constraint. `plan_TODO_plan.md` references resolving "Python stderr logging, MCP auto-sync and time field, docs reorganisation, CLAUDE.md lcyt-mcp reference" — these appear to already be addressed given CLAUDE.md's current state; no further open items found in TODO.md itself.
+
+---
+
+## 3. Grep Findings: TODO / FIXME / WIP / stub / "not implemented"
+
+A repo-wide case-insensitive grep across `packages/`, `python-packages/`, `android/` (excluding `node_modules`, `dist`, `build`) turned up ~30 hits. The large majority are test-file vocabulary ("stub DB", "stub fetch", "AnalyserNode stub") describing test mocks, not unfinished product code. Hits that represent **real gaps**:
+
+| File | Marker | What it means |
+|---|---|---|
+| `packages/plugins/lcyt-agent/src/agent-engine.js:181` | `// Stub — requires vision-capable LLM integration (Phase 6)` | `analyseImage()` is a placeholder; this is plan_agent Phase 4/7 (video/image inference) |
+| `packages/plugins/lcyt-production/src/adapters/mixer/obs.js:29-31, 141` | "routing for OBS is not implemented in the current bridge agent" | The OBS mixer adapter returns a forward-compatible `obs_switch` object, but `lcyt-bridge` doesn't yet dispatch it — switching doesn't actually reach OBS yet |
+| `packages/plugins/lcyt-files/src/routes/files.js:57` | "Defensive fallback... adapter-less stub that returns 503" | Intentional safety fallback, not a gap |
+| `packages/lcyt-orchestrator/src/index.js:194, 203` | "Stubbed: do not call external worker APIs" / "accept caption and return success without external calls" | `POST /compute/jobs/:jobId/caption` is a stub — caption forwarding to workers isn't wired up. Matches plan_dock_ffmpeg Phase 4 gap |
+| `packages/lcyt-backend/test/integration/dsk-integration.test.js:3-5` | `test.skip(...)`, "TODO: implement" | DSK Playwright/Chromium integration test is a scaffolded placeholder, skipped |
+| `packages/lcyt-backend/test/integration/stt-integration.test.js:3-6` | `test.skip(...)`, "TODO: implement" | Real STT integration test (needs HLS/ffmpeg/MediaMTX) not yet written, skipped |
+| `packages/lcyt-web/src/main.jsx:138-147` | `StubPage` component | Defined as scaffolding for "routes not yet fully implemented" but **not actually referenced anywhere** in the router — dead code, not an active gap |
+
+Everything else (the bulk of matches) is test-mock terminology and not indicative of incomplete features.
+
+---
+
+## 4. Package Maturity Signals (`package.json` versions)
+
+| Package | Version | Signal |
+|---|---|---|
+| `packages/lcyt` | 3.0.0 | Mature, published, stable API |
+| `packages/lcyt-cli` | 2.0.0 | Mature, published |
+| `packages/lcyt-backend` | 1.0.0 | Stable, production-tagged |
+| `packages/lcyt-web` | 1.0.0 | Stable |
+| `packages/lcyt-bridge` | 0.3.0 | Functional but pre-1.0 |
+| `packages/lcyt-mcp-stdio` | 0.1.0 | Stable but early |
+| `packages/lcyt-mcp-sse` | 0.1.0 | Stable but early |
+| `packages/lcyt-site` | 0.1.0 | Early (marketing site) |
+| `packages/lcyt-orchestrator` | 0.0.1 (private) | Scaffolded, not production-hardened |
+| `packages/lcyt-worker-daemon` | 0.0.0 (private) | Scaffolded, not production-hardened |
+| `packages/plugins/*` (cues, production, rtmp, dsk, music, files, agent) | 0.1.0 each | Stable internal plugins, not independently versioned/released |
+
+The orchestrator and worker-daemon's `0.0.x` versions corroborate the plan index: they're scaffolded but the distributed-compute path (plan_dock_ffmpeg Phases 4-7) isn't finished.
+
+---
+
+## 5. Where to Continue Next (prioritized)
+
+1. **Wire up orchestrator ↔ worker-daemon caption forwarding and real job dispatch** (plan_dock_ffmpeg Phase 4). `lcyt-orchestrator/src/index.js:194-203` is explicitly stubbed; this blocks horizontal scaling and is the most concrete, scoped next task. Phases 1-3 (runner abstraction) are done, so this only requires finishing the integration layer.
+2. **S3 storage wiring for worker output** (Phase 5) — natural follow-on once job dispatch works.
+3. **Hetzner burst autoscaling** (Phase 6) — client/autoscaler code exists (`packages/lcyt-orchestrator/src/hetzner.js`, `autoscaler.js`) but unproven end-to-end; depends on 1-2.
+4. **OBS mixer dispatch in lcyt-bridge** — the adapter is ready (`adapters/mixer/obs.js`) but the bridge agent doesn't yet send `obs_switch` commands; small, well-scoped fix if OBS support matters to current use cases.
+5. **STT provider hardening** (plan_server_stt Phases 2-4) — gRPC streaming polish and RTMP/WHEP fallback; REST/HLS path already works.
+6. **Server-side music detection** (plan_music Phase 2) — port the existing client-side classifier logic to the HLS segment path; `music_config` DB table + routes needed.
+7. **AI Agent vision/image inference** (plan_agent Phase 4) — replace the `analyseImage()` stub with a real vision-capable LLM call.
+8. **Write the two skipped integration tests** (`dsk-integration.test.js`, `stt-integration.test.js`) once Playwright/Chromium and HLS/ffmpeg/MediaMTX test infra is available — currently `test.skip`.
+9. Lower priority / polish: plan_help (screenshot capture for the help page), plan_dsk Phase 5 (animations), plan_userprojects Phase 4 (QR codes, tally light, time-limited sessions), plan_cloudfleet optional enhancements (Helm chart, Litestream, Postgres, ServiceMonitor, CI CFCR push).
+10. **plan_translate** remains in draft — worth a decision on whether to formally schedule it (closes the gap where STT/CLI captions can't be server-side translated) or shelve it.
+
+**Recommended starting point:** item 1 (orchestrator/worker-daemon job dispatch) — it's the most clearly scoped, has no blocking dependencies, and unlocks the rest of the distributed-compute roadmap.

--- a/package-lock.json
+++ b/package-lock.json
@@ -437,6 +437,32 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1075.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1075.0.tgz",
+      "integrity": "sha512-h1A6nIl1YX6Y45enGsTK7ef3ZrOnBiQJ1qF5R2K/nMWfsu6A9mc2Y5T66nxerABzyjjyyvign3MrzafnFoQKmA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/credential-provider-node": "^3.972.58",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.33",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.54",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/core": {
       "version": "3.974.23",
       "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.23.tgz",
@@ -817,7 +843,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1332,7 +1357,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1381,7 +1405,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1431,6 +1454,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1447,6 +1471,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1463,6 +1488,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1479,6 +1505,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1495,6 +1522,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1511,6 +1539,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1527,6 +1556,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1543,6 +1573,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1559,6 +1590,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1575,6 +1607,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1591,6 +1624,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1607,6 +1641,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1623,6 +1658,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1639,6 +1675,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1655,6 +1692,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1671,6 +1709,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1687,6 +1726,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1719,6 +1759,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1751,6 +1792,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1783,6 +1825,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1799,6 +1842,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1815,6 +1859,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1831,6 +1876,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3870,6 +3916,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -3959,7 +4006,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -6272,7 +6320,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6508,7 +6555,6 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
       "integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.1.2",
         "@chevrotain/gast": "11.1.2",
@@ -6888,7 +6934,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -7310,7 +7355,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7635,7 +7679,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -7858,7 +7903,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -8008,7 +8052,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -8665,7 +8708,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.1.tgz",
       "integrity": "sha512-hi9afu8g0lfJVLolxElAZGANCTTl6bewIdsRNhaywfP9K8BPf++F2z6OLrYGIinUwpRKzbZHMhPwvc0ZEpAwGw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -9410,6 +9452,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9430,6 +9473,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9450,6 +9494,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9470,6 +9515,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9490,6 +9536,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9510,6 +9557,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9530,6 +9578,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9550,6 +9599,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9570,6 +9620,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9590,6 +9641,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9610,6 +9662,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9704,6 +9757,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -11378,6 +11432,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -11393,6 +11448,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -11571,7 +11627,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -11584,7 +11639,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -11630,7 +11684,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -12053,7 +12108,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.58.0.tgz",
       "integrity": "sha512-wbT0mBmWbIvvq8NeEYWWvevvxnOyhKChir47S66WCxw1SXqhw7ssIYejnQEVt7XYQpsj2y8F9PM+Cr3SNEa0gw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -13354,7 +13408,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -13550,7 +13603,6 @@
       "integrity": "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/runtime": "0.115.0",
         "lightningcss": "^1.32.0",
@@ -13946,7 +13998,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -14073,7 +14124,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/packages/lcyt-bridge/package.json
+++ b/packages/lcyt-bridge/package.json
@@ -11,10 +11,16 @@
     "test": "node --test test/*.test.js",
     "start": "node src/index.js",
     "build:bundle": "node scripts/build.cjs",
+    "prefetch": "node scripts/prefetch.cjs",
+    "prebuild:win": "node scripts/prefetch.cjs win",
     "build:win": "node scripts/build.cjs win",
+    "prebuild:mac": "node scripts/prefetch.cjs mac",
     "build:mac": "node scripts/build.cjs mac",
+    "prebuild:linux": "node scripts/prefetch.cjs linux",
     "build:linux": "node scripts/build.cjs linux",
+    "prebuild:linux-arm64": "node scripts/prefetch.cjs linux-arm64",
     "build:linux-arm64": "node scripts/build.cjs linux-arm64",
+    "prebuild:all": "node scripts/prefetch.cjs",
     "build:all": "node scripts/build.cjs all"
   },
   "pkg": {

--- a/packages/lcyt-bridge/scripts/prefetch.cjs
+++ b/packages/lcyt-bridge/scripts/prefetch.cjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+/**
+ * Pre-fetches the @yao-pkg/pkg-fetch base Node.js binaries needed to build
+ * the lcyt-bridge executable, verifies their SHA-256 against pkg-fetch's
+ * pinned hashes, and places them in pkg-fetch's local cache.
+ *
+ * Why this exists: pkg-fetch downloads base binaries (~50MB) via node-fetch.
+ * On some networks/proxies that download silently stalls or fails partway
+ * through, and pkg-fetch's `download()` swallows the error instead of
+ * throwing — `npm run build:*` then exits 0 having produced no executable,
+ * with no error message explaining why. `curl` against the exact same URL
+ * has proven reliable where node-fetch stalls, so this script fetches the
+ * binary with curl (falling back to a plain Node https client if curl is
+ * unavailable), verifies it against pkg-fetch's own expected-shas.json, and
+ * places it exactly where pkg-fetch expects to find it. The normal
+ * build:* scripts then find it already cached and skip the flaky fetch.
+ *
+ * Usage:
+ *   node scripts/prefetch.cjs              # prefetch all build targets
+ *   node scripts/prefetch.cjs linux        # prefetch one target (see build.cjs)
+ *   node scripts/prefetch.cjs win mac      # prefetch several targets
+ */
+const { spawnSync } = require('child_process');
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+const { getNodeVersion } = require('@yao-pkg/pkg-fetch');
+const { localPlace, remotePlace } = require('@yao-pkg/pkg-fetch/lib-es5/places');
+const { EXPECTED_HASHES } = require('@yao-pkg/pkg-fetch/lib-es5/expected');
+const pkgFetchPkg = require('@yao-pkg/pkg-fetch/package.json');
+
+// Keep in sync with the `targets` map in scripts/build.cjs.
+const PKG_TARGETS = {
+  win: 'node18-win-x64',
+  mac: 'node18-macos-x64',
+  linux: 'node18-linux-x64',
+  'linux-arm64': 'node18-linux-arm64',
+};
+
+function parseTarget(target) {
+  const parts = target.split('-');
+  const nodeRange = parts[0];
+  const arch = parts[parts.length - 1];
+  const platform = parts.slice(1, -1).join('-');
+  return { nodeRange, platform, arch };
+}
+
+function hashFile(file) {
+  return new Promise((resolve, reject) => {
+    const hash = crypto.createHash('sha256');
+    const stream = fs.createReadStream(file);
+    stream.on('error', reject);
+    stream.on('data', (chunk) => hash.update(chunk));
+    stream.on('end', () => resolve(hash.digest('hex')));
+  });
+}
+
+function curlDownload(url, dest) {
+  const result = spawnSync(
+    'curl',
+    ['-fL', '--retry', '3', '--retry-delay', '2', '--connect-timeout', '15', '-o', dest, url],
+    { stdio: 'inherit' },
+  );
+  if (result.error) {
+    if (result.error.code === 'ENOENT') return null; // curl not installed
+    throw result.error;
+  }
+  return result.status === 0;
+}
+
+function nodeDownload(url, dest) {
+  // Fallback for environments without curl. Mirrors pkg-fetch's own
+  // node-fetch-based download (incl. HTTPS_PROXY support) but without the
+  // silent-failure swallowing, so an actual error surfaces here.
+  return new Promise((resolve, reject) => {
+    const https = require('https');
+    const { HttpsProxyAgent } = require('https-proxy-agent');
+    const proxy = process.env.HTTPS_PROXY || process.env.https_proxy
+      || process.env.HTTP_PROXY || process.env.http_proxy;
+    const agent = proxy ? new HttpsProxyAgent(proxy) : undefined;
+
+    function get(currentUrl, redirectsLeft) {
+      https.get(currentUrl, { agent }, (res) => {
+        if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+          if (redirectsLeft <= 0) return reject(new Error('Too many redirects'));
+          res.resume();
+          return get(res.headers.location, redirectsLeft - 1);
+        }
+        if (res.statusCode !== 200) {
+          res.resume();
+          return reject(new Error(`HTTP ${res.statusCode} fetching ${currentUrl}`));
+        }
+        const out = fs.createWriteStream(dest);
+        res.pipe(out);
+        out.on('finish', () => out.close(() => resolve(true)));
+        out.on('error', reject);
+      }).on('error', reject);
+    }
+    get(url, 5);
+  });
+}
+
+async function downloadVerified(url, dest, expectedHash) {
+  const tmp = `${dest}.prefetching`;
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  fs.rmSync(tmp, { force: true });
+
+  console.log(`[prefetch] downloading ${url}`);
+  let ok = curlDownload(url, tmp);
+  if (ok === null) {
+    console.log('[prefetch] curl not found, falling back to Node https client');
+    ok = await nodeDownload(url, tmp);
+  }
+  if (!ok) {
+    fs.rmSync(tmp, { force: true });
+    throw new Error(`Failed to download ${url}`);
+  }
+
+  const actualHash = await hashFile(tmp);
+  if (actualHash !== expectedHash) {
+    fs.rmSync(tmp, { force: true });
+    throw new Error(
+      `SHA-256 mismatch for ${path.basename(dest)}: expected ${expectedHash}, got ${actualHash}`,
+    );
+  }
+
+  fs.renameSync(tmp, dest);
+  fs.chmodSync(dest, 0o755);
+  console.log(`[prefetch] verified + cached -> ${dest}`);
+}
+
+async function prefetchTarget(target) {
+  const { nodeRange, platform, arch } = parseTarget(target);
+  const nodeVersion = getNodeVersion(nodeRange);
+  const local = localPlace({
+    from: 'fetched',
+    arch,
+    nodeVersion,
+    platform,
+    version: pkgFetchPkg.version,
+  });
+  const remote = remotePlace({ version: pkgFetchPkg.version, nodeVersion, platform, arch });
+  const expectedHash = EXPECTED_HASHES[remote.name];
+  if (!expectedHash) {
+    throw new Error(`No known SHA-256 for ${remote.name} (unsupported target: ${target})`);
+  }
+
+  if (fs.existsSync(local)) {
+    const existingHash = await hashFile(local);
+    if (existingHash === expectedHash) {
+      console.log(`[prefetch] ${target}: already cached and verified -> ${local}`);
+      return;
+    }
+    console.log(`[prefetch] ${target}: cached file hash mismatch, re-fetching`);
+  }
+
+  const url = `https://github.com/yao-pkg/pkg-fetch/releases/download/${remote.tag}/${remote.name}`;
+  await downloadVerified(url, local, expectedHash);
+}
+
+async function main() {
+  const requested = process.argv.slice(2);
+  const platforms = requested.length > 0 ? requested : Object.keys(PKG_TARGETS);
+
+  for (const platform of platforms) {
+    const target = PKG_TARGETS[platform];
+    if (!target) {
+      console.error(`[prefetch] Unknown platform: ${platform}. Valid: ${Object.keys(PKG_TARGETS).join(', ')}`);
+      process.exit(1);
+    }
+    await prefetchTarget(target);
+  }
+}
+
+main().catch((err) => {
+  console.error('[prefetch] Fatal:', err.message || err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Diagnosed and fixed a silent failure in `packages/lcyt-bridge`'s executable build: `@yao-pkg/pkg-fetch` swallows `node-fetch` errors when downloading its base Node.js binary, so `npm run build:*` could exit 0 without ever producing an executable.
- Added `packages/lcyt-bridge/scripts/prefetch.cjs`, which downloads the base binary via `curl` (falling back to a plain Node `https` client), verifies its SHA-256 against pkg-fetch's pinned hashes, and places it in pkg-fetch's cache. Wired as a `pre*` step on each `build:*` script (plus standalone `npm run prefetch`), so this no longer recurs.
- Verified end-to-end: clean `npm run build:linux` now produces a working Linux executable, confirmed by direct execution and the full `lcyt-bridge` test suite (57/57 passing).
- Added `docs/PROJECT_STATUS.md`: a survey of plan completeness, package maturity, known stubs/gaps, and prioritized next steps.
- Added a `SessionStart` hook (`.claude/settings.json` + `.claude/session-start-npm-install.sh`) that runs `npm install` detached in the background at session start, so workspace dependencies stay warm without blocking.
- Refreshed `package-lock.json` (lockfile churn only, no real dependency version changes).

## Test plan
- [x] `npm test -w packages/lcyt-bridge` — 57/57 passing
- [x] `rm -rf dist` + `npm run build:linux` from a cold cache — prefetch downloads, verifies, and caches the base binary; build produces a working ELF executable
- [x] Ran the built executable directly — starts up, reports version, runs backend health check, exits cleanly
- [x] Verified the `SessionStart` hook returns in ~3ms while `npm install` completes detached in the background

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qfv3xEfLPfntuPudygfY6p


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qfv3xEfLPfntuPudygfY6p)_