### PR TITLE
DSK Phase 5: entry/exit CSS animations for graphic overlays

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,0 +1,181 @@
+# LCYT Feature List & Pipeline Guide
+
+A from-the-ground-up tour of what LCYT can do, organized as ready-made production pipelines. Use this as marketing copy, a sales sheet, or an onboarding map — pick the pipeline that matches your event and follow the linked docs.
+
+---
+
+## 1. Feature List
+
+### Core caption delivery
+- **YouTube Live HTTP POST caption ingestion** — Google's official closed-caption API, with sequence tracking, 60-second timestamp windows, and NTP-style clock sync (`syncOffset`) so captions land in time even on a flaky connection.
+- **Multi-target fan-out** — one caption stream, delivered simultaneously to:
+  - **YouTube** (one or more stream keys — multi-channel simulcast)
+  - **Viewer pages** (public SSE broadcast, no auth, embeddable, Android TV app)
+  - **Generic webhook** (arbitrary HTTP POST endpoint, e.g. your own overlay or CMS)
+- **Caption file management** — local filesystem, S3-compatible (R2/MinIO/B2), or WebDAV storage; upload, replay, batch-send, and auto-archive every session.
+- **CEA-608/708 embedding** — burn standards-compliant closed captions directly into the RTMP/HLS video stream (eia608 encoder + SRT pipe), for platforms that don't support sidecar captions.
+- **HLS multilingual subtitle sidecar** — rolling WebVTT segments per language, served via an HLS.js player at `/video/:key` with a CC language picker.
+
+### Speech-to-text (two independent paths)
+- **Browser-side STT** — Web Speech API and Google Cloud STT, client-side voice-activity detection, live translation before sending.
+- **Server-side STT** — no browser or microphone required; transcribes directly from the incoming RTMP/HLS/WHEP stream. Google Cloud (REST/gRPC), Whisper-compatible HTTP, or OpenAI-compatible endpoints. Per-caption confidence filtering.
+
+### Translation
+- Real-time client-side translation (MyMemory, Google, DeepL, LibreTranslate) before captions are sent, multi-target routing (different languages to different viewer pages), and translated WebVTT sidecar generation.
+
+### Streaming infrastructure
+- **RTMP relay & fan-out** — one ingest, many destinations.
+- **HLS (video+audio)** — MediaMTX-based, no ffmpeg in the hot path.
+- **Audio-only radio HLS** — dual mode: ffmpeg pipeline or MediaMTX + nginx slug proxying.
+- **Live preview thumbnails** — JPEG snapshot polling for monitoring dashboards.
+- **Distributed ffmpeg compute** — runs ffmpeg locally, in a Docker container, or dispatched to a fleet of remote worker VMs with automatic Hetzner Cloud burst-autoscaling under load. Falls back gracefully to local execution if no orchestrator is reachable.
+
+### Inline metacodes (caption text drives everything else)
+A single text stream can carry hidden HTML-comment directives that the backend strips before delivery and turns into real-time events:
+- `<!-- graphics:... -->` — show/hide DSK overlay elements, per-viewport or globally, with additive/subtractive deltas.
+- `<!-- cue:... -->` — advance a rundown/runsheet: exact phrase, fuzzy (typo-tolerant), semantic (embedding similarity), or AI event-based ("when the speaker mentions communion").
+- `<!-- sound:... -->` / `<!-- bpm:... -->` — music/speech/silence state and tempo, fed by the music-detection engine.
+
+### Graphics (DSK overlays)
+- Headless-Chromium template renderer composited live onto the RTMP feed.
+- Visual drag/resize/multi-select editor with undo/redo, snap-to-grid/edge, alignment tools, copy/paste, and a media library for uploaded images.
+- **Named viewports** — push different graphic sets to differently-shaped outputs (e.g. 16:9 landscape program feed vs. a 9:16 vertical clip feed) from one caption stream, simultaneously, independently controlled.
+
+### Production control (cameras & switchers)
+- PTZ camera presets and live video-mixer source switching, driven from the same operator UI or via metacodes.
+- A standalone **bridge agent** (`lcyt-bridge`) relays commands to on-site hardware over TCP, so the cloud backend never needs direct network access to the venue.
+
+### Music & audio analysis
+- Detects music / speech / silence and estimates BPM, from either server-side audio (HLS or RTMP) or a browser microphone — no song identification, just state.
+- Used to suppress low-confidence STT during music, drive a "music in progress" cue light, or time graphics cuts to the beat.
+
+### AI Agent
+- Per-user pluggable embedding/LLM provider config (server-default, OpenAI, or custom endpoint).
+- Context-window-aware event-cue evaluation ("fire this cue when the content matches this description").
+- AI-assisted DSK template generation/editing and AI-assisted rundown/runsheet generation.
+
+### Platform & operations
+- Multi-user accounts, project (API key) management, team membership with roles, per-project feature flags, device-role pin-code logins for shared production hardware.
+- Full admin panel: user/project CRUD, audit log, batch operations, JSON export/import.
+- Two-phase adaptive login (feature-probing against `GET /health`) so the same frontend serves a full-featured cloud backend or a minimal self-hosted relay.
+- Embeddable widgets (`/embed/*`) for audio capture, text input, sent-log, file drop, settings, RTMP control, and viewer — drop any one into an existing production dashboard via iframe, synced over `BroadcastChannel`.
+- Android TV viewer app for full-screen caption display on TV/Fire TV.
+- Three deployment tiers: single docker-compose stack, docker-compose + Hetzner burst workers, or full Kubernetes (CloudFleet) manifests.
+
+---
+
+## 2. Pipeline Suggestions
+
+Each of these is a complete, ready-to-run configuration of the platform for a specific production need.
+
+### Pipeline A — Captions only, frontend (browser) transcribe
+**Best for:** solo operators, small churches/events, no server-side audio infrastructure.
+
+The operator opens `/audio` (or the `/embed/audio` widget) in a browser, grants mic access, and Web Speech API or Google Cloud STT transcribes locally. Client-side VAD trims silence; optional live translation runs before send. Captions go straight to YouTube (and optionally a viewer page) via `BackendCaptionSender`.
+
+- **Needs:** a browser, a microphone, an API key. No RTMP, no media server.
+- **Docs:** `docs/plans/plan_stt.md`, `packages/lcyt-web/src/hooks/useWebSpeech.js`.
+
+### Pipeline B — Captions only, backend (server-side) transcribe
+**Best for:** unattended/headless rigs, hardware encoders with no browser in the loop, consistent transcription quality independent of operator hardware.
+
+An RTMP (or WHEP) encoder pushes audio+video to the backend. `SttManager` pulls audio from the live HLS/RTMP/WHEP stream and transcribes via Google Cloud, Whisper-compatible, or OpenAI-compatible STT, with a confidence threshold to silently drop low-quality fragments. Transcripts are injected straight into the session's send queue — delivered exactly like manually typed captions.
+
+- **Needs:** an RTMP/WHEP-capable encoder, an STT provider credential.
+- **Docs:** `docs/plans/plan_server_stt.md`, `/stt/*` API routes.
+
+### Pipeline C — RTMP fan-out
+**Best for:** simulcasting one source to multiple outputs (HLS player, radio stream, thumbnail monitor, DSK-composited feed) without re-encoding per destination.
+
+One RTMP ingest is split by `RtmpRelayManager` into: a video+audio HLS feed (MediaMTX), an audio-only "radio" HLS feed, periodic JPEG preview thumbnails, optional CEA-708 caption embedding, and an optional DSK-composited output. All from a single upstream connection.
+
+- **Needs:** an RTMP source, relay slot configuration per API key.
+- **Docs:** `docs/plans/plan_rtmp.md`, `docs/plans/plan_mediamtx.md`.
+
+### Pipeline D — Metacode-driven automation
+**Best for:** operators who want one text stream to silently drive graphics, rundown advancement, and sound-aware behavior, instead of juggling multiple control panels.
+
+Caption text carries `<!-- graphics:... -->`, `<!-- cue:... -->`, and `<!-- sound:... -->`/`<!-- bpm:... -->` directives inline. The backend strips them before delivery to YouTube and fans the directives out as SSE events to DSK overlays, the cue engine, and connected dashboards — so a single typed or transcribed stream becomes the control surface for the whole show.
+
+- **Needs:** nothing extra — metacodes work on top of any caption source.
+- **Docs:** `docs/METACODE.md`.
+
+### Pipeline E — Camera (PTZ) control
+**Best for:** productions with one or more remotely-controllable cameras and an operator who wants preset recall from the same dashboard as captions.
+
+PTZ presets are triggered from `/production/cameras` or via the bridge agent, against:
+
+| Adapter | Supported devices |
+|---|---|
+| `amx` | AMX-protocol PTZ controllers (TCP/IP) |
+| `visca-ip` | Any VISCA-over-IP PTZ camera (most professional PTZ cameras — Sony, Panasonic, PTZOptics, and other VISCA-over-IP-compliant models) |
+| `browser` | Browser/WebRTC media-device capture (software-only, no physical PTZ) |
+| `none` | No-op placeholder for software-only camera targets |
+
+- **Needs:** a camera reachable over TCP/IP (for AMX/VISCA) and, for on-site hardware, a running `lcyt-bridge` agent.
+- **Docs:** `docs/plans/plan_prod.md`, `packages/plugins/lcyt-production/src/adapters/camera/`.
+
+### Pipeline F — Video switcher (mixer) control
+**Best for:** productions that need source switching (camera A/B, graphics key, slides) triggered remotely or via metacode automation.
+
+| Adapter | Supported devices |
+|---|---|
+| `roland` | Roland video mixers (TCP) |
+| `amx` | AMX-protocol mixers (TCP) |
+| `atem` | Blackmagic Design ATEM switchers |
+| `obs` | OBS Studio (obs-websocket) — *see gap note below* |
+| `lcyt` | LCYT's own software mixer |
+| `monarch_hdx` | Matrox Monarch HDX encoder/mixer |
+
+- **Needs:** a mixer reachable over TCP (or obs-websocket/network for OBS), and for on-site hardware, `lcyt-bridge` running locally.
+- **Docs:** `docs/plans/plan_prod.md`, `packages/plugins/lcyt-production/src/adapters/mixer/`.
+
+### Pipeline G — Graphics (DSK overlays)
+**Best for:** lower-thirds, branding, sponsor cards, and any caption-driven on-screen graphic that needs to look broadcast-quality without a dedicated graphics operator.
+
+Design templates visually in the DSK editor (drag/resize/multi-select, snap-to-grid, media library), then drive which elements are visible live via metacodes or the DSK control panel. A headless-Chromium renderer composites the result and pushes it onto the RTMP output in real time.
+
+- **Needs:** an RTMP output target (for hardware compositing) or a browser overlay page (for software/streaming-software compositing, e.g. an OBS browser source).
+- **Docs:** `docs/plans/plan_dsk.md`, `packages/plugins/lcyt-dsk/`.
+
+### Pipeline H — Graphics to multiple screens with different dimensions
+**Best for:** simultaneous landscape program output + vertical (9:16) clip/social feed, or multi-room productions where each screen needs its own graphic set and aspect ratio.
+
+Define named **viewports** (e.g. `landscape`/`default`/`main`, `vertical-left`, `vertical-right`) each with their own dimensions. A single metacode stream can target one, several, or all viewports independently:
+```
+<!-- graphics[vertical-left]:stanza,logo -->   vertical-left gets stanza+logo
+<!-- graphics:logo,banner -->                  every viewport gets logo+banner
+<!-- graphics[vertical-right]: -->             vertical-right cleared
+```
+Each viewport renders and streams independently, so a 16:9 landscape feed and a 9:16 vertical feed can show entirely different overlay content from the same show, at the same time.
+
+- **Needs:** one DSK renderer instance per output dimension/destination.
+- **Docs:** `docs/plans/plan_dsk.md` (viewport CRUD), `docs/METACODE.md`.
+
+### Pipeline I — Music detection
+**Best for:** worship/concert productions where you want STT to go quiet during musical numbers, or want a producer-facing "music is playing" / BPM cue light without identifying the song.
+
+Two independent audio paths feed the same classifier output (music/speech/silence + BPM estimate): server-side (HLS segments or RTMP PCM, no browser needed) or client-side (browser mic, Web Audio API). Output is exposed as SSE events and `<!-- sound:... -->`/`<!-- bpm:... -->` metacodes — wire it into STT confidence gating, a DSK "now playing" indicator, or BPM-synced graphic cuts.
+
+- **Needs:** either an RTMP/HLS audio source, or a browser microphone.
+- **Docs:** `docs/plans/plan_music.md`, `packages/plugins/lcyt-music/`.
+
+---
+
+## 3. Pipelines That Need More Code
+
+Honest gap list — what's solid today vs. what still needs engineering work before each pipeline above is fully production-ready end to end.
+
+| Pipeline | Status | What's missing |
+|---|---|---|
+| **A. Frontend transcribe** | ✅ Fully implemented | No known gaps. |
+| **B. Backend transcribe** | ⚠️ Functional, needs hardening | REST/HLS path works today. gRPC streaming mode and the RTMP/WHEP audio-source fallback paths (plan_server_stt Phases 2-4) are still being hardened — expect rough edges under sustained load or on flaky RTMP ingests. |
+| **C. RTMP fan-out** | ✅ Fully implemented | `NginxManager` reload-failure handling has a documented test gap (low risk, not user-facing). |
+| **D. Metacode automation** | ✅ Fully implemented | None blocking; `plan_metacode_refactor` is an internal code-organization cleanup, not a feature gap. |
+| **E. Camera control** | ✅ Fully implemented | All four adapters (AMX, VISCA-IP, browser, none) are wired with no open stubs. |
+| **F. Video switcher control** | ⚠️ One real gap | The `obs` mixer adapter (`adapters/mixer/obs.js`) builds a correct `obs_switch` command object, but **`lcyt-bridge` does not yet dispatch it** — OBS switching is configured but inert today. Roland/AMX/ATEM/LCYT/Monarch HDX all work. This is the most concretely scoped piece of missing code in the whole feature set. |
+| **G. Graphics (DSK)** | ✅ Core fully implemented | Phase 5 (animated transitions between graphic states) is still on the roadmap; static/instant show-hide works today. |
+| **H. Multi-screen graphics** | ✅ Fully implemented | Viewport targeting and independent rendering both work today; the only related gap is the same animation Phase 5 noted above. |
+| **I. Music detection** | ⚠️ Functional, polish remaining | Detection, BPM estimation, and both audio paths (server + client) work. Phase 4 (tuning, export, pluggable external classifier) is unstarted, and the `on_publish` auto-start hook for `music_config.autoStart` isn't wired — autostart-on-stream-begin doesn't happen automatically yet, has to be triggered manually via `/music/start`. |
+
+**Single most actionable fix:** wiring `obs_switch` dispatch into `lcyt-bridge` (Pipeline F) — the adapter-side contract already exists, it's a bridge-agent-only change with no architectural ambiguity.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -174,8 +174,8 @@ Honest gap list — what's solid today vs. what still needs engineering work bef
 | **D. Metacode automation** | ✅ Fully implemented | None blocking; `plan_metacode_refactor` is an internal code-organization cleanup, not a feature gap. |
 | **E. Camera control** | ✅ Fully implemented | All four adapters (AMX, VISCA-IP, browser, none) are wired with no open stubs. |
 | **F. Video switcher control** | ⚠️ One real gap | The `obs` mixer adapter (`adapters/mixer/obs.js`) builds a correct `obs_switch` command object, but **`lcyt-bridge` does not yet dispatch it** — OBS switching is configured but inert today. Roland/AMX/ATEM/LCYT/Monarch HDX all work. This is the most concretely scoped piece of missing code in the whole feature set. |
-| **G. Graphics (DSK)** | ✅ Core fully implemented | Phase 5 (animated transitions between graphic states) is still on the roadmap; static/instant show-hide works today. |
-| **H. Multi-screen graphics** | ✅ Fully implemented | Viewport targeting and independent rendering both work today; the only related gap is the same animation Phase 5 noted above. |
+| **G. Graphics (DSK)** | ✅ Fully implemented | Phase 5 (entry/exit CSS animations) is done for the `/dsk/:key` overlay page. The ffmpeg-filter RTMP overlay compositing path (`relayManager.setDskOverlay()`) has no DOM/CSS engine and remains an instant cut — architecturally out of scope for CSS animation. |
+| **H. Multi-screen graphics** | ✅ Fully implemented | Viewport targeting and independent rendering both work today, including per-viewport animations. |
 | **I. Music detection** | ⚠️ Functional, polish remaining | Detection, BPM estimation, and both audio paths (server + client) work. Phase 4 (tuning, export, pluggable external classifier) is unstarted, and the `on_publish` auto-start hook for `music_config.autoStart` isn't wired — autostart-on-stream-begin doesn't happen automatically yet, has to be triggered manually via `/music/start`. |
 
 **Single most actionable fix:** wiring `obs_switch` dispatch into `lcyt-bridge` (Pipeline F) — the adapter-side contract already exists, it's a bridge-agent-only change with no architectural ambiguity.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -31,7 +31,7 @@ This is a point-in-time snapshot, not a maintained changelog. The repo has no `C
 | plan_setup_wizard | Setup Wizard | `/setup` guided flow, fully implemented |
 | plan_userprojects | Feature Flags, Membership, Device Roles | Phases 1-3 done; Phase 4 (QR codes, tally light, time-limited sessions) future work |
 | plan_cloudfleet | Hosting Modes & Cloudfleet Deployment | All 3 tiers done; optional Helm/Litestream/Postgres/ServiceMonitor pending |
-| plan_dsk | DSK Graphics Editor (Phases 2-4) | Canvas editing, multi-select, media library; Phase 5 (Animations) remains |
+| plan_dsk | DSK Graphics Editor (Phases 2-5) | Canvas editing, multi-select, media library, entry/exit animations — all complete |
 | plan_files3 | lcyt-files Storage Adapters | local/S3/WebDAV done; CDN URL field, S3 mock tests, migration script remain low-priority |
 | plan_admin | Admin Panel | Phases 1-2 done: CRUD, audit log, import/export |
 | plan_ui | Frontend & UI Plans | All backlog items done (command palette, shortcuts, reconnect, etc.) |
@@ -117,7 +117,7 @@ The orchestrator and worker-daemon's `0.0.x` versions are now a lag indicator, n
 4. **AI Agent vision/image inference** (plan_agent Phase 4) — replace the `analyseImage()` stub with a real vision-capable LLM call.
 5. **Write the two skipped integration tests** (`dsk-integration.test.js`, `stt-integration.test.js`) once Playwright/Chromium and HLS/ffmpeg/MediaMTX test infra is available — currently `test.skip`.
 6. **Prove out Hetzner burst autoscaling end-to-end** — the orchestrator/worker-daemon path is wired (job dispatch, caption forwarding, S3 upload) but real-world burst-provisioning under load remains unproven; bump `lcyt-orchestrator`/`lcyt-worker-daemon` package versions once it is.
-7. Lower priority / polish: plan_help (screenshot capture for the help page), plan_dsk Phase 5 (animations), plan_userprojects Phase 4 (QR codes, tally light, time-limited sessions), plan_cloudfleet optional enhancements (Helm chart, Litestream, Postgres, ServiceMonitor, CI CFCR push).
+7. Lower priority / polish: plan_help (screenshot capture for the help page), plan_userprojects Phase 4 (QR codes, tally light, time-limited sessions), plan_cloudfleet optional enhancements (Helm chart, Litestream, Postgres, ServiceMonitor, CI CFCR push).
 8. **plan_translate** remains in draft — worth a decision on whether to formally schedule it (closes the gap where STT/CLI captions can't be server-side translated) or shelve it.
 
 **Recommended starting point:** item 1 (OBS mixer dispatch) — smallest, most concretely scoped, no dependencies.

--- a/docs/plans/plan_dsk.md
+++ b/docs/plans/plan_dsk.md
@@ -1,11 +1,11 @@
 ---
 id: plan/dsk
-title: "DSK Graphics Editor — Phases 2–4 (Editable Shapes, Multi-select, Media Library)"
+title: "DSK Graphics Editor — Phases 2–5 (Editable Shapes, Multi-select, Media Library, Animations)"
 status: implemented
-summary: "Phases 1–4 complete. Direct canvas manipulation (drag/resize/nudge), undo/redo, multi-selection, snap-to-grid, snap-to-edges, grouping, alignment, Media Library."
+summary: "Phases 1–5 complete. Direct canvas manipulation (drag/resize/nudge), undo/redo, multi-selection, snap-to-grid, snap-to-edges, grouping, alignment, Media Library, entry/exit CSS animations for DSK graphic images."
 ---
 
-# Plan: DSK Graphics Editor — Phases 2–4 (Editable Shapes, Multi-select, Media Library)
+# Plan: DSK Graphics Editor — Phases 2–5 (Editable Shapes, Multi-select, Media Library, Animations)
 
 > Target branch: `claude/add-editable-shapes-yxAXO`
 
@@ -123,9 +123,55 @@ All Phase 3 features (previously listed as "excluded from Phase 2") are implemen
 
 ---
 
-## Phase 5 — Animations (future)
+## Phase 5 — Animations — Status: Complete ✓
 
-Preset picker, per-layer CSS animation shorthand, live preview. LCYT keyframe
-CSS is already injected in `DskEditorPage.jsx`; the `AnimationEditor` component
-and `ANIM_PRESETS` list are in place. Full animation editing UI is a future phase.
+### Goal
+
+Entry animations (CSS `animation` shorthand, e.g. `lcyt-fadeIn 0.5s`) already played
+correctly when a DSK image or template layer first mounted, on all three rendering
+paths (browser overlay page, editor preview, Playwright renderer). What was missing:
+images had no editor UI to set per-viewport animations beyond a raw text input, and
+nothing played a matching *exit* animation before an image left the DOM — it just
+vanished instantly the moment a `<!-- graphics:... -->` metacode dropped it from the
+active set. Phase 5 closes both gaps for the public `/dsk/:key` overlay page (the
+path OBS browser sources and viewer pages actually render).
+
+### Implemented
+
+| Feature | File | Status |
+|---|---|---|
+| Exit-animation derivation (reverses entry preset, falls back to fade) | `packages/lcyt-web/src/lib/dskExitAnimation.js` | ✓ Done |
+| Animation total-duration helper (duration + delay, ms) | `packages/lcyt-web/src/lib/dskExitAnimation.js` | ✓ Done |
+| `DskPage.jsx` keeps a removed image mounted for its exit-animation duration, then unmounts it | `packages/lcyt-web/src/components/DskPage.jsx` | ✓ Done |
+| Images with no configured animation are removed instantly (legacy behaviour preserved) | `packages/lcyt-web/src/components/DskPage.jsx` | ✓ Done |
+| Fixed: LCYT `@keyframes` were only injected into the page when a template was active, silently breaking image-only animations | `packages/lcyt-web/src/components/DskPage.jsx` | ✓ Done |
+| `AnimationEditor` preset picker wired into the per-viewport image settings table (was a raw text input) | `packages/lcyt-web/src/components/dsk-viewports/ImageSettingsTable.jsx` | ✓ Done |
+| Unit tests for `dskExitAnimation.js` | `packages/lcyt-web/test/dskExitAnimation.test.js` | ✓ Done |
+| Component tests for `DskPage.jsx` exit-animation lifecycle | `packages/lcyt-web/test/components/DskPage.test.jsx` | ✓ Done |
+
+### Scope notes
+
+- Out of scope: the ffmpeg-filter-based overlay compositing used by
+  `relayManager.setDskOverlay()` (`packages/plugins/lcyt-rtmp/src/rtmp-manager.js`)
+  has no DOM/CSS engine and restarts the whole relay ffmpeg process on every overlay
+  change — it cannot play CSS animations and is architecturally incompatible with
+  them. The RTMP "DSK overlay" path for the landscape stream remains an instant cut.
+- Out of scope: cross-fading between two different *templates* in the Playwright
+  renderer (`packages/plugins/lcyt-dsk/src/renderer.js`) — template swaps still do a
+  full-page reload. Per-layer entry/exit animations *within* a single rendered
+  template already worked before this phase via the page's own CSS `animation`.
+- Per-layer exit animations in the `TemplatePreview.jsx` editor canvas were left as
+  an instant hide on visibility toggle — there's no live-broadcast trigger event for
+  single-layer visibility changes without a full template reload, so there was
+  nothing to animate against.
+
+### Files changed in Phase 5
+
+| File | Change |
+|---|---|
+| `packages/lcyt-web/src/lib/dskExitAnimation.js` | New — `deriveExitAnimation()` + `getAnimationTotalMs()` pure helpers |
+| `packages/lcyt-web/src/components/DskPage.jsx` | Added `exitingNames` state machine; merged active+exiting images into the render list; fixed always-on `@keyframes` injection |
+| `packages/lcyt-web/src/components/dsk-viewports/ImageSettingsTable.jsx` | Replaced raw animation text input with `AnimationEditor` preset picker |
+| `packages/lcyt-web/test/dskExitAnimation.test.js` | New — unit tests (node:test) |
+| `packages/lcyt-web/test/components/DskPage.test.jsx` | New — component tests (Vitest) for the exit-animation lifecycle |
 

--- a/packages/lcyt-web/src/components/DskPage.jsx
+++ b/packages/lcyt-web/src/components/DskPage.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { KEYS } from '../lib/storageKeys.js';
+import { deriveExitAnimation, getAnimationTotalMs } from '../lib/dskExitAnimation.js';
 
 /**
  * DSK (downstream keyer) display page.
@@ -62,6 +63,9 @@ export function DskPage() {
   // ── State ───────────────────────────────────────────────
   const [images, setImages]           = useState([]); // [{ id, shorthand, mimeType, url, settingsJson }]
   const [activeNames, setActiveNames] = useState([]); // string[]
+  // Images that were just dropped from activeNames but are still playing their exit
+  // animation — kept mounted until their animation duration elapses (see effect below).
+  const [exitingNames, setExitingNames] = useState([]); // string[]
   const [ccText, setCcText]           = useState('');
   const [status, setStatus]           = useState('connecting');
   // viewport dimensions (null = use 100vw/100vh)
@@ -82,6 +86,8 @@ export function DskPage() {
   const retryDelay  = useRef(1000);
   const retryTimer  = useRef(null);
   const mounted     = useRef(true);
+  const prevActiveRef = useRef([]);
+  const exitTimersRef = useRef(new Map()); // name -> timeoutId
 
   // ── Image pre-loading ───────────────────────────────────
   async function fetchImages() {
@@ -231,8 +237,45 @@ export function DskPage() {
       mounted.current = false;
       esRef.current?.close();
       if (retryTimer.current) clearTimeout(retryTimer.current);
+      for (const t of exitTimersRef.current.values()) clearTimeout(t);
+      exitTimersRef.current.clear();
     };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // When activeNames changes, any name that just dropped out keeps playing its exit
+  // animation for one more render pass instead of disappearing instantly. Images with no
+  // configured animation are removed immediately (unchanged legacy behaviour).
+  useEffect(() => {
+    const prevActive = prevActiveRef.current;
+    prevActiveRef.current = activeNames;
+
+    const removed = prevActive.filter(n => !activeNames.includes(n));
+    if (removed.length === 0) return;
+
+    // A name that re-appeared in this same update cancels any pending exit timer.
+    for (const name of activeNames) {
+      const t = exitTimersRef.current.get(name);
+      if (t) { clearTimeout(t); exitTimersRef.current.delete(name); }
+    }
+
+    const toExit = [];
+    for (const name of removed) {
+      const img = images.find(i => i.shorthand === name);
+      const vpSettings = img ? getViewportSettings(img.settingsJson, viewportName) : {};
+      if (!vpSettings.animation) continue; // no entry animation configured → vanish instantly
+      toExit.push(name);
+      const ms = getAnimationTotalMs(vpSettings.animation);
+      const timer = setTimeout(() => {
+        exitTimersRef.current.delete(name);
+        if (!mounted.current) return;
+        setExitingNames(prev => prev.filter(n => n !== name));
+      }, ms);
+      exitTimersRef.current.set(name, timer);
+    }
+    if (toExit.length > 0) {
+      setExitingNames(prev => [...prev.filter(n => !activeNames.includes(n)), ...toExit]);
+    }
+  }, [activeNames, images, viewportName]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // ── Container sizing ────────────────────────────────────
   // When a viewport with specific dimensions is set, scale the fixed-size container to fit
@@ -254,8 +297,9 @@ export function DskPage() {
 
   return (
     <div style={containerStyle}>
-      {/* CSS keyframes for template layer animations */}
-      {activeTemplates.length > 0 && <style>{LCYT_KEYFRAMES}</style>}
+      {/* CSS keyframes for DSK image and template layer animations — always injected so
+          named animations resolve regardless of whether a template or only images are active. */}
+      <style>{LCYT_KEYFRAMES}</style>
 
       {/* All images pre-loaded (hidden) for zero-latency visibility toggle */}
       {images.map(img => (
@@ -268,14 +312,22 @@ export function DskPage() {
         />
       ))}
 
-      {/* Active images rendered in metacode order: first name = lowest z-index (bottom layer), last = highest */}
-      {activeNames.map((name, layerIdx) => {
+      {/* Active images rendered in metacode order: first name = lowest z-index (bottom layer), last = highest.
+          Exiting images (recently removed from activeNames but still playing their exit animation) are
+          appended after active ones so they stay mounted until their animation completes. */}
+      {[...activeNames, ...exitingNames.filter(name => !activeNames.includes(name))].map((name, layerIdx) => {
         const img = images.find(i => i.shorthand === name);
         if (!img) return null;
 
+        const isExiting = !activeNames.includes(name) && exitingNames.includes(name);
+
         // Per-viewport settings
         const vpSettings = getViewportSettings(img.settingsJson, viewportName);
-        if (vpSettings.visible === false) return null;
+        if (vpSettings.visible === false && !isExiting) return null;
+
+        const effectiveSettings = isExiting
+          ? { ...vpSettings, animation: deriveExitAnimation(vpSettings.animation) }
+          : vpSettings;
 
         return (
           <img
@@ -283,7 +335,7 @@ export function DskPage() {
             src={`${serverUrl}/images/${img.id}`}
             alt=""
             aria-hidden="true"
-            style={buildImageStyle(layerIdx, vpSettings, vpDimensions)}
+            style={buildImageStyle(layerIdx, effectiveSettings, vpDimensions)}
             crossOrigin="anonymous"
           />
         );

--- a/packages/lcyt-web/src/components/dsk-viewports/ImageSettingsTable.jsx
+++ b/packages/lcyt-web/src/components/dsk-viewports/ImageSettingsTable.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { dark, btnPrimary, btnDanger, btnSmall, inputStyle, labelStyle } from './styles.js';
+import AnimationEditor from '../dsk-editor/AnimationEditor.jsx';
 
 function ImageRow({ img, settings, isExpanded, onToggleExpand, onSave, serverUrl }) {
   const visible = settings.visible !== false;
@@ -84,13 +85,11 @@ function ImageRow({ img, settings, isExpanded, onToggleExpand, onSave, serverUrl
                 />
               </div>
             ))}
-            <div style={{ flex: '1 1 200px' }}>
+            <div style={{ flex: '1 1 260px' }}>
               <label style={labelStyle}>Animation</label>
-              <input
-                style={{ ...inputStyle, width: '100%' }}
-                placeholder="e.g. lcyt-fadeIn 0.5s"
+              <AnimationEditor
                 value={draft.animation}
-                onChange={e => setDraft(d => ({ ...d, animation: e.target.value }))}
+                onChange={v => setDraft(d => ({ ...d, animation: v || '' }))}
               />
             </div>
           </div>

--- a/packages/lcyt-web/src/lib/dskExitAnimation.js
+++ b/packages/lcyt-web/src/lib/dskExitAnimation.js
@@ -1,0 +1,53 @@
+/**
+ * Exit-animation helpers for DSK graphics.
+ *
+ * Entry animations (CSS `animation` shorthand, e.g. "lcyt-fadeIn 0.5s") already play when a
+ * DSK image first appears. These helpers derive the matching "exit" animation so an image
+ * can play a mirrored transition before being removed from the DOM, instead of vanishing
+ * instantly when a `<!-- graphics:... -->` metacode drops it from the active set.
+ */
+
+// Maps an entry preset to its natural reverse. Presets without an obvious reverse
+// (pulse, blink, typewriter, the *Out presets themselves, slideInUp/Down — no
+// slideOutUp/Down keyframes exist) fall back to DEFAULT_EXIT_PRESET.
+const EXIT_PRESET_MAP = {
+  'lcyt-fadeIn':       'lcyt-fadeOut',
+  'lcyt-slideInLeft':  'lcyt-slideOutLeft',
+  'lcyt-slideInRight': 'lcyt-slideOutRight',
+  'lcyt-zoomIn':       'lcyt-zoomOut',
+};
+
+const DEFAULT_EXIT_PRESET = 'lcyt-fadeOut';
+
+/**
+ * Given a CSS animation shorthand string used for an element's entry, derive the matching
+ * exit animation shorthand (same timing/easing/iterations/direction/fill, mirrored preset).
+ *
+ * @param {string} animation  e.g. "lcyt-slideInLeft 0.6s ease-out 0s 1 normal forwards"
+ * @returns {string} the exit animation shorthand, or '' if no entry animation was given
+ *   (callers should skip the exit animation and remove the element immediately).
+ */
+export function deriveExitAnimation(animation) {
+  if (!animation || !animation.trim()) return '';
+  const parts = animation.trim().split(/\s+/);
+  const exitPreset = EXIT_PRESET_MAP[parts[0]] || DEFAULT_EXIT_PRESET;
+  return [exitPreset, ...parts.slice(1)].join(' ');
+}
+
+/**
+ * Total time (ms) an animation shorthand needs to finish — duration + delay — i.e. how long
+ * to keep an exiting element mounted before it's safe to remove it from the DOM.
+ * Falls back to 300ms when the shorthand is missing or unparseable.
+ *
+ * @param {string} animation
+ * @returns {number} milliseconds
+ */
+export function getAnimationTotalMs(animation) {
+  if (!animation || !animation.trim()) return 300;
+  const parts = animation.trim().split(/\s+/);
+  const duration = parseFloat(parts[1]);
+  const delay = parseFloat(parts[3]);
+  const durationMs = Number.isFinite(duration) ? duration * 1000 : 300;
+  const delayMs = Number.isFinite(delay) ? delay * 1000 : 0;
+  return Math.round(durationMs + delayMs);
+}

--- a/packages/lcyt-web/test/components/DskPage.test.jsx
+++ b/packages/lcyt-web/test/components/DskPage.test.jsx
@@ -1,0 +1,124 @@
+/**
+ * Tests for DskPage exit-animation behaviour.
+ *
+ * EventSource is stubbed globally in test/setup.vitest.js, but that stub doesn't let
+ * tests dispatch events. We install a local fake EventSource here that records its
+ * listeners so the test can fire 'graphics' events the way the real SSE stream would.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act, waitFor } from '@testing-library/react';
+import { DskPage } from '../../src/components/DskPage.jsx';
+
+const IMAGE = {
+  id: 1,
+  shorthand: 'logo',
+  mimeType: 'image/png',
+  settingsJson: {
+    viewports: {
+      landscape: { animation: 'lcyt-fadeIn 0.2s ease 0s 1 normal forwards' },
+    },
+  },
+};
+
+let esInstances;
+
+class FakeEventSource {
+  constructor(url) {
+    this.url = url;
+    this.listeners = {};
+    this.close = vi.fn();
+    esInstances.push(this);
+  }
+  addEventListener(type, handler) {
+    (this.listeners[type] ||= []).push(handler);
+  }
+  removeEventListener() {}
+  emit(type, data) {
+    for (const handler of this.listeners[type] || []) {
+      handler({ data: JSON.stringify(data) });
+    }
+  }
+}
+
+beforeEach(() => {
+  esInstances = [];
+  global.EventSource = FakeEventSource;
+  global.fetch = vi.fn((url) => {
+    if (String(url).includes('/images')) {
+      return Promise.resolve({ ok: true, json: async () => ({ images: [IMAGE] }) });
+    }
+    return Promise.resolve({ ok: true, json: async () => ({}) });
+  });
+  window.history.pushState({}, '', '/dsk/testkey?viewport=landscape');
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+function activeImg(container) {
+  return container.querySelector('img[aria-hidden="true"]');
+}
+
+describe('DskPage — exit animation', () => {
+  it('keeps an exiting image mounted with the derived exit animation, then removes it', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const { container } = render(<DskPage />);
+
+    await waitFor(() => expect(esInstances.length).toBe(1));
+    const es = esInstances[0];
+
+    act(() => {
+      es.emit('graphics', { default: ['logo'], viewports: {}, ts: Date.now() });
+    });
+
+    await waitFor(() => expect(activeImg(container)).not.toBeNull());
+    expect(activeImg(container).style.animation).toContain('lcyt-fadeIn');
+
+    act(() => {
+      es.emit('graphics', { default: [], viewports: {}, ts: Date.now() });
+    });
+
+    // Still mounted right after removal, now playing the derived exit animation.
+    await waitFor(() => {
+      const img = activeImg(container);
+      expect(img).not.toBeNull();
+      expect(img.style.animation).toContain('lcyt-fadeOut');
+    });
+
+    // Once the animation's total duration has elapsed, the element is removed.
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+    await waitFor(() => expect(activeImg(container)).toBeNull());
+  });
+
+  it('removes an image instantly when it has no configured animation', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    global.fetch = vi.fn((url) => {
+      if (String(url).includes('/images')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ images: [{ id: 2, shorthand: 'plain', mimeType: 'image/png', settingsJson: { viewports: { landscape: {} } } }] }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
+
+    const { container } = render(<DskPage />);
+    await waitFor(() => expect(esInstances.length).toBe(1));
+    const es = esInstances[0];
+
+    act(() => {
+      es.emit('graphics', { default: ['plain'], viewports: {}, ts: Date.now() });
+    });
+    await waitFor(() => expect(activeImg(container)).not.toBeNull());
+
+    act(() => {
+      es.emit('graphics', { default: [], viewports: {}, ts: Date.now() });
+    });
+    await waitFor(() => expect(activeImg(container)).toBeNull());
+  });
+});

--- a/packages/lcyt-web/test/dskExitAnimation.test.js
+++ b/packages/lcyt-web/test/dskExitAnimation.test.js
@@ -1,0 +1,109 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { deriveExitAnimation, getAnimationTotalMs } from '../src/lib/dskExitAnimation.js';
+
+// ── deriveExitAnimation ─────────────────────────────────────────────────────
+
+describe('deriveExitAnimation', () => {
+  it('returns empty string for empty/missing input', () => {
+    assert.equal(deriveExitAnimation(''), '');
+    assert.equal(deriveExitAnimation('   '), '');
+    assert.equal(deriveExitAnimation(undefined), '');
+    assert.equal(deriveExitAnimation(null), '');
+  });
+
+  it('maps lcyt-fadeIn to lcyt-fadeOut, preserving the rest of the shorthand', () => {
+    assert.equal(
+      deriveExitAnimation('lcyt-fadeIn 0.5s ease-out 0s 1 normal forwards'),
+      'lcyt-fadeOut 0.5s ease-out 0s 1 normal forwards'
+    );
+  });
+
+  it('maps lcyt-slideInLeft to lcyt-slideOutLeft', () => {
+    assert.equal(
+      deriveExitAnimation('lcyt-slideInLeft 0.6s ease-out 0s 1 normal forwards'),
+      'lcyt-slideOutLeft 0.6s ease-out 0s 1 normal forwards'
+    );
+  });
+
+  it('maps lcyt-slideInRight to lcyt-slideOutRight', () => {
+    assert.equal(
+      deriveExitAnimation('lcyt-slideInRight 1s linear'),
+      'lcyt-slideOutRight 1s linear'
+    );
+  });
+
+  it('maps lcyt-zoomIn to lcyt-zoomOut', () => {
+    assert.equal(deriveExitAnimation('lcyt-zoomIn 0.3s'), 'lcyt-zoomOut 0.3s');
+  });
+
+  it('falls back to lcyt-fadeOut for presets with no natural reverse', () => {
+    assert.equal(deriveExitAnimation('lcyt-pulse 1s infinite'), 'lcyt-fadeOut 1s infinite');
+    assert.equal(deriveExitAnimation('lcyt-blink 0.5s'), 'lcyt-fadeOut 0.5s');
+    assert.equal(deriveExitAnimation('lcyt-typewriter 2s'), 'lcyt-fadeOut 2s');
+  });
+
+  it('falls back to lcyt-fadeOut for slideInUp/Down (no slideOutUp/Down keyframes)', () => {
+    assert.equal(deriveExitAnimation('lcyt-slideInUp 0.5s'), 'lcyt-fadeOut 0.5s');
+    assert.equal(deriveExitAnimation('lcyt-slideInDown 0.5s'), 'lcyt-fadeOut 0.5s');
+  });
+
+  it('falls back to lcyt-fadeOut for *Out presets used as entry (already an exit preset)', () => {
+    assert.equal(deriveExitAnimation('lcyt-fadeOut 0.5s'), 'lcyt-fadeOut 0.5s');
+    assert.equal(deriveExitAnimation('lcyt-slideOutLeft 0.5s'), 'lcyt-fadeOut 0.5s');
+  });
+
+  it('falls back to lcyt-fadeOut for unknown preset names', () => {
+    assert.equal(deriveExitAnimation('custom-anim 1s'), 'lcyt-fadeOut 1s');
+  });
+
+  it('handles a bare preset name with no other shorthand parts', () => {
+    assert.equal(deriveExitAnimation('lcyt-fadeIn'), 'lcyt-fadeOut');
+  });
+
+  it('collapses internal whitespace when rejoining parts', () => {
+    assert.equal(
+      deriveExitAnimation('  lcyt-fadeIn   0.5s   ease  '),
+      'lcyt-fadeOut 0.5s ease'
+    );
+  });
+});
+
+// ── getAnimationTotalMs ──────────────────────────────────────────────────────
+
+describe('getAnimationTotalMs', () => {
+  it('returns 300ms default for empty/missing input', () => {
+    assert.equal(getAnimationTotalMs(''), 300);
+    assert.equal(getAnimationTotalMs('   '), 300);
+    assert.equal(getAnimationTotalMs(undefined), 300);
+    assert.equal(getAnimationTotalMs(null), 300);
+  });
+
+  it('parses duration in seconds to milliseconds', () => {
+    assert.equal(getAnimationTotalMs('lcyt-fadeIn 0.5s'), 500);
+    assert.equal(getAnimationTotalMs('lcyt-fadeIn 2s'), 2000);
+  });
+
+  it('adds delay to duration', () => {
+    assert.equal(getAnimationTotalMs('lcyt-fadeIn 0.5s ease-out 0.25s'), 750);
+  });
+
+  it('falls back to 300ms duration when duration is unparseable', () => {
+    assert.equal(getAnimationTotalMs('lcyt-fadeIn xs'), 300);
+  });
+
+  it('treats missing delay as 0', () => {
+    assert.equal(getAnimationTotalMs('lcyt-fadeIn 1s ease-out'), 1000);
+  });
+
+  it('rounds fractional totals', () => {
+    assert.equal(getAnimationTotalMs('lcyt-fadeIn 0.333s ease-out 0.111s'), 444);
+  });
+
+  it('handles the full canonical shorthand', () => {
+    assert.equal(
+      getAnimationTotalMs('lcyt-slideInLeft 0.6s ease-out 0.2s 1 normal forwards'),
+      800
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Closes the last open DSK gap: images on the public `/dsk/:key` overlay page now play a derived **exit animation** (reversing the configured entry preset, falling back to `lcyt-fadeOut`) and stay mounted until it completes, instead of vanishing instantly when a `<!-- graphics:... -->` metacode drops them.
- Replaces the raw CSS text input for image animations in the per-viewport settings table with the existing `AnimationEditor` preset picker, so operators no longer have to hand-type CSS shorthand.
- Fixes a latent bug where the LCYT `@keyframes` block was only injected into the page when a template was active, silently breaking image-only animations.
- Updates `docs/plans/plan_dsk.md`, `docs/FEATURES.md`, and `docs/PROJECT_STATUS.md` to reflect Phase 5 as complete, with explicit scope notes on what remains out of scope (the ffmpeg-filter RTMP overlay compositing path and Playwright template-to-template cross-fades — neither has a DOM/CSS engine to animate against).

## New files

- `packages/lcyt-web/src/lib/dskExitAnimation.js` — `deriveExitAnimation()` + `getAnimationTotalMs()` pure helpers
- `packages/lcyt-web/test/dskExitAnimation.test.js` — 18 `node:test` unit tests
- `packages/lcyt-web/test/components/DskPage.test.jsx` — Vitest component tests for the exit-animation lifecycle

## Test plan

- [x] `npm test -w packages/lcyt-web` — 312/312 passed
- [x] `npm run test:components -w packages/lcyt-web` — 285/285 passed

https://claude.ai/code/session_01Lm3PSeJQ88G45CABaYLHDD


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lm3PSeJQ88G45CABaYLHDD)_