### PR TITLE
docs: update PROJECT_STATUS for plan_dock_ffmpeg completion

### DIFF
--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -1,6 +1,6 @@
 # LCYT Project Status
 
-*Compiled 2026-06-29. Sources: `docs/PLANS.md`, `docs/plans/*.md`, `TODO.md`, package.json versions, and a repo-wide grep for TODO/FIXME/WIP/stub markers.*
+*Compiled 2026-06-30. Sources: `docs/PLANS.md`, `docs/plans/*.md`, `TODO.md`, package.json versions, and a repo-wide grep for TODO/FIXME/WIP/stub markers.*
 
 This is a point-in-time snapshot, not a maintained changelog. The repo has no `CHANGELOG.md`, `HISTORY.md`, or git tags — `docs/PLANS.md` (summarized below) is the closest thing to a living project history, alongside git log itself.
 
@@ -8,9 +8,9 @@ This is a point-in-time snapshot, not a maintained changelog. The repo has no `C
 
 ## 1. Plan Index (from `docs/PLANS.md`)
 
-27 plans total: 20 implemented, 5 in-progress, 1 pending, 1 draft, 2 reference artifacts.
+27 plans total: 21 implemented, 4 in-progress, 1 pending, 1 draft, 2 reference artifacts.
 
-### Implemented (20)
+### Implemented (21)
 
 | Plan | Title | Notes |
 |---|---|---|
@@ -35,16 +35,16 @@ This is a point-in-time snapshot, not a maintained changelog. The repo has no `C
 | plan_files3 | lcyt-files Storage Adapters | local/S3/WebDAV done; CDN URL field, S3 mock tests, migration script remain low-priority |
 | plan_admin | Admin Panel | Phases 1-2 done: CRUD, audit log, import/export |
 | plan_ui | Frontend & UI Plans | All backlog items done (command palette, shortcuts, reconnect, etc.) |
+| plan_dock_ffmpeg | FFmpeg Compute Containers → Distributed Hetzner Architecture | All phases done. Phases 1-3: runner abstraction (`FFMPEG_RUNNER`); Phases 4-7: `lcyt-orchestrator` (worker registry, job routing, Hetzner client, autoscaler, Prometheus metrics) + `lcyt-worker-daemon` (job lifecycle, Docker execution, S3 uploader) fully wired, including caption forwarding (`POST /compute/jobs/:jobId/caption`). See `docs/distributed-compute.md`. |
 
-### In Progress (5, + TODO follow-through)
+### In Progress (4, + TODO follow-through)
 
 | Plan | Done | Remaining |
 |---|---|---|
 | plan_cues (Cue Engine) | Phases 1-7: phrase/fuzzy/semantic/event cues, music-state triggers | Phase 8: multi-modal scene understanding |
 | plan_agent (AI Agent) | Phases 1-3, 5-6: config, embeddings, context window, event-cue LLM eval, AI template/rundown generation | Phase 4: video/image inference (`analyseImage()` is a stub — see §3); Phase 7: multi-modal scene understanding; Phase 8: local Ollama support |
 | plan_server_stt (Server-side STT) | Phase 1: HlsSegmentFetcher, Google/Whisper/OpenAI adapters, SttManager, `/stt` routes | Phases 2-4: gRPC streaming hardening, RTMP/WHEP fallback enhancements |
-| plan_dock_ffmpeg (FFmpeg Compute Containers) | Phases 1-3: runner abstraction (`FFMPEG_RUNNER`), local/docker/worker runners; orchestrator + worker-daemon packages scaffolded | Phases 4-7: full distributed Hetzner architecture (orchestrator/worker-daemon hardening, S3 wiring, Hetzner autoscaling, runbooks) — **biggest structural gap** |
-| plan_music (Music Detection) | Phase 1: client-side Web Audio API path, `lcyt-music` plugin, hooks/components | Phase 2: `music_config` DB table, backend routes, server-side HLS analysis |
+| plan_music (Music Detection) | Phases 1-3: client-side Web Audio API path, server-side HLS analysis, `music_config` DB table + routes, RTMP audio-source fallback | Phase 4: tuning/export/external classifier; `on_publish` auto-start hook for `music_config.autoStart` not yet wired |
 | TODO_plan | — | Resolve TODO.md items (see §2) |
 
 ### Pending (1)
@@ -81,7 +81,6 @@ A repo-wide case-insensitive grep across `packages/`, `python-packages/`, `andro
 | `packages/plugins/lcyt-agent/src/agent-engine.js:181` | `// Stub — requires vision-capable LLM integration (Phase 6)` | `analyseImage()` is a placeholder; this is plan_agent Phase 4/7 (video/image inference) |
 | `packages/plugins/lcyt-production/src/adapters/mixer/obs.js:29-31, 141` | "routing for OBS is not implemented in the current bridge agent" | The OBS mixer adapter returns a forward-compatible `obs_switch` object, but `lcyt-bridge` doesn't yet dispatch it — switching doesn't actually reach OBS yet |
 | `packages/plugins/lcyt-files/src/routes/files.js:57` | "Defensive fallback... adapter-less stub that returns 503" | Intentional safety fallback, not a gap |
-| `packages/lcyt-orchestrator/src/index.js:194, 203` | "Stubbed: do not call external worker APIs" / "accept caption and return success without external calls" | `POST /compute/jobs/:jobId/caption` is a stub — caption forwarding to workers isn't wired up. Matches plan_dock_ffmpeg Phase 4 gap |
 | `packages/lcyt-backend/test/integration/dsk-integration.test.js:3-5` | `test.skip(...)`, "TODO: implement" | DSK Playwright/Chromium integration test is a scaffolded placeholder, skipped |
 | `packages/lcyt-backend/test/integration/stt-integration.test.js:3-6` | `test.skip(...)`, "TODO: implement" | Real STT integration test (needs HLS/ffmpeg/MediaMTX) not yet written, skipped |
 | `packages/lcyt-web/src/main.jsx:138-147` | `StubPage` component | Defined as scaffolding for "routes not yet fully implemented" but **not actually referenced anywhere** in the router — dead code, not an active gap |
@@ -102,25 +101,23 @@ Everything else (the bulk of matches) is test-mock terminology and not indicativ
 | `packages/lcyt-mcp-stdio` | 0.1.0 | Stable but early |
 | `packages/lcyt-mcp-http` | 0.1.0 | Stable but early |
 | `packages/lcyt-site` | 0.1.0 | Early (marketing site) |
-| `packages/lcyt-orchestrator` | 0.0.1 (private) | Scaffolded, not production-hardened |
-| `packages/lcyt-worker-daemon` | 0.0.0 (private) | Scaffolded, not production-hardened |
+| `packages/lcyt-orchestrator` | 0.0.1 (private) | Functionally wired (worker registry, job dispatch, caption forwarding, Hetzner autoscaling) but version number not yet bumped past scaffold-era `0.0.x` |
+| `packages/lcyt-worker-daemon` | 0.0.0 (private) | Same — functional, version number stale |
 | `packages/plugins/*` (cues, production, rtmp, dsk, music, files, agent) | 0.1.0 each | Stable internal plugins, not independently versioned/released |
 
-The orchestrator and worker-daemon's `0.0.x` versions corroborate the plan index: they're scaffolded but the distributed-compute path (plan_dock_ffmpeg Phases 4-7) isn't finished.
+The orchestrator and worker-daemon's `0.0.x` versions are now a lag indicator, not a maturity signal — plan_dock_ffmpeg Phases 4-7 shipped in PR #221 (see `docs/distributed-compute.md`), but the package versions weren't bumped to reflect it.
 
 ---
 
 ## 5. Where to Continue Next (prioritized)
 
-1. **Wire up orchestrator ↔ worker-daemon caption forwarding and real job dispatch** (plan_dock_ffmpeg Phase 4). `lcyt-orchestrator/src/index.js:194-203` is explicitly stubbed; this blocks horizontal scaling and is the most concrete, scoped next task. Phases 1-3 (runner abstraction) are done, so this only requires finishing the integration layer.
-2. **S3 storage wiring for worker output** (Phase 5) — natural follow-on once job dispatch works.
-3. **Hetzner burst autoscaling** (Phase 6) — client/autoscaler code exists (`packages/lcyt-orchestrator/src/hetzner.js`, `autoscaler.js`) but unproven end-to-end; depends on 1-2.
-4. **OBS mixer dispatch in lcyt-bridge** — the adapter is ready (`adapters/mixer/obs.js`) but the bridge agent doesn't yet send `obs_switch` commands; small, well-scoped fix if OBS support matters to current use cases.
-5. **STT provider hardening** (plan_server_stt Phases 2-4) — gRPC streaming polish and RTMP/WHEP fallback; REST/HLS path already works.
-6. **Server-side music detection** (plan_music Phase 2) — port the existing client-side classifier logic to the HLS segment path; `music_config` DB table + routes needed.
-7. **AI Agent vision/image inference** (plan_agent Phase 4) — replace the `analyseImage()` stub with a real vision-capable LLM call.
-8. **Write the two skipped integration tests** (`dsk-integration.test.js`, `stt-integration.test.js`) once Playwright/Chromium and HLS/ffmpeg/MediaMTX test infra is available — currently `test.skip`.
-9. Lower priority / polish: plan_help (screenshot capture for the help page), plan_dsk Phase 5 (animations), plan_userprojects Phase 4 (QR codes, tally light, time-limited sessions), plan_cloudfleet optional enhancements (Helm chart, Litestream, Postgres, ServiceMonitor, CI CFCR push).
-10. **plan_translate** remains in draft — worth a decision on whether to formally schedule it (closes the gap where STT/CLI captions can't be server-side translated) or shelve it.
+1. **OBS mixer dispatch in lcyt-bridge** — the adapter is ready (`adapters/mixer/obs.js`) but the bridge agent doesn't yet send `obs_switch` commands; small, well-scoped fix if OBS support matters to current use cases.
+2. **STT provider hardening** (plan_server_stt Phases 2-4) — gRPC streaming polish and RTMP/WHEP fallback; REST/HLS path already works.
+3. **Server-side music detection tuning** (plan_music Phase 4) — tuning/export/external classifier, plus wiring the `on_publish` auto-start hook for `music_config.autoStart`. Phases 1-3 (client-side, server-side HLS analysis, RTMP fallback) are done.
+4. **AI Agent vision/image inference** (plan_agent Phase 4) — replace the `analyseImage()` stub with a real vision-capable LLM call.
+5. **Write the two skipped integration tests** (`dsk-integration.test.js`, `stt-integration.test.js`) once Playwright/Chromium and HLS/ffmpeg/MediaMTX test infra is available — currently `test.skip`.
+6. **Prove out Hetzner burst autoscaling end-to-end** — the orchestrator/worker-daemon path is wired (job dispatch, caption forwarding, S3 upload) but real-world burst-provisioning under load remains unproven; bump `lcyt-orchestrator`/`lcyt-worker-daemon` package versions once it is.
+7. Lower priority / polish: plan_help (screenshot capture for the help page), plan_dsk Phase 5 (animations), plan_userprojects Phase 4 (QR codes, tally light, time-limited sessions), plan_cloudfleet optional enhancements (Helm chart, Litestream, Postgres, ServiceMonitor, CI CFCR push).
+8. **plan_translate** remains in draft — worth a decision on whether to formally schedule it (closes the gap where STT/CLI captions can't be server-side translated) or shelve it.
 
-**Recommended starting point:** item 1 (orchestrator/worker-daemon job dispatch) — it's the most clearly scoped, has no blocking dependencies, and unlocks the rest of the distributed-compute roadmap.
+**Recommended starting point:** item 1 (OBS mixer dispatch) — smallest, most concretely scoped, no dependencies.


### PR DESCRIPTION
## Summary

Update `docs/PROJECT_STATUS.md` to reflect the completion of plan_dock_ffmpeg (FFmpeg Compute Containers → Distributed Hetzner Architecture) in PR #221. The distributed-compute path is now fully wired and functional, though package versions remain at scaffold-era `0.0.x`.

## Key Changes

- **Plan index:** Move plan_dock_ffmpeg from "In Progress (5)" to "Implemented (21)" — all phases 1-7 complete, including worker registry, job routing, Hetzner autoscaling, caption forwarding, and S3 upload
- **Stub removal:** Delete the explicit stub note for `POST /compute/jobs/:jobId/caption` from §3 (Stubs & Gaps) — caption forwarding is now wired
- **Package version context:** Update lcyt-orchestrator and lcyt-worker-daemon descriptions to clarify that `0.0.x` versions are now a lag indicator (functional but not yet bumped), not a maturity signal
- **plan_music status:** Advance from "Phase 1" to "Phases 1-3 done" (client-side Web Audio API, server-side HLS analysis, RTMP fallback); Phase 4 (tuning/export/auto-start hook) remains
- **Prioritized next steps:** Reorder "Where to Continue Next" — distributed-compute is no longer the blocking item; OBS mixer dispatch, STT hardening, and music detection tuning are now top priorities
- **Recommended starting point:** Change from orchestrator/worker-daemon job dispatch (now complete) to OBS mixer dispatch (smallest, most concretely scoped remaining task)

## Implementation Details

- Compilation date bumped to 2026-06-30
- All references to distributed-compute gaps removed; cross-reference added to `docs/distributed-compute.md`
- Roadmap reordered to reflect actual completion state and unblock downstream work

https://claude.ai/code/session_01Lm3PSeJQ88G45CABaYLHDD