### PR TITLE
Add License section to lcyt-site Library page

### DIFF
--- a/docs/lib/license.md
+++ b/docs/lib/license.md
@@ -1,0 +1,149 @@
+---
+title: "License"
+---
+
+# License
+
+The `lcyt` core library (Node.js and Python) and the `lcyt-cli` command-line tool are licensed under the **European Union Public Licence (EUPL) v. 1.2**. This page reproduces the licence text in full; the canonical copy lives in each package's `LICENSE` file (`packages/lcyt/LICENSE`, `packages/lcyt-cli/LICENSE`) and at [eupl.eu/1.2/en](https://eupl.eu/1.2/en/).
+
+> Other parts of the LCYT monorepo (backends, web UI, plugins, etc.) may be licensed differently — check each package's own `LICENSE` file.
+
+---
+
+## European Union Public Licence (EUPL) v. 1.2
+
+### Terms and Conditions
+
+This European Union Public Licence (the "Licence") applies to the Work (as defined below) which is provided under the terms of this Licence. Any use of the Work, other than as authorised under this Licence is prohibited (to the extent such use is covered by a right of the copyright holder of the Work).
+
+The Work is provided under the terms of this Licence when the Licensor (as defined below) has placed the following notice immediately following the copyright notice for the Work:
+
+> "Licensed under the EUPL"
+
+or has expressed it in any other manner.
+
+### 1. Definitions
+
+In this Licence, the following terms have the following meaning:
+
+- The **"Licence"**: this licence.
+- The **"Original Work"**: the work or software distributed or communicated by the Licensor under this Licence, including source code and documentation, and any updates or upgrades thereof unless they constitute Derivative Works. If the Original Work is a database, then any updates or upgrades thereof exclude the contents of the database for the purposes of defining the Original Work. If the Original Work is a source code repository, then any updates or upgrades consisting of data contained in the repository itself are excluded from the definition of the Original Work; for the purposes of this definition, a repository is a location where data is stored and managed, whether or not it is accessible via electronic networks.
+- The **"Derivative Works"**: any work or software, other than the Original Work, that is based on (or derived from) the Original Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship, of which the copyright is held by the Licensor or, where applicable, any third party. This Licence does not define the degree of modification or dependence on the Original Work required to classify a work as a Derivative Work; this degree is determined by copyright law of the country mentioned in Article 15.
+- The **"Work"**: the Original Work or its Derivative Works.
+- The **"Licensor"**: the natural or legal person distributing or communicating the Work under this Licence.
+- **"Distribution"** or **"Communication"**: any act of selling, giving, lending, renting, transmitting, or otherwise making available, online or offline, copies of the Work or providing access to its essential functionalities at a distance by any person to any other person. For the purposes of this definition, transmission of the Work as part of a larger work in which the Work is incorporated shall not constitute Distribution or Communication.
+- **"You"** or **"Licensee"**: the natural or legal person exercising rights under the Licence.
+- **"Source code"**: the human-readable form of a work that is the most convenient for people to study and modify it.
+- **"Object code"**: any form of a work that results from the transformation or translation of source code, including but not limited to compiled object code and intermediate forms such as bytecode.
+
+### 2. Scope of the Licence
+
+The rights granted to You under this Licence are subject to the following scope: The Licensor hereby grants You a worldwide, royalty-free, non-exclusive, sublicensable licence to do the following, for the duration of copyright vested in the Original Work:
+
+(a) use the Work in any circumstance and for all usage,
+(b) reproduce the Work,
+(c) modify the Work, and develop Derivative Works based upon the Work,
+(d) communicate to the public, including the right to make available or display the Work or copies thereof to the public and perform publicly, as the case may be, the Work,
+(e) distribute the Work or copies thereof,
+(f) lend and rent the Work or copies thereof,
+(g) sublicense rights in the Work or copies thereof.
+
+These rights can be exercised on any media, supports and formats, whether now known or later invented, as far as the applicable law permits so.
+
+In the countries where moral rights apply, the Licensor waives the right to exercise the moral right of paternity of the Work to the fullest extent allowed by law so as to allow for the effective exercise of the economic rights aforesaid.
+
+The Licensor grants to the Licensee royalty-free, non-exclusive usage rights to any patents held by the Licensor, to the extent necessary to make use of the rights granted on the Work under this Licence.
+
+### 3. Communication of Source Code
+
+The Licensor may provide the Work either in its source code form, or as object code. If the Work is provided as object code, the Licensor provides in addition a machine-readable copy of the source code of the Work along with each copy of the Work that the Licensor distributes or indicates, in a notice following the copyright notice attached to the Work, a repository where the source code is easily and freely accessible for as long as the Licensor continues to distribute or communicate the Work.
+
+### 4. Limitations on copyright
+
+Nothing in this Licence is intended to deprive the Licensee of the benefits from any exception or limitation to the exclusive rights of the rights owners in the Original Work or Derivative Works, nor does it constitute a waiver of any of the said benefits and limitations.
+
+### 5. Obligations of the Licensee
+
+The grant of the rights mentioned above is subject to some restrictions and obligations imposed on the Licensee. Those obligations are the following:
+
+**Attribution right:** The Licensee shall keep intact all copyright, patent or trademarks notices and all notices that refer to the Licence and to the disclaimer of warranties. The Licensee must include a copy of such notices and a copy of the Licence with every copy of the Work he/she distributes or communicates. The Licensee must cause any Derivative Work to carry prominent notices stating that the Work has been modified and the date of modification.
+
+**Copyleft clause:** If the Licensee distributes or communicates copies of the Original Works or Derivative Works thereof, this Distribution or Communication will be done under the terms of this Licence or of a later version of this Licence unless the Original Work is expressly distributed only under this version of the Licence — for example by the communication of "EUPL v. 1.2 only". The Licensee (becoming Licensor) cannot offer or impose any additional terms or conditions on the Work or Derivative Work that alter or restrict the terms of the Licence.
+
+**Compatibility clause:** If the Licensee distributes or communicates Derivative Works or copies thereof based upon both the Work and another work licensed under a compatible licence, this Distribution or Communication can be done under the terms of this compatible licence. For the sake of this clause, "compatible licence" refers to the licences listed in the appendix attached to this Licence. Should the Licensee's obligations under the compatible licence conflict with his/her obligations under this Licence, the obligations of the compatible licence shall prevail.
+
+**Provision of Source Code:** When distributing or communicating copies of the Work, the Licensee will provide a machine-readable copy of the source code or indicate a repository where this source is easily and freely accessible for as long as the Licensee continues to distribute or communicate the Work.
+
+**Legal Protection of the Licensee:** Any Licensee which finally and non-provisionally terminates its violations of this Licence is reinstated with all his rights under this Licence. The reinstatement of rights is permanent. However, if the violation continues after a year following the notice of the non-definitive termination and a cure, termination of the Licence is permanent.
+
+### 6. Disclaimer of Warranties
+
+The Work is a work in progress, which is continuously improved by numerous contributors. It is not a finished work and may therefore contain defects or bugs inherent to this type of development.
+
+For the above reason, the Work is provided under the Licence on an "as-is" basis and without warranties of any kind concerning the Work, including without limitation merchantability, fitness for a particular purpose, absence of defects or errors, accuracy, non-infringement of intellectual property rights other than as stated in Article 4 of this Licence.
+
+This disclaimer of warranties is an essential part of the Licence and a condition for the grant of any rights to the Work.
+
+### 7. Limitation of Liability
+
+Subject to the provisions of Article 8, the Licensor shall not be liable for any direct or indirect, material or moral, damages of any kind, arising out of the Licence or of the use of the Work, including without limitation, damages for loss of goodwill, work stoppage, computer failure or malfunction, loss of data or any commercial damage, even if the Licensor has been advised of the possibility of such damage. However, the Licensor will be liable under statutory product liability laws as far such laws apply to the Work.
+
+### 8. Limitation of Liability
+
+The limitation of liability shall not apply to:
+
+(a) liability for death or personal injury resulting from negligence attributable to the Licensor,
+(b) liability for direct damages resulting from any breach of the essential obligations in this Licence or from violation of intellectual property rights by the Licensor, since these are the reasons for which the Licensor is party to this Licence.
+
+For the sake of clarity, this Licence is a licence of copyright held by the Licensor and does not transfer any ownership of the Work.
+
+### 9. Miscellaneous
+
+(a) Each time You accept the Licence, the original Licensor offers You a licence to the Work under the same terms and conditions.
+(b) If any provision of this Licence is invalid or unenforceable under applicable law, this shall not affect the validity or enforceability of the Licence as a whole. Such provision shall be interpreted or reformed so as to achieve the goals and purposes of that provision under applicable law.
+(c) Without prejudice to any other proceedings which may be available to him/her, any Licensor revoking this Licence for your material breach of the terms and conditions of this Licence by a written notice addressed to you, will not be liable for damages resulting from loss of opportunity (loss of revenue, profit and anticipated savings) or for indirect damages, consequential damages or punitive damages as regards such revocation.
+(d) As the Work is continuously developed, assistance is often provided by various contributors ("Contributors"). Except in the case provided for in Article 5(c), the Contributors do not benefit from any exclusive rights and each Contributor retains copyright to modifications made by him/her.
+
+### 10. Versions of the Licence
+
+**10.1. New Versions**
+
+The European Commission may publish new versions and/or new language versions of this Licence or updated versions of the Appendix, so far this is required to address new developments, further to the results of the Community legal framework relating to information society technology. Every version of the Licence will be given a distinguishing version number.
+
+**10.2. Effect of New Versions**
+
+Any Work already distributed or communicated by a Licensor under this version of the Licence may continue to be distributed or communicated thereunder, as long as the Derivative Works are distributed under the same version of the Licence.
+
+**10.3. Earlier Versions**
+
+You may choose to use the Work under the terms of either this Licence or any earlier version, unless the Licence explicitly excludes the use under the terms of the earlier versions. For any version of the Licence, you will find in the Appendix all the licenses with which that version is considered compatible.
+
+### 11. Jurisdiction
+
+Without prejudice to specific agreement between parties,
+
+(a) any litigation resulting from the interpretation of this License, arising between the European Commission, as a Licensor, and any Licensee, will be subject to the jurisdiction of the Court of Justice of the European Communities, as laid down in article 292 of the Treaty establishing the European Community,
+(b) any litigation arising between other parties and resulting from the interpretation of this License, will be subject to the exclusive jurisdiction of the competent court where the Licensor resides.
+
+### 12. Applicable Law
+
+This Licence shall be governed by the law of the European Union country in which the Licensor resides.
+
+However, this choice will not deprive the Licensee of the protection granted by mandatory provisions of the law of the country in which the Licensee resides.
+
+### 13. Appendix
+
+"Compatible Licences" according to Article 5 EUPL are:
+
+- GNU General Public License (GPL) v. 2, v. 3
+- GNU Affero General Public License (AGPL) v. 3
+- Open Software License (OSL) v. 2.1, v. 3.0
+- Eclipse Public License (EPL) v. 1.0
+- CeCILL v. 2.0, v. 2.1
+- Mozilla Public License (MPL) v. 2.0
+- GNU Lesser General Public License (LGPL) v. 2.1, v. 3
+- Creative Commons Attribution-ShareAlike 3.0 Unported
+
+---
+
+Copyright (c) 2026 Juha Itäleino

--- a/packages/lcyt-site/src/pages/lib/index.astro
+++ b/packages/lcyt-site/src/pages/lib/index.astro
@@ -2,6 +2,7 @@
 import { getCollection, render } from 'astro:content';
 import DocsLayout from '../../layouts/DocsLayout.astro';
 
+const LICENSE_ORDER = ['license'];
 const JS_ORDER = ['README', 'sender', 'backend-sender', 'config', 'logger', 'errors'];
 const PY_ORDER = [
   'python/README', 'python/sender', 'python/backend-sender',
@@ -17,12 +18,17 @@ function docLabel(id: string, title?: string): string {
 
 const allDocs = await getCollection('lib');
 
+const licenseDocs = LICENSE_ORDER.map(id => allDocs.find(d => d.id === id)).filter(Boolean) as typeof allDocs;
 const jsDocs = JS_ORDER.map(id => allDocs.find(d => d.id === id)).filter(Boolean) as typeof allDocs;
 const pyDocs = PY_ORDER.map(id => allDocs.find(d => d.id === id)).filter(Boolean) as typeof allDocs;
 
-const docs = [...jsDocs, ...pyDocs];
+const docs = [...licenseDocs, ...jsDocs, ...pyDocs];
 
 const sidebarSections = [
+  {
+    heading: 'License',
+    items: licenseDocs.map(d => ({ id: d.id, label: docLabel(d.id, d.data.title) })),
+  },
   {
     heading: 'Node.js',
     items: jsDocs.map(d => ({ id: d.id, label: docLabel(d.id, d.data.title) })),


### PR DESCRIPTION
Adds a new top sidebar section to the /lib page reproducing the EUPL-1.2
license text that covers the lcyt library (Node.js + Python) and lcyt-cli.