### PR TITLE
Implement lcyt-music Phase 4: history, auto-calibration, external classifier

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,3 +94,18 @@ SESSION_TTL=7200000
 CLEANUP_INTERVAL=300000
 REVOKED_KEY_TTL_DAYS=30
 REVOKED_KEY_CLEANUP_INTERVAL=86400000
+
+# ── Music detection (lcyt-music) ───────────────────────────────────────────────
+# Set to 1 to mount the /music routes and allow server-side analysis to start
+MUSIC_DETECTION_ACTIVE=0
+# Optional external/ML classifier endpoint. When set, MusicManager POSTs raw
+# PCM (as a WAV body) here and uses the returned { label, confidence } in
+# place of the built-in spectral heuristic, falling back to the heuristic on
+# error or timeout. Leave empty to always use the built-in heuristic.
+MUSIC_CLASSIFIER_URL=
+# Local nginx-rtmp base URL + app name used by the RTMP audio source
+# (audioSource: 'rtmp') for both MusicManager and SttManager.
+# Shared with the RTMP relay; MEDIAMTX_HLS_BASE_URL above covers the default
+# 'hls' audio source for MusicManager instead.
+HLS_LOCAL_RTMP=rtmp://127.0.0.1:1935
+HLS_RTMP_APP=live

--- a/packages/lcyt-web/src/components/CaptionsModal.jsx
+++ b/packages/lcyt-web/src/components/CaptionsModal.jsx
@@ -18,6 +18,7 @@ import {
 import { applyTextSize } from '../lib/settings';
 import { VadPanel } from './panels/VadPanel.jsx';
 import { MusicPanel } from './panels/MusicPanel.jsx';
+import { MusicHistoryPanel } from './panels/MusicHistoryPanel.jsx';
 import { useAudioContext } from '../contexts/AudioContext';
 
 export function CaptionsModal({ isOpen, onClose }) {
@@ -547,6 +548,7 @@ export function CaptionsModal({ isOpen, onClose }) {
                 available={music.available}
                 running={music.running}
               />
+              <MusicHistoryPanel />
             </div>
           )}
 

--- a/packages/lcyt-web/src/components/panels/MusicHistoryPanel.jsx
+++ b/packages/lcyt-web/src/components/panels/MusicHistoryPanel.jsx
@@ -1,0 +1,98 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useLang } from '../../contexts/LangContext.jsx';
+import { useSessionApiContext } from '../../contexts/SessionApiContext.jsx';
+
+const PAGE_SIZE = 20;
+
+/**
+ * MusicHistoryPanel — paginated timeline of server-side music detection events.
+ *
+ * Self-fetches via SessionApiContext.getMusicEventsHistory(); unlike MusicPanel
+ * (purely presentational, client-side detector state), this panel owns its own
+ * data fetching since it surfaces server-side session history, a distinct concern.
+ */
+export function MusicHistoryPanel() {
+  const { t } = useLang();
+  const { getMusicEventsHistory } = useSessionApiContext();
+
+  const [events, setEvents] = useState([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
+
+  const loadPage = useCallback(async (offset) => {
+    setLoading(true);
+    setError(false);
+    try {
+      const res = await getMusicEventsHistory({ limit: PAGE_SIZE, offset });
+      setEvents(prev => (offset === 0 ? res.events : [...prev, ...res.events]));
+      setTotal(res.total);
+    } catch {
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [getMusicEventsHistory]);
+
+  useEffect(() => {
+    loadPage(0);
+  }, [loadPage]);
+
+  function formatEventTime(ts) {
+    try {
+      return new Date(ts * 1000).toLocaleTimeString([], {
+        hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false,
+      });
+    } catch {
+      return '—';
+    }
+  }
+
+  function eventLabel(event) {
+    if (event.event_type === 'bpm_update') {
+      return `${t('settings.music.historyBpmUpdate')}: ${Math.round(event.bpm)} ${t('settings.music.bpmSuffix')}`;
+    }
+    return `${t('settings.music.historyLabelChange')}: ${event.label ?? '—'}`;
+  }
+
+  const hasMore = events.length < total;
+
+  return (
+    <div className="settings-field">
+      <label className="settings-field__label">{t('settings.music.historyTitle')}</label>
+
+      {events.length === 0 && !loading && !error && (
+        <span className="settings-field__hint">{t('settings.music.historyEmpty')}</span>
+      )}
+
+      {error && (
+        <span className="settings-field__hint">{t('settings.music.historyError')}</span>
+      )}
+
+      {events.length > 0 && (
+        <ul className="music-history-list">
+          {events.map(event => (
+            <li key={event.id} className="music-history-list__item">
+              <span className="music-history-list__time">{formatEventTime(event.ts)}</span>
+              <span className="music-history-list__label">{eventLabel(event)}</span>
+              {event.confidence != null && (
+                <span className="music-history-list__confidence">{Math.round(event.confidence * 100)}%</span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {hasMore && (
+        <button
+          type="button"
+          className="btn btn--secondary"
+          disabled={loading}
+          onClick={() => loadPage(events.length)}
+        >
+          {loading ? t('settings.music.historyLoading') : t('settings.music.historyLoadMore')}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/packages/lcyt-web/src/contexts/AppProviders.jsx
+++ b/packages/lcyt-web/src/contexts/AppProviders.jsx
@@ -210,6 +210,7 @@ export function AppProviders({ children, initConfig, autoConnect, embed }) {
     getRelayHistory:  session.getRelayHistory,
     setRelayActive:   session.setRelayActive,
     getYouTubeConfig: session.getYouTubeConfig,
+    getMusicEventsHistory: session.getMusicEventsHistory,
   }), []); // eslint-disable-line react-hooks/exhaustive-deps -- all methods are stable
 
   return (

--- a/packages/lcyt-web/src/contexts/SessionApiContext.jsx
+++ b/packages/lcyt-web/src/contexts/SessionApiContext.jsx
@@ -15,7 +15,7 @@ import { createContext, useContext } from 'react';
  *        listIcons, uploadIcon, deleteIcon,
  *        configureRelay, updateRelay, stopRelaySlot, stopRelay,
  *        getRelayStatus, getRelayHistory, setRelayActive,
- *        getYouTubeConfig
+ *        getYouTubeConfig, getMusicEventsHistory
  */
 export const SessionApiContext = createContext(null);
 

--- a/packages/lcyt-web/src/hooks/useMusicDetector.js
+++ b/packages/lcyt-web/src/hooks/useMusicDetector.js
@@ -13,6 +13,12 @@
  * This hook NEVER requests microphone access itself; it only reads from the
  * analyserRef that AudioPanel already set up.
  *
+ * When autoCalibrate is on and no persisted threshold exists yet, the first
+ * ~5s of ticks are spent sampling RMS energy (via classifyFromFrequency's
+ * features.rms) instead of classifying; the derived silenceThreshold is then
+ * persisted to localStorage and reused on subsequent sessions, mirroring the
+ * server-side calibration phase in lcyt-music's MusicManager.
+ *
  * @param {object} opts
  * @param {React.RefObject<AnalyserNode|null>} opts.analyserRef
  * @param {boolean}  [opts.enabled=false]            master on/off switch
@@ -20,6 +26,10 @@
  * @param {number}   [opts.intervalMs=500]           analysis tick interval (ms)
  * @param {number}   [opts.confirmFrames=4]          consecutive frames to confirm a label
  * @param {number}   [opts.confidenceThreshold=0.5]  minimum confidence to accept classification
+ * @param {boolean}  [opts.autoCalibrate=true]       sample RMS for the first ~5s and derive a
+ *                                                    calibrated silenceThreshold instead of the
+ *                                                    fixed default; persisted in localStorage so
+ *                                                    calibration only runs once per device
  * @param {function} [opts.onLabelChange]            ({ label, previous, confidence, bpm })
  * @param {function} [opts.onBpmUpdate]              ({ bpm, confidence })
  * @returns {{ label: string|null, bpm: number|null, confidence: number|null, available: boolean, running: boolean }}
@@ -29,6 +39,27 @@ import { useState, useEffect, useRef } from 'react';
 import { classifyFromFrequency, detectBpmFromPcm, createBpmSmoother } from '../lib/musicAnalysis.js';
 import { useCaptionContext } from '../contexts/CaptionContext.jsx';
 import { useSessionContext } from '../contexts/SessionContext.jsx';
+import { KEYS } from '../lib/storageKeys.js';
+
+// Mirrors the server-side calibration constants in lcyt-music's music-manager.js.
+const CALIBRATION_MS = 5000;
+const CALIBRATION_MIN_THRESHOLD = 0.002;
+const CALIBRATION_MAX_THRESHOLD = 0.05;
+const CALIBRATION_FACTOR = 0.5; // midpoint between observed min/max RMS
+
+function loadPersistedThreshold() {
+  try {
+    const raw = localStorage.getItem(KEYS.audio.musicDetectThreshold);
+    const v = raw === null ? null : Number(raw);
+    return Number.isFinite(v) ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+function persistThreshold(value) {
+  try { localStorage.setItem(KEYS.audio.musicDetectThreshold, String(value)); } catch {}
+}
 
 export function useMusicDetector({
   analyserRef,
@@ -37,6 +68,7 @@ export function useMusicDetector({
   intervalMs      = 500,
   confirmFrames   = 4,
   confidenceThreshold = 0.5,
+  autoCalibrate   = true,
   onLabelChange,
   onBpmUpdate,
 } = {}) {
@@ -55,6 +87,12 @@ export function useMusicDetector({
   const lastBpmRef        = useRef(null);
   const smootherRef       = useRef(createBpmSmoother(0.3));
 
+  // Calibration state
+  const calibratingRef         = useRef(false);
+  const calibrationSamplesRef  = useRef([]);
+  const calibrationTicksRef    = useRef(0);
+  const calibratedThresholdRef = useRef(null);
+
   useEffect(() => {
     if (!enabled) {
       setRunning(false);
@@ -62,6 +100,24 @@ export function useMusicDetector({
     }
 
     setRunning(true);
+
+    if (autoCalibrate) {
+      const persisted = loadPersistedThreshold();
+      if (persisted != null) {
+        calibratedThresholdRef.current = persisted;
+        calibratingRef.current = false;
+      } else {
+        calibratedThresholdRef.current = null;
+        calibratingRef.current = true;
+        calibrationSamplesRef.current = [];
+        calibrationTicksRef.current = 0;
+      }
+    } else {
+      calibratedThresholdRef.current = null;
+      calibratingRef.current = false;
+    }
+
+    const calibrationTicks = Math.max(1, Math.ceil(CALIBRATION_MS / intervalMs));
 
     const id = setInterval(() => {
       const analyser = analyserRef?.current;
@@ -73,8 +129,31 @@ export function useMusicDetector({
 
       const sampleRate = analyser.context?.sampleRate ?? 44100;
 
+      // ── Calibration phase: sample RMS, skip classification ─────────────
+      if (calibratingRef.current) {
+        const { features } = classifyFromFrequency(freqData, sampleRate);
+        calibrationSamplesRef.current.push(features.rms);
+        calibrationTicksRef.current += 1;
+
+        if (calibrationTicksRef.current >= calibrationTicks) {
+          const sorted = [...calibrationSamplesRef.current].sort((a, b) => a - b);
+          const min = sorted[0];
+          const max = sorted[sorted.length - 1];
+          const raw = min + (max - min) * CALIBRATION_FACTOR;
+          const threshold = Math.max(CALIBRATION_MIN_THRESHOLD, Math.min(CALIBRATION_MAX_THRESHOLD, raw));
+
+          calibratedThresholdRef.current = threshold;
+          calibratingRef.current = false;
+          persistThreshold(threshold);
+        }
+        return;
+      }
+
       // ── Classify ──────────────────────────────────────────────────────
-      const result = classifyFromFrequency(freqData, sampleRate);
+      const classifyOpts = calibratedThresholdRef.current != null
+        ? { silenceThreshold: calibratedThresholdRef.current }
+        : {};
+      const result = classifyFromFrequency(freqData, sampleRate, classifyOpts);
       if (result.confidence < confidenceThreshold && result.label !== 'silence') {
         // Low-confidence non-silence: skip this frame to avoid noise
         return;
@@ -137,7 +216,7 @@ export function useMusicDetector({
       setRunning(false);
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [enabled, bpmEnabled, intervalMs, confirmFrames, confidenceThreshold]);
+  }, [enabled, bpmEnabled, intervalMs, confirmFrames, confidenceThreshold, autoCalibrate]);
 
   const available = !!(analyserRef?.current);
 

--- a/packages/lcyt-web/src/hooks/useSession.js
+++ b/packages/lcyt-web/src/hooks/useSession.js
@@ -714,6 +714,15 @@ export function useSession({
     return api.post('/stt/stop', {});
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
+  const getMusicEventsHistory = useCallback(async function getMusicEventsHistory({ limit, offset, eventType } = {}) {
+    const params = new URLSearchParams();
+    if (limit != null) params.set('limit', limit);
+    if (offset != null) params.set('offset', offset);
+    if (eventType) params.set('eventType', eventType);
+    const qs = params.toString();
+    return api.get(`/music/events/history${qs ? `?${qs}` : ''}`);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
   return {
     connected, sequence, syncOffset, backendUrl, apiKey, streamKey, startedAt,
     micHolder, clientId: CLIENT_ID, graphicsEnabled,
@@ -731,6 +740,7 @@ export function useSession({
     configureRelay, updateRelay, stopRelaySlot, stopRelay, getRelayStatus, getRelayHistory, setRelayActive,
     getYouTubeConfig,
     getSttStatus, getSttConfig, updateSttConfig, startStt, stopStt,
+    getMusicEventsHistory,
     getPersistedConfig, getAutoConnect, setAutoConnect, clearPersistedConfig,
     getQueuedCount,
     /** Returns the active session JWT (for EventSource ?token= param) */

--- a/packages/lcyt-web/src/locales/en.js
+++ b/packages/lcyt-web/src/locales/en.js
@@ -150,6 +150,13 @@ export default {
       bpmSuffix: 'BPM',
       notAvailable: 'Start microphone to enable detection',
       statusTitle: 'Music detection status',
+      historyTitle: 'Detection history',
+      historyEmpty: 'No detection events yet.',
+      historyLoadMore: 'Load more',
+      historyLoading: 'Loading…',
+      historyError: 'Failed to load detection history.',
+      historyLabelChange: 'Label change',
+      historyBpmUpdate: 'BPM update',
     },
     translation: {
       enable: 'Enable translation',

--- a/packages/lcyt-web/src/styles/components.css
+++ b/packages/lcyt-web/src/styles/components.css
@@ -1092,6 +1092,42 @@
   accent-color: var(--color-accent);
 }
 
+/* ─── Music detection history ───────────────────────────────── */
+
+.music-history-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+.music-history-list__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  padding: 4px 6px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.music-history-list__time {
+  color: var(--color-text-dim);
+  font-variant-numeric: tabular-nums;
+}
+
+.music-history-list__label {
+  flex: 1;
+  color: var(--color-text);
+}
+
+.music-history-list__confidence {
+  color: var(--color-text-dim);
+}
+
 /* ─── Toast notifications ───────────────────────────────── */
 
 #toast-container {

--- a/packages/lcyt-web/test/components/MusicHistoryPanel.test.jsx
+++ b/packages/lcyt-web/test/components/MusicHistoryPanel.test.jsx
@@ -1,0 +1,126 @@
+/**
+ * Tests for MusicHistoryPanel component.
+ *
+ * Vitest + jsdom environment. SessionApiContext is mocked directly (no real
+ * network traffic occurs).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { LangProvider } from '../../src/contexts/LangContext.jsx';
+import { SessionApiContext } from '../../src/contexts/SessionApiContext.jsx';
+import { MusicHistoryPanel } from '../../src/components/panels/MusicHistoryPanel.jsx';
+
+function renderPanel(getMusicEventsHistory) {
+  return render(
+    <SessionApiContext.Provider value={{ getMusicEventsHistory }}>
+      <LangProvider>
+        <MusicHistoryPanel />
+      </LangProvider>
+    </SessionApiContext.Provider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('MusicHistoryPanel — initial load', () => {
+  it('shows the empty state when there are no events', async () => {
+    const getMusicEventsHistory = vi.fn().mockResolvedValue({ events: [], total: 0, limit: 20, offset: 0 });
+    renderPanel(getMusicEventsHistory);
+
+    await waitFor(() => {
+      expect(screen.getByText('No detection events yet.')).toBeInTheDocument();
+    });
+    expect(getMusicEventsHistory).toHaveBeenCalledWith({ limit: 20, offset: 0 });
+  });
+
+  it('renders fetched events', async () => {
+    const getMusicEventsHistory = vi.fn().mockResolvedValue({
+      events: [
+        { id: 2, event_type: 'label_change', label: 'music', bpm: null, confidence: 0.9, ts: 1700000100 },
+        { id: 1, event_type: 'bpm_update', label: null, bpm: 128, confidence: 0.8, ts: 1700000000 },
+      ],
+      total: 2,
+      limit: 20,
+      offset: 0,
+    });
+    renderPanel(getMusicEventsHistory);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Label change: music/)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/BPM update: 128 BPM/)).toBeInTheDocument();
+  });
+
+  it('shows the error state when the fetch fails', async () => {
+    const getMusicEventsHistory = vi.fn().mockRejectedValue(new Error('network error'));
+    renderPanel(getMusicEventsHistory);
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load detection history.')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('MusicHistoryPanel — pagination', () => {
+  it('shows a "Load more" button only when more events remain', async () => {
+    const getMusicEventsHistory = vi.fn().mockResolvedValue({
+      events: [{ id: 1, event_type: 'label_change', label: 'speech', bpm: null, confidence: 0.7, ts: 1700000000 }],
+      total: 5,
+      limit: 20,
+      offset: 0,
+    });
+    renderPanel(getMusicEventsHistory);
+
+    await waitFor(() => {
+      expect(screen.getByText('Load more')).toBeInTheDocument();
+    });
+  });
+
+  it('does not show "Load more" once all events are loaded', async () => {
+    const getMusicEventsHistory = vi.fn().mockResolvedValue({
+      events: [{ id: 1, event_type: 'label_change', label: 'speech', bpm: null, confidence: 0.7, ts: 1700000000 }],
+      total: 1,
+      limit: 20,
+      offset: 0,
+    });
+    renderPanel(getMusicEventsHistory);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Label change: speech/)).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Load more')).not.toBeInTheDocument();
+  });
+
+  it('appends the next page and requests the correct offset on "Load more" click', async () => {
+    const getMusicEventsHistory = vi.fn()
+      .mockResolvedValueOnce({
+        events: [{ id: 1, event_type: 'label_change', label: 'speech', bpm: null, confidence: 0.7, ts: 1700000000 }],
+        total: 2,
+        limit: 20,
+        offset: 0,
+      })
+      .mockResolvedValueOnce({
+        events: [{ id: 2, event_type: 'label_change', label: 'music', bpm: null, confidence: 0.9, ts: 1700000100 }],
+        total: 2,
+        limit: 20,
+        offset: 1,
+      });
+    renderPanel(getMusicEventsHistory);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Label change: speech/)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Load more'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Label change: music/)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Label change: speech/)).toBeInTheDocument();
+    expect(getMusicEventsHistory).toHaveBeenLastCalledWith({ limit: 20, offset: 1 });
+    expect(screen.queryByText('Load more')).not.toBeInTheDocument();
+  });
+});

--- a/packages/lcyt-web/test/components/useMusicDetector.test.jsx
+++ b/packages/lcyt-web/test/components/useMusicDetector.test.jsx
@@ -62,6 +62,7 @@ function makeSpeechFreqData(binCount = 1024) {
 beforeEach(() => {
   vi.useFakeTimers();
   vi.clearAllMocks();
+  localStorage.clear();
 });
 
 afterEach(() => {
@@ -119,6 +120,7 @@ describe('useMusicDetector — silence detection', () => {
         intervalMs: 100,
         confirmFrames: 2,
         confidenceThreshold: 0.1,
+        autoCalibrate: false,
       }),
     );
 
@@ -142,6 +144,7 @@ describe('useMusicDetector — music detection', () => {
         intervalMs: 100,
         confirmFrames: 3,
         confidenceThreshold: 0,
+        autoCalibrate: false,
       }),
     );
 
@@ -164,6 +167,7 @@ describe('useMusicDetector — metacode emission', () => {
         intervalMs: 100,
         confirmFrames: 2,
         confidenceThreshold: 0,
+        autoCalibrate: false,
       }),
     );
 
@@ -202,6 +206,7 @@ describe('useMusicDetector — metacode emission', () => {
         intervalMs: 100,
         confirmFrames: 2,
         confidenceThreshold: 0,
+        autoCalibrate: false,
       }),
     );
 
@@ -223,7 +228,7 @@ describe('useMusicDetector — disable / cleanup', () => {
     const analyserRef = { current: analyser };
 
     const { result, rerender } = renderHook(
-      ({ enabled }) => useMusicDetector({ analyserRef, enabled, intervalMs: 100, confirmFrames: 2 }),
+      ({ enabled }) => useMusicDetector({ analyserRef, enabled, intervalMs: 100, confirmFrames: 2, autoCalibrate: false }),
       { initialProps: { enabled: true } },
     );
 
@@ -231,5 +236,120 @@ describe('useMusicDetector — disable / cleanup', () => {
 
     rerender({ enabled: false });
     expect(result.current.running).toBe(false);
+  });
+});
+
+describe('useMusicDetector — auto-calibration', () => {
+  const STORAGE_KEY = 'lcyt.audio.musicDetectThreshold';
+  const CALIBRATION_TICKS = 50; // Math.ceil(5000ms / 100ms intervalMs)
+
+  it('skips classification while calibrating (no label, no metacode sent)', async () => {
+    const spyClassify = vi.spyOn(musicAnalysis, 'classifyFromFrequency').mockImplementation(() => ({
+      label: 'music', confidence: 1, features: { rms: 0.01 },
+    }));
+    const analyser = makeAnalyser({ freqData: makeMusicFreqData() });
+    const analyserRef = { current: analyser };
+
+    const { result } = renderHook(() =>
+      useMusicDetector({
+        analyserRef,
+        enabled: true,
+        intervalMs: 100,
+        confirmFrames: 2,
+        confidenceThreshold: 0,
+        autoCalibrate: true,
+      }),
+    );
+
+    // Advance well short of the calibration window.
+    await act(async () => { vi.advanceTimersByTime(100 * (CALIBRATION_TICKS - 5)); });
+
+    expect(result.current.label).toBeNull();
+    expect(mockSend).not.toHaveBeenCalled();
+    spyClassify.mockRestore();
+  });
+
+  it('derives and persists a calibrated threshold once the calibration window elapses', async () => {
+    const rmsValues = [0.001, 0.004, 0.002, 0.006, 0.003];
+    let i = 0;
+    const spyClassify = vi.spyOn(musicAnalysis, 'classifyFromFrequency').mockImplementation(() => ({
+      label: 'silence', confidence: 1, features: { rms: rmsValues[i++ % rmsValues.length] },
+    }));
+    const analyser = makeAnalyser();
+    const analyserRef = { current: analyser };
+
+    renderHook(() =>
+      useMusicDetector({
+        analyserRef,
+        enabled: true,
+        intervalMs: 100,
+        confirmFrames: 2,
+        confidenceThreshold: 0,
+        autoCalibrate: true,
+      }),
+    );
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+
+    await act(async () => { vi.advanceTimersByTime(100 * CALIBRATION_TICKS); });
+
+    const persisted = localStorage.getItem(STORAGE_KEY);
+    expect(persisted).not.toBeNull();
+    const threshold = Number(persisted);
+    expect(threshold).toBeGreaterThanOrEqual(0.002);
+    expect(threshold).toBeLessThanOrEqual(0.05);
+    spyClassify.mockRestore();
+  });
+
+  it('skips calibration and classifies immediately when a threshold is already persisted', async () => {
+    localStorage.setItem(STORAGE_KEY, '0.01');
+    const spyClassify = vi.spyOn(musicAnalysis, 'classifyFromFrequency').mockImplementation((freqData, sampleRate, opts) => {
+      expect(opts).toEqual({ silenceThreshold: 0.01 });
+      return { label: 'music', confidence: 1, features: { rms: 0.05 } };
+    });
+    const analyser = makeAnalyser({ freqData: makeMusicFreqData() });
+    const analyserRef = { current: analyser };
+
+    const { result } = renderHook(() =>
+      useMusicDetector({
+        analyserRef,
+        enabled: true,
+        intervalMs: 100,
+        confirmFrames: 2,
+        confidenceThreshold: 0,
+        autoCalibrate: true,
+      }),
+    );
+
+    // Only a few ticks needed — no calibration phase to wait through.
+    await act(async () => { vi.advanceTimersByTime(100 * 3); });
+
+    expect(result.current.label).toBe('music');
+    spyClassify.mockRestore();
+  });
+
+  it('classifies immediately with the default threshold when autoCalibrate is false, even without a persisted value', async () => {
+    const spyClassify = vi.spyOn(musicAnalysis, 'classifyFromFrequency').mockImplementation((freqData, sampleRate, opts) => {
+      expect(opts).toEqual({});
+      return { label: 'music', confidence: 1, features: { rms: 0.05 } };
+    });
+    const analyser = makeAnalyser({ freqData: makeMusicFreqData() });
+    const analyserRef = { current: analyser };
+
+    const { result } = renderHook(() =>
+      useMusicDetector({
+        analyserRef,
+        enabled: true,
+        intervalMs: 100,
+        confirmFrames: 2,
+        confidenceThreshold: 0,
+        autoCalibrate: false,
+      }),
+    );
+
+    await act(async () => { vi.advanceTimersByTime(100 * 3); });
+
+    expect(result.current.label).toBe('music');
+    spyClassify.mockRestore();
   });
 });

--- a/packages/plugins/lcyt-music/README.md
+++ b/packages/plugins/lcyt-music/README.md
@@ -4,7 +4,7 @@ Metacode-based audio classification signaling for LCYT. Detects when music is pl
 
 **Version:** 0.1.0
 **License:** MIT
-**Status:** Phase 1 (client-side browser-mic detection) and Phase 2 (server-side HLS audio analysis) are both implemented.
+**Status:** Phases 1-4 are all implemented — client-side browser-mic detection, server-side HLS/RTMP audio analysis, paginated event history, auto-calibration (client + server), and an optional external/ML classifier hook.
 
 ## Overview
 
@@ -12,10 +12,12 @@ lcyt-music provides:
 - **Client-side audio classification** — Classify browser microphone audio into `music / speech / silence` (Web Audio API, `useMusicDetector` hook in lcyt-web)
 - **Client-side BPM estimation** — Real-time beats-per-minute estimate when music is detected
 - **Server-side audio classification** — `MusicManager` polls a stream's own MediaMTX fMP4 HLS segments, decodes them via ffmpeg, and runs the same spectral classifier + BPM estimator without any browser involved
+- **Auto-calibration** — both the client detector and `MusicManager` can sample a few seconds of room/stream noise at startup and derive a calibrated silence threshold instead of relying on a fixed default
+- **Optional external/ML classifier** — `MusicManager` can delegate classification to an external HTTP endpoint (`MUSIC_CLASSIFIER_URL`) instead of the built-in spectral heuristic, falling back to the heuristic on error/timeout
 - **Metacode pipeline** — `<!-- sound:music -->`, `<!-- bpm:128 -->` markers, stripped server-side before YouTube delivery
-- **SSE events** — `sound_label` and `bpm_update` events on the existing `GET /events` stream, plus a dedicated public `GET /music/:key/live` SSE stream
-- **Event log** — Every label change / BPM update is persisted to the `music_events` table
-- **Per-key config** — `GET/PUT /music/config` for tuning thresholds, BPM range, and confirm-segment smoothing
+- **SSE events** — `sound_label` and `bpm_update` events on the existing `GET /events` stream, plus a dedicated public `GET /music/:key/live` SSE stream (also emits `music_calibrated`)
+- **Event log** — Every label change / BPM update is persisted to the `music_events` table, queryable via a paginated history endpoint
+- **Per-key config** — `GET/PUT /music/config` for tuning thresholds, BPM range, confirm-segment smoothing, and auto-calibration
 
 ## Installation
 
@@ -137,21 +139,46 @@ soundProcessor(apiKey, '<!-- sound:music --> <!-- bpm:128 -->')
 
 Select it by passing `audioSource: 'rtmp'` to `POST /music/start` (default is `'hls'`). No MediaMTX or `HlsSegmentFetcher` involvement — only `HLS_LOCAL_RTMP` / `HLS_RTMP_APP` (already used by the RTMP relay) are needed.
 
+## Auto-Calibration (Phase 4)
+
+A fixed silence threshold doesn't generalise across rooms/streams with different background noise floors. When `music_config.auto_calibrate` is enabled for a key (`PUT /music/config { autoCalibrate: true }`; default `false`), both the server-side and client-side detectors run a short calibration phase instead of using the configured/default `silenceThreshold` outright:
+
+- **Server-side** (`MusicManager`): for the first ~5 seconds of audio after `POST /music/start`, RMS energy is sampled per window instead of running `classify()` — no `label_change`/`bpm_update` events are emitted during this window. Once enough audio has accumulated, a calibrated threshold is derived from the observed min/max RMS range (`min + (max - min) * 0.5`, clamped to `[0.002, 0.05]`), stored on the session, and a `calibrated` event (`{ apiKey, silenceThreshold, ts }`) is emitted — relayed as `music_calibrated` on `GET /music/:key/live` (see [SSE Events](#sse-events)). All classification from then on for that session uses the calibrated threshold instead of `config.silenceThreshold`. `GET /music/status` exposes `calibrating` and `calibratedSilenceThreshold` so clients can show a "calibrating…" state.
+- **Client-side** (`useMusicDetector`): mirrors the same idea — samples RMS for the first ~5s after the detector starts, derives a calibrated `silenceThreshold`, and persists it to the `musicDetectThreshold` localStorage key so the browser doesn't recalibrate on every page load. Gated by a separate client-only `autoCalibrate` option (default `true` — no backward-compatibility concern client-side, unlike the server default).
+
+Calibration runs once per `MusicManager.start()` / detector-start call, regardless of whether the session was started manually or (in the future) via an `on_publish` auto-start hook.
+
+## External Classifier Hook (Phase 4)
+
+By default, server-side classification uses the built-in zero-dependency spectral heuristic (`analyser/spectral-detector.js`). Setting `MUSIC_CLASSIFIER_URL` lets `MusicManager` delegate classification to an external HTTP endpoint instead — useful for swapping in a trained ML model without adding any ML library as a hard dependency of this plugin:
+
+- `MusicManager` POSTs the window's raw PCM, encoded as a WAV body (`Content-Type: audio/wav`), to `MUSIC_CLASSIFIER_URL`.
+- The endpoint must respond with JSON: `{ "label": "music"|"speech"|"silence", "confidence": number|null }`.
+- Requests time out after 3 seconds (`AbortSignal.timeout`); on error, non-2xx response, timeout, or a malformed response (missing `label`), `MusicManager` transparently falls back to the built-in heuristic for that window — there is no user-visible failure mode.
+- Leave `MUSIC_CLASSIFIER_URL` unset (the default) to always use the built-in heuristic; nothing else changes.
+
 ## API Routes
 
 Mounted at `/music` only when `MUSIC_DETECTION_ACTIVE=1` and a `MusicManager` was constructed (i.e. `initMusicControl(db, store)` was called with a session store):
 
 ```
-GET  /music/status      — current analysis state for the authenticated API key (Bearer token)
-POST /music/start       — start server-side analysis { streamKey?, audioSource? } (Bearer token)
-                            audioSource: 'hls' (default) | 'rtmp'
-POST /music/stop        — stop analysis (Bearer token)
-GET  /music/:key/live   — public SSE stream of snapshot / label_change / bpm_update / music_error / music_stopped events
-GET  /music/config      — get per-key detector config (Bearer token)
-PUT  /music/config      — update per-key detector config, partial patch (Bearer token)
+GET  /music/status          — current analysis state for the authenticated API key (Bearer token)
+POST /music/start           — start server-side analysis { streamKey?, audioSource? } (Bearer token)
+                                audioSource: 'hls' (default) | 'rtmp'
+POST /music/stop            — stop analysis (Bearer token)
+GET  /music/events/history  — paginated music_events history (Bearer token)
+                                query: limit? (default 50, clamp 1-200), offset? (default 0),
+                                       eventType? ('label_change' | 'bpm_update')
+                                response: { events, total, limit, offset }
+GET  /music/:key/live       — public SSE stream of snapshot / label_change / bpm_update /
+                                music_calibrated / music_error / music_stopped events
+GET  /music/config          — get per-key detector config (Bearer token)
+PUT  /music/config          — update per-key detector config, partial patch (Bearer token)
 ```
 
 On connect, `GET /music/:key/live` seeds the client with a `snapshot` event built from the most recent `label_change` / `bpm_update` rows in `music_events` (if any exist for the key), so a newly-opened SSE connection doesn't have to wait for the next live transition to know the current state.
+
+`GET /music/events/history` is ordered `ts DESC, id DESC` (most recent first; `id` is a composite tiebreaker since `ts` only has 1-second resolution) and is scoped to the authenticated session's `api_key`.
 
 Phase 1 (client-side / browser mic) requires no routes — it's entirely passive:
 1. The frontend detector sends a caption containing a `<!-- sound:... -->` / `<!-- bpm:... -->` metacode.
@@ -177,6 +204,15 @@ On `GET /events`, music detection emits:
 
 `ts` is a `Date.now()` millisecond epoch (Node.js convention — see the timestamp handling section of the root `CLAUDE.md`), not an ISO string. `confidence` is currently always `null`: the `<!-- sound:... -->` / `<!-- bpm:... -->` metacode format does not carry a confidence value, so nothing is available server-side to populate it with, even though `useMusicDetector` computes a confidence score locally (exposed via its own return value, not over SSE).
 
+On the dedicated `GET /music/:key/live` SSE stream only (not on `GET /events`), `MusicManager` additionally emits a `music_calibrated` event once its auto-calibration phase finishes (only when `music_config.auto_calibrate` is enabled for the key — see [Auto-Calibration](#auto-calibration) below):
+
+```json
+{
+  "type": "music_calibrated",
+  "data": { "silenceThreshold": 0.0123, "ts": 1772100000000 }
+}
+```
+
 ## Configuration
 
 | Variable | Purpose | Default |
@@ -185,6 +221,7 @@ On `GET /events`, music detection emits:
 | `MEDIAMTX_HLS_BASE_URL` | Base URL of the MediaMTX HLS server `MusicManager` polls for fMP4 audio segments (`audioSource: 'hls'`; shared with `lcyt-rtmp`'s `HlsManager`/`SttManager`) | `http://127.0.0.1:8888` |
 | `HLS_LOCAL_RTMP` | Local nginx-rtmp base URL `MusicManager` spawns ffmpeg against (`audioSource: 'rtmp'`; shared with the RTMP relay) | `rtmp://127.0.0.1:1935` |
 | `HLS_RTMP_APP` | RTMP application name for the `rtmp` audio source (shared with the RTMP relay) | `live` |
+| `MUSIC_CLASSIFIER_URL` | Optional external/ML classifier endpoint (Phase 4). When set, `MusicManager` POSTs raw PCM as a WAV body and uses the returned `{ label, confidence }`, falling back to the built-in heuristic on error/timeout | unset (always uses the built-in heuristic) |
 
 Client-side (browser-mic) detection has no environment variables — it's configured entirely client-side via `useMusicDetector` options (`enabled`, `bpmEnabled`, `intervalMs`, `confirmFrames`, `confidenceThreshold`) and persisted in `localStorage` by `useMusic` (`KEYS.audio.musicDetect`, `KEYS.audio.musicDetectBpm`).
 
@@ -212,8 +249,9 @@ CREATE INDEX music_events_key_ts ON music_events(api_key, ts);
 If a single caption carries both a `sound:` and a `bpm:` metacode, only one `label_change` row is written (with `bpm` attached) — there is no separate `bpm_update` row in that case, even though a separate `bpm_update` SSE event is still emitted.
 
 ```sql
--- Per-API-key server-side detector config (Phase 2). Row is created lazily
--- on first GET/PUT /music/config with DEFAULT_MUSIC_CONFIG values.
+-- Per-API-key server-side detector config (Phase 2; auto_calibrate added in
+-- Phase 4 via an additive migration). Row is created lazily on first
+-- GET/PUT /music/config with DEFAULT_MUSIC_CONFIG values.
 CREATE TABLE music_config (
   api_key           TEXT PRIMARY KEY,
   silence_threshold REAL    NOT NULL DEFAULT 0.01,
@@ -223,7 +261,8 @@ CREATE TABLE music_config (
   bpm_enabled       INTEGER NOT NULL DEFAULT 1,
   bpm_min           INTEGER NOT NULL DEFAULT 40,
   bpm_max           INTEGER NOT NULL DEFAULT 200,
-  auto_start        INTEGER NOT NULL DEFAULT 0
+  auto_start        INTEGER NOT NULL DEFAULT 0,
+  auto_calibrate    INTEGER NOT NULL DEFAULT 0
 );
 ```
 
@@ -290,18 +329,23 @@ npm test -w packages/plugins/lcyt-music
 - `test/bpm-detector.test.js` — `detectBpm` beat-tracking estimator
 - `test/music-manager.test.js` — `MusicManager` start/stop lifecycle, confirm-segments smoothing, BPM delta-gating, direct `soundProcessor` invocation (bypassing `_sendQueue`)
 - `test/music-manager-rtmp.test.js` — `MusicManager` RTMP audio source: ffmpeg spawn args/URL building, process lifecycle (stop/error/non-zero exit), PCM windowing/accumulation, shared classify/confirm-segments/BPM pipeline reuse
+- `test/db.test.js` (Phase 4) — `getMusicEventsPage` pagination/ordering/`eventType` filtering/`total` count, `autoCalibrate` config field round-trip, `runMigrations` idempotency (re-running migrations on an already-migrated DB is a no-op)
+- `test/music-manager-calibration.test.js` (Phase 4) — RMS accumulation during the calibration window, classification/emission suppressed while calibrating, `calibratedSilenceThreshold` derivation, `calibrated` event emission, subsequent classification using the calibrated threshold, `getStatus()` calibration fields
+- `test/external-classifier.test.js` (Phase 4) — `classifyExternal` success path (mocked `fetch`), timeout (`AbortSignal.timeout`), non-2xx response, malformed response, and `MUSIC_CLASSIFIER_URL` unset
+- `test/music-manager-classifier-queue.test.js` (Phase 4) — `MUSIC_CLASSIFIER_URL` integration: async `_analysePcm`/`_processRtmpWindow`, fallback to the built-in heuristic on classifier failure, RTMP `processingQueue` ordering guarantee when multiple windows arrive within a single `data` chunk (events fire in emission order, not promise-resolution order)
 
 ## Client-side (lcyt-web)
 
-- `packages/lcyt-web/src/hooks/useMusicDetector.js` — microphone-derived classification, BPM estimation, confirm/debounce state machine, sends the metacode caption.
+- `packages/lcyt-web/src/hooks/useMusicDetector.js` — microphone-derived classification, BPM estimation, confirm/debounce state machine, auto-calibration phase (Phase 4; persists the calibrated threshold to the `musicDetectThreshold` localStorage key), sends the metacode caption.
 - `packages/lcyt-web/src/hooks/useMusic.js` — wraps `useMusicDetector`, layers in SSE-confirmed state from the backend, and persists on/off + BPM-on/off toggles to `localStorage`.
+- `packages/lcyt-web/src/components/panels/MusicHistoryPanel.jsx` (Phase 4) — self-fetching, paginated timeline of server-side `music_events` history via `useSessionApiContext().getMusicEventsHistory()`; mounted alongside `MusicPanel` in the Music Detection settings tab (`CaptionsModal.jsx`).
 
 ## Limitations
 
 - **No song identification** — No Shazam-style fingerprinting
 - **No copyright detection** — Not for DMCA/rights management
 - **Server-side analysis requires an active RTMP/HLS stream** — `MusicManager` reads from the same MediaMTX HLS output as `HlsManager`; there must be a live stream for the API key for `POST /music/start` to do anything
-- **Accuracy depends on the spectral heuristic** — `classifyFromFrequency` is a heuristic classifier, not a trained ML model; accuracy varies by source material
+- **Accuracy depends on the spectral heuristic by default** — `classifyFromFrequency` is a heuristic classifier, not a trained ML model; accuracy varies by source material. Set `MUSIC_CLASSIFIER_URL` to delegate to an external/ML classifier instead (see [External Classifier Hook](#external-classifier-hook-phase-4))
 - **Client-side requires mic permission** — User must grant microphone access in the browser
 - **No confidence data in SSE/DB** — see [SSE Events](#sse-events) above
 

--- a/packages/plugins/lcyt-music/src/analyser/external-classifier.js
+++ b/packages/plugins/lcyt-music/src/analyser/external-classifier.js
@@ -1,0 +1,46 @@
+/**
+ * Optional external/ML classifier hook (Phase 4).
+ *
+ * When MUSIC_CLASSIFIER_URL is set, MusicManager posts raw PCM (as a WAV
+ * body) here and uses the returned { label, confidence } in place of the
+ * built-in spectral heuristic (analyser/spectral-detector.js), falling back
+ * to that heuristic on error or timeout. Disabled by default — the
+ * zero-dependency heuristic path is entirely unaffected when the env var
+ * is unset.
+ */
+
+import { buildWav } from '../wav-encoder.js';
+
+export const CLASSIFIER_TIMEOUT_MS = 3000;
+
+/**
+ * @param {Float32Array} pcm
+ * @param {object} [opts]
+ * @param {number} [opts.sampleRate=22050]
+ * @param {number} [opts.timeoutMs=CLASSIFIER_TIMEOUT_MS]
+ * @returns {Promise<{ label: 'music'|'speech'|'silence', confidence: number|null }>}
+ */
+export async function classifyExternal(pcm, { sampleRate = 22050, timeoutMs = CLASSIFIER_TIMEOUT_MS } = {}) {
+  const url = process.env.MUSIC_CLASSIFIER_URL;
+  if (!url) throw new Error('classifyExternal: MUSIC_CLASSIFIER_URL is not set');
+
+  const wav = buildWav(pcm, sampleRate);
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'audio/wav' },
+    body: wav,
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+
+  if (!res.ok) {
+    throw new Error(`classifyExternal: classifier returned ${res.status}`);
+  }
+
+  const data = await res.json();
+  if (!data || typeof data.label !== 'string') {
+    throw new Error('classifyExternal: malformed response (missing label)');
+  }
+
+  return { label: data.label, confidence: typeof data.confidence === 'number' ? data.confidence : null };
+}

--- a/packages/plugins/lcyt-music/src/api.js
+++ b/packages/plugins/lcyt-music/src/api.js
@@ -35,7 +35,7 @@ import { createMusicConfigRouter } from './routes/music-config.js';
 
 export { createSoundCaptionProcessor } from './sound-caption-processor.js';
 export {
-  runMigrations, insertMusicEvent, getRecentMusicEvents,
+  runMigrations, insertMusicEvent, getRecentMusicEvents, getMusicEventsPage,
   getMusicConfig, setMusicConfig,
 } from './db.js';
 export { MusicManager } from './music-manager.js';

--- a/packages/plugins/lcyt-music/src/db.js
+++ b/packages/plugins/lcyt-music/src/db.js
@@ -41,6 +41,13 @@ export function runMigrations(db) {
       updated_at          INTEGER NOT NULL DEFAULT (strftime('%s','now'))
     )
   `);
+
+  // Phase 4: auto-calibration opt-in. Additive column migration — default 0
+  // (off) so existing configs/sessions keep today's fixed-threshold behaviour.
+  const musicConfigCols = new Set(db.prepare("PRAGMA table_info(music_config)").all().map((c) => c.name));
+  if (!musicConfigCols.has('auto_calibrate')) {
+    db.exec('ALTER TABLE music_config ADD COLUMN auto_calibrate INTEGER NOT NULL DEFAULT 0');
+  }
 }
 
 const DEFAULT_MUSIC_CONFIG = {
@@ -52,6 +59,7 @@ const DEFAULT_MUSIC_CONFIG = {
   bpmMin: 40,
   bpmMax: 200,
   autoStart: false,
+  autoCalibrate: false,
 };
 
 /**
@@ -74,6 +82,7 @@ export function getMusicConfig(db, apiKey) {
     bpmMin: row.bpm_min,
     bpmMax: row.bpm_max,
     autoStart: !!row.auto_start,
+    autoCalibrate: !!row.auto_calibrate,
   };
 }
 
@@ -92,8 +101,8 @@ export function setMusicConfig(db, apiKey, patch = {}) {
   db.prepare(`
     INSERT INTO music_config (
       api_key, silence_threshold, flatness_threshold, zcr_threshold,
-      confirm_segments, bpm_enabled, bpm_min, bpm_max, auto_start, updated_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, strftime('%s','now'))
+      confirm_segments, bpm_enabled, bpm_min, bpm_max, auto_start, auto_calibrate, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, strftime('%s','now'))
     ON CONFLICT(api_key) DO UPDATE SET
       silence_threshold = excluded.silence_threshold,
       flatness_threshold = excluded.flatness_threshold,
@@ -103,6 +112,7 @@ export function setMusicConfig(db, apiKey, patch = {}) {
       bpm_min = excluded.bpm_min,
       bpm_max = excluded.bpm_max,
       auto_start = excluded.auto_start,
+      auto_calibrate = excluded.auto_calibrate,
       updated_at = strftime('%s','now')
   `).run(
     apiKey,
@@ -114,6 +124,7 @@ export function setMusicConfig(db, apiKey, patch = {}) {
     merged.bpmMin,
     merged.bpmMax,
     merged.autoStart ? 1 : 0,
+    merged.autoCalibrate ? 1 : 0,
   );
   return merged;
 }
@@ -148,4 +159,36 @@ export function getRecentMusicEvents(db, apiKey, limit = 20) {
     ORDER BY ts DESC
     LIMIT ?
   `).all(apiKey, limit);
+}
+
+/**
+ * Retrieve a paginated page of music events for an API key, newest first.
+ *
+ * @param {import('better-sqlite3').Database} db
+ * @param {string} apiKey
+ * @param {object} [opts]
+ * @param {number} [opts.limit=50]
+ * @param {number} [opts.offset=0]
+ * @param {'label_change'|'bpm_update'|null} [opts.eventType]
+ * @returns {{ events: Array<object>, total: number }}
+ */
+export function getMusicEventsPage(db, apiKey, { limit = 50, offset = 0, eventType = null } = {}) {
+  const where = eventType
+    ? `WHERE api_key = ? AND event_type = ?`
+    : `WHERE api_key = ?`;
+  const params = eventType ? [apiKey, eventType] : [apiKey];
+
+  const { total } = db.prepare(`
+    SELECT COUNT(*) AS total FROM music_events ${where}
+  `).get(...params);
+
+  const events = db.prepare(`
+    SELECT id, event_type, label, bpm, confidence, ts
+    FROM music_events
+    ${where}
+    ORDER BY ts DESC, id DESC
+    LIMIT ? OFFSET ?
+  `).all(...params, limit, offset);
+
+  return { events, total };
 }

--- a/packages/plugins/lcyt-music/src/music-manager.js
+++ b/packages/plugins/lcyt-music/src/music-manager.js
@@ -43,6 +43,7 @@ import { spawn } from 'node:child_process';
 import { HlsSegmentFetcher } from './hls-segment-fetcher.js';
 import { extractPcm, probeFfmpegVersion } from './pcm-extractor.js';
 import { classify } from './analyser/spectral-detector.js';
+import { classifyExternal } from './analyser/external-classifier.js';
 import { detectBpm, createBpmSmoother } from './analyser/bpm-detector.js';
 import { getMusicConfig } from './db.js';
 
@@ -54,6 +55,21 @@ const BPM_CHANGE_THRESHOLD = 2;
 // Open Questions #3) — a comfortable 3-4 beat window at most tempos.
 const RTMP_WINDOW_SECONDS = 6;
 const RTMP_WINDOW_BYTES = SAMPLE_RATE * RTMP_WINDOW_SECONDS * 2; // s16le mono
+
+// Phase 4: auto-calibration. Sample RMS energy for the first ~5s of audio
+// (instead of classifying) and derive a silenceThreshold from the observed
+// range, clamped to a sane band so a near-silent or very loud room can't
+// produce a degenerate threshold.
+const CALIBRATION_SECONDS = 5;
+const CALIBRATION_MIN_THRESHOLD = 0.002;
+const CALIBRATION_MAX_THRESHOLD = 0.05;
+const CALIBRATION_FACTOR = 0.5; // midpoint between observed min/max RMS
+
+function computeRms(pcm) {
+  let sum = 0;
+  for (let i = 0; i < pcm.length; i++) sum += pcm[i] * pcm[i];
+  return Math.sqrt(sum / pcm.length);
+}
 
 /**
  * @typedef {object} MusicSession
@@ -71,6 +87,11 @@ const RTMP_WINDOW_BYTES = SAMPLE_RATE * RTMP_WINDOW_SECONDS * 2; // s16le mono
  * @property {number|null} lastEmittedBpm
  * @property {ReturnType<typeof createBpmSmoother>} bpmSmoother
  * @property {object} config
+ * @property {boolean} calibrating
+ * @property {number[]} calibrationSamples   RMS values observed during the calibration window
+ * @property {number} calibrationSampleCount total raw PCM samples observed during calibration
+ * @property {number|null} calibratedSilenceThreshold
+ * @property {Promise<void>|null} processingQueue   serialises RTMP window analysis when MUSIC_CLASSIFIER_URL is set
  */
 
 export class MusicManager extends EventEmitter {
@@ -130,6 +151,11 @@ export class MusicManager extends EventEmitter {
       lastEmittedBpm: null,
       bpmSmoother: createBpmSmoother(),
       config,
+      calibrating: config.autoCalibrate === true,
+      calibrationSamples: [],
+      calibrationSampleCount: 0,
+      calibratedSilenceThreshold: null,
+      processingQueue: null,
     };
 
     this._sessions.set(apiKey, session);
@@ -264,6 +290,8 @@ export class MusicManager extends EventEmitter {
       label: session.lastEmittedLabel,
       bpm: session.lastEmittedBpm,
       ffmpegVersion: this.ffmpegVersion ?? null,
+      calibrating: session.calibrating,
+      calibratedSilenceThreshold: session.calibratedSilenceThreshold,
     };
   }
 
@@ -282,7 +310,7 @@ export class MusicManager extends EventEmitter {
     const pcm = await extractPcm(segmentBuffer, { sampleRate: SAMPLE_RATE });
     if (pcm.length === 0) return;
 
-    this._analysePcm(apiKey, session, pcm);
+    await this._analysePcm(apiKey, session, pcm);
   }
 
   /**
@@ -306,7 +334,22 @@ export class MusicManager extends EventEmitter {
     }
     if (pcm.length === 0) return;
 
-    this._analysePcm(apiKey, session, pcm);
+    // Default path (no MUSIC_CLASSIFIER_URL): call _analysePcm directly
+    // rather than via .then() chaining. Its body runs synchronously to
+    // completion in that case (no await is reached), which several RTMP
+    // tests rely on — they emit('data', ...) and assert state immediately
+    // afterward with no await. When MUSIC_CLASSIFIER_URL is set, route
+    // through session.processingQueue so windows arriving in the same
+    // chunk are classified (and their events emitted) in strict order.
+    if (process.env.MUSIC_CLASSIFIER_URL) {
+      session.processingQueue = (session.processingQueue ?? Promise.resolve())
+        .then(() => this._analysePcm(apiKey, session, pcm))
+        .catch((err) => { this.emit('error', { apiKey, error: err }); });
+    } else {
+      this._analysePcm(apiKey, session, pcm).catch((err) => {
+        this.emit('error', { apiKey, error: err });
+      });
+    }
   }
 
   /**
@@ -314,19 +357,42 @@ export class MusicManager extends EventEmitter {
    * metacode emission pipeline, used by both the HLS (_processSegment) and
    * RTMP (_processRtmpWindow) audio sources.
    *
+   * When MUSIC_CLASSIFIER_URL is set, delegates to the external classifier
+   * hook and falls back to the local heuristic on error/timeout. That path
+   * is the only one that actually awaits anything — the default (no env
+   * var) path below stays fully synchronous so existing callers/tests that
+   * assert state immediately after triggering analysis are unaffected.
+   *
    * @param {string} apiKey
    * @param {MusicSession} session
    * @param {Float32Array} pcm
    */
-  _analysePcm(apiKey, session, pcm) {
+  async _analysePcm(apiKey, session, pcm) {
     const { config } = session;
 
-    const { label: rawLabel, confidence } = classify(pcm, {
+    if (session.calibrating) {
+      this._accumulateCalibration(apiKey, session, pcm);
+      return;
+    }
+
+    const effectiveSilenceThreshold = session.calibratedSilenceThreshold ?? config.silenceThreshold;
+    const classifyOpts = {
       sampleRate: SAMPLE_RATE,
-      silenceThreshold: config.silenceThreshold,
+      silenceThreshold: effectiveSilenceThreshold,
       flatnessThreshold: config.flatnessThreshold,
       zcrThreshold: config.zcrThreshold,
-    });
+    };
+
+    let rawLabel, confidence;
+    if (process.env.MUSIC_CLASSIFIER_URL) {
+      try {
+        ({ label: rawLabel, confidence } = await classifyExternal(pcm, { sampleRate: SAMPLE_RATE }));
+      } catch {
+        ({ label: rawLabel, confidence } = classify(pcm, classifyOpts));
+      }
+    } else {
+      ({ label: rawLabel, confidence } = classify(pcm, classifyOpts));
+    }
 
     // Confirm-segments state machine: require N consecutive identical raw
     // labels before treating it as a real transition (smooths flicker).
@@ -372,5 +438,33 @@ export class MusicManager extends EventEmitter {
     if (parts.length > 0) {
       this._soundProcessor(apiKey, parts.join(' '));
     }
+  }
+
+  /**
+   * Accumulate RMS energy samples during the calibration window. Once enough
+   * audio has been observed, derive calibratedSilenceThreshold from the
+   * observed min/max RMS range, end calibration, and emit 'calibrated'.
+   * Classification is skipped entirely for windows spent calibrating.
+   *
+   * @param {string} apiKey
+   * @param {MusicSession} session
+   * @param {Float32Array} pcm
+   */
+  _accumulateCalibration(apiKey, session, pcm) {
+    session.calibrationSamples.push(computeRms(pcm));
+    session.calibrationSampleCount += pcm.length;
+
+    if (session.calibrationSampleCount < SAMPLE_RATE * CALIBRATION_SECONDS) return;
+
+    const sorted = [...session.calibrationSamples].sort((a, b) => a - b);
+    const min = sorted[0];
+    const max = sorted[sorted.length - 1];
+    const raw = min + (max - min) * CALIBRATION_FACTOR;
+    const threshold = Math.max(CALIBRATION_MIN_THRESHOLD, Math.min(CALIBRATION_MAX_THRESHOLD, raw));
+
+    session.calibratedSilenceThreshold = threshold;
+    session.calibrating = false;
+
+    this.emit('calibrated', { apiKey, silenceThreshold: threshold, ts: Date.now() });
   }
 }

--- a/packages/plugins/lcyt-music/src/routes/music-config.js
+++ b/packages/plugins/lcyt-music/src/routes/music-config.js
@@ -29,7 +29,7 @@ export function createMusicConfigRouter(db, auth) {
     const { apiKey } = req.session;
     const {
       silenceThreshold, flatnessThreshold, zcrThreshold,
-      confirmSegments, bpmEnabled, bpmMin, bpmMax, autoStart,
+      confirmSegments, bpmEnabled, bpmMin, bpmMax, autoStart, autoCalibrate,
     } = req.body || {};
 
     for (const [name, value] of [
@@ -60,7 +60,7 @@ export function createMusicConfigRouter(db, auth) {
     const patch = {};
     for (const [key, value] of Object.entries({
       silenceThreshold, flatnessThreshold, zcrThreshold,
-      confirmSegments, bpmEnabled, bpmMin, bpmMax, autoStart,
+      confirmSegments, bpmEnabled, bpmMin, bpmMax, autoStart, autoCalibrate,
     })) {
       if (value !== undefined) patch[key] = value;
     }

--- a/packages/plugins/lcyt-music/src/routes/music.js
+++ b/packages/plugins/lcyt-music/src/routes/music.js
@@ -4,23 +4,27 @@
  * Mounted at /music in the main server.
  *
  * Routes:
- *   GET  /music/status      — current analysis state for the authenticated API key
- *   POST /music/start       — start analysis { streamKey?, audioSource? ('hls'|'rtmp', default 'hls') }
- *   POST /music/stop        — stop analysis
- *   GET  /music/:key/live   — public SSE stream of label_change / bpm_update events
+ *   GET  /music/status         — current analysis state for the authenticated API key
+ *   POST /music/start          — start analysis { streamKey?, audioSource? ('hls'|'rtmp', default 'hls') }
+ *   POST /music/stop           — stop analysis
+ *   GET  /music/events/history — paginated music_events history { limit?, offset?, eventType? } (Phase 4)
+ *   GET  /music/:key/live      — public SSE stream of label_change / bpm_update events
  *
  * SSE events on GET /music/:key/live:
- *   connected     { apiKey }
- *   snapshot      { label, labelConfidence, labelTs, bpm, bpmConfidence, bpmTs } — most recent
- *                   persisted state from music_events, sent once on connect (if any exists)
- *   label_change  { label, confidence, bpm, ts }
- *   bpm_update    { bpm, confidence, ts }
- *   music_error   { error }
- *   music_stopped { apiKey }
+ *   connected        { apiKey }
+ *   snapshot         { label, labelConfidence, labelTs, bpm, bpmConfidence, bpmTs } — most recent
+ *                      persisted state from music_events, sent once on connect (if any exists)
+ *   label_change     { label, confidence, bpm, ts }
+ *   bpm_update       { bpm, confidence, ts }
+ *   music_calibrated { silenceThreshold, ts } — auto-calibration finished (Phase 4)
+ *   music_error      { error }
+ *   music_stopped    { apiKey }
  */
 
 import { Router } from 'express';
-import { getRecentMusicEvents } from '../db.js';
+import { getRecentMusicEvents, getMusicEventsPage } from '../db.js';
+
+const VALID_EVENT_TYPES = new Set(['label_change', 'bpm_update']);
 
 /** Send an SSE event line to an Express response. */
 function sendEvent(res, eventName, data) {
@@ -62,6 +66,27 @@ export function createMusicRouter(db, auth, musicManager) {
     const { apiKey } = req.session;
     await musicManager.stop(apiKey);
     res.json({ ok: true });
+  });
+
+  // ── GET /music/events/history ────────────────────────────────────────────
+
+  router.get('/events/history', auth, (req, res) => {
+    const { apiKey } = req.session;
+    const { eventType = null } = req.query;
+
+    if (eventType !== null && !VALID_EVENT_TYPES.has(eventType)) {
+      return res.status(400).json({ error: `eventType must be one of: ${[...VALID_EVENT_TYPES].join(', ')}` });
+    }
+
+    let limit = parseInt(req.query.limit, 10);
+    if (!Number.isInteger(limit)) limit = 50;
+    limit = Math.max(1, Math.min(200, limit));
+
+    let offset = parseInt(req.query.offset, 10);
+    if (!Number.isInteger(offset) || offset < 0) offset = 0;
+
+    const { events, total } = getMusicEventsPage(db, apiKey, { limit, offset, eventType });
+    res.json({ events, total, limit, offset });
   });
 
   // ── GET /music/:key/live (public SSE) ────────────────────────────────────
@@ -110,11 +135,16 @@ export function createMusicRouter(db, auth, musicManager) {
       if (k !== apiKey) return;
       sendEvent(res, 'music_stopped', { apiKey });
     }
+    function onCalibrated({ apiKey: k, silenceThreshold, ts }) {
+      if (k !== apiKey) return;
+      sendEvent(res, 'music_calibrated', { silenceThreshold, ts });
+    }
 
     musicManager.on('label_change', onLabelChange);
     musicManager.on('bpm_update', onBpmUpdate);
     musicManager.on('error', onError);
     musicManager.on('stopped', onStopped);
+    musicManager.on('calibrated', onCalibrated);
 
     const heartbeat = setInterval(() => {
       if (!res.writableEnded) res.write(': heartbeat\n\n');
@@ -126,6 +156,7 @@ export function createMusicRouter(db, auth, musicManager) {
       musicManager.off('bpm_update', onBpmUpdate);
       musicManager.off('error', onError);
       musicManager.off('stopped', onStopped);
+      musicManager.off('calibrated', onCalibrated);
     });
   });
 

--- a/packages/plugins/lcyt-music/src/wav-encoder.js
+++ b/packages/plugins/lcyt-music/src/wav-encoder.js
@@ -1,0 +1,45 @@
+/**
+ * Local WAV encoder for the external classifier hook (Phase 4).
+ *
+ * Duplicated from lcyt-rtmp's stt-adapters/pcm-buffer.js buildWav() rather
+ * than imported — plugins never import each other's source (see
+ * pcm-extractor.js's probeFfmpegVersion for the established precedent).
+ */
+
+/**
+ * Wrap normalised Float32 PCM ([-1, 1], mono) in a 44-byte RIFF/WAV header.
+ *
+ * @param {Float32Array} pcm
+ * @param {number} sampleRate
+ * @returns {Buffer}
+ */
+export function buildWav(pcm, sampleRate) {
+  const channels = 1;
+  const bitsPerSample = 16;
+  const byteRate = sampleRate * channels * (bitsPerSample / 8);
+  const blockAlign = channels * (bitsPerSample / 8);
+  const dataLen = pcm.length * 2;
+
+  const buf = Buffer.alloc(44 + dataLen);
+  buf.write('RIFF', 0, 'ascii');
+  buf.writeUInt32LE(36 + dataLen, 4);
+  buf.write('WAVE', 8, 'ascii');
+  buf.write('fmt ', 12, 'ascii');
+  buf.writeUInt32LE(16, 16); // PCM subchunk size
+  buf.writeUInt16LE(1, 20);  // PCM format = 1
+  buf.writeUInt16LE(channels, 22);
+  buf.writeUInt32LE(sampleRate, 24);
+  buf.writeUInt32LE(byteRate, 28);
+  buf.writeUInt16LE(blockAlign, 32);
+  buf.writeUInt16LE(bitsPerSample, 34);
+  buf.write('data', 36, 'ascii');
+  buf.writeUInt32LE(dataLen, 40);
+
+  for (let i = 0; i < pcm.length; i++) {
+    const clamped = Math.max(-1, Math.min(1, pcm[i]));
+    const sample = clamped < 0 ? clamped * 32768 : clamped * 32767;
+    buf.writeInt16LE(Math.round(sample), 44 + i * 2);
+  }
+
+  return buf;
+}

--- a/packages/plugins/lcyt-music/test/db.test.js
+++ b/packages/plugins/lcyt-music/test/db.test.js
@@ -1,0 +1,106 @@
+import { test, describe, before, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import Database from 'better-sqlite3';
+
+describe('lcyt-music db', () => {
+  let runMigrations, insertMusicEvent, getMusicEventsPage, getMusicConfig, setMusicConfig;
+  let db;
+
+  before(async () => {
+    ({ runMigrations, insertMusicEvent, getMusicEventsPage, getMusicConfig, setMusicConfig } =
+      await import('../src/db.js'));
+  });
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    runMigrations(db);
+  });
+
+  describe('getMusicEventsPage', () => {
+    function seed(n, eventType = 'label_change') {
+      for (let i = 0; i < n; i++) {
+        insertMusicEvent(db, 'key1', { event_type: eventType, label: 'music', bpm: null, confidence: 0.9 });
+      }
+    }
+
+    test('returns empty page with total 0 when no events exist', () => {
+      const { events, total } = getMusicEventsPage(db, 'key1');
+      assert.deepEqual(events, []);
+      assert.equal(total, 0);
+    });
+
+    test('respects limit and reports total across all matching rows', () => {
+      seed(5);
+      const { events, total } = getMusicEventsPage(db, 'key1', { limit: 2 });
+      assert.equal(events.length, 2);
+      assert.equal(total, 5);
+    });
+
+    test('respects offset for subsequent pages', () => {
+      seed(5);
+      const page1 = getMusicEventsPage(db, 'key1', { limit: 2, offset: 0 });
+      const page2 = getMusicEventsPage(db, 'key1', { limit: 2, offset: 2 });
+      const page1Ids = page1.events.map((e) => e.id);
+      const page2Ids = page2.events.map((e) => e.id);
+      assert.equal(page1Ids.length, 2);
+      assert.equal(page2Ids.length, 2);
+      assert.deepEqual(page1Ids.filter((id) => page2Ids.includes(id)), []);
+    });
+
+    test('orders newest first (ts DESC, id DESC tiebreaker)', () => {
+      seed(3);
+      const { events } = getMusicEventsPage(db, 'key1', { limit: 10 });
+      const ids = events.map((e) => e.id);
+      assert.deepEqual(ids, [...ids].sort((a, b) => b - a));
+    });
+
+    test('filters by eventType when provided', () => {
+      seed(2, 'label_change');
+      seed(3, 'bpm_update');
+      const { events, total } = getMusicEventsPage(db, 'key1', { limit: 10, eventType: 'bpm_update' });
+      assert.equal(total, 3);
+      assert.ok(events.every((e) => e.event_type === 'bpm_update'));
+    });
+
+    test('only returns events for the requested api_key', () => {
+      insertMusicEvent(db, 'key1', { event_type: 'label_change', label: 'music' });
+      insertMusicEvent(db, 'key2', { event_type: 'label_change', label: 'speech' });
+      const { events, total } = getMusicEventsPage(db, 'key1', { limit: 10 });
+      assert.equal(total, 1);
+      assert.equal(events[0].label, 'music');
+    });
+
+    test('defaults to limit 50, offset 0 when not provided', () => {
+      seed(3);
+      const { events } = getMusicEventsPage(db, 'key1');
+      assert.equal(events.length, 3);
+    });
+  });
+
+  describe('autoCalibrate config field', () => {
+    test('defaults to false when no config row exists', () => {
+      const config = getMusicConfig(db, 'key1');
+      assert.equal(config.autoCalibrate, false);
+    });
+
+    test('round-trips true through setMusicConfig/getMusicConfig', () => {
+      setMusicConfig(db, 'key1', { autoCalibrate: true });
+      const config = getMusicConfig(db, 'key1');
+      assert.equal(config.autoCalibrate, true);
+    });
+
+    test('omitted autoCalibrate keeps existing value on patch', () => {
+      setMusicConfig(db, 'key1', { autoCalibrate: true });
+      setMusicConfig(db, 'key1', { bpmEnabled: false });
+      const config = getMusicConfig(db, 'key1');
+      assert.equal(config.autoCalibrate, true);
+      assert.equal(config.bpmEnabled, false);
+    });
+  });
+
+  describe('runMigrations idempotency', () => {
+    test('running migrations twice does not throw (additive column already present)', () => {
+      assert.doesNotThrow(() => runMigrations(db));
+    });
+  });
+});

--- a/packages/plugins/lcyt-music/test/external-classifier.test.js
+++ b/packages/plugins/lcyt-music/test/external-classifier.test.js
@@ -1,0 +1,92 @@
+/**
+ * classifyExternal() unit tests (Phase 4).
+ *
+ * Stubs globalThis.fetch directly — no network involved. Mirrors the
+ * fetch-stubbing pattern used in test/music-manager.test.js.
+ */
+import { test, describe, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { classifyExternal, CLASSIFIER_TIMEOUT_MS } from '../src/analyser/external-classifier.js';
+
+function makePcm(length = 256) {
+  const pcm = new Float32Array(length);
+  for (let i = 0; i < length; i++) pcm[i] = Math.sin(i * 0.1) * 0.5;
+  return pcm;
+}
+
+describe('classifyExternal', () => {
+  let originalFetch;
+  let originalUrl;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    originalUrl = process.env.MUSIC_CLASSIFIER_URL;
+    process.env.MUSIC_CLASSIFIER_URL = 'http://classifier.example.test/classify';
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (originalUrl === undefined) delete process.env.MUSIC_CLASSIFIER_URL;
+    else process.env.MUSIC_CLASSIFIER_URL = originalUrl;
+  });
+
+  test('throws when MUSIC_CLASSIFIER_URL is not set', async () => {
+    delete process.env.MUSIC_CLASSIFIER_URL;
+    await assert.rejects(() => classifyExternal(makePcm()), /MUSIC_CLASSIFIER_URL is not set/);
+  });
+
+  test('posts a WAV body and returns { label, confidence } on success', async () => {
+    let captured = null;
+    globalThis.fetch = async (url, opts) => {
+      captured = { url, opts };
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ label: 'music', confidence: 0.87 }),
+      };
+    };
+
+    const result = await classifyExternal(makePcm(), { sampleRate: 22050 });
+    assert.deepEqual(result, { label: 'music', confidence: 0.87 });
+
+    assert.equal(captured.url, 'http://classifier.example.test/classify');
+    assert.equal(captured.opts.method, 'POST');
+    assert.equal(captured.opts.headers['Content-Type'], 'audio/wav');
+    assert.ok(Buffer.isBuffer(captured.opts.body) || captured.opts.body instanceof Uint8Array);
+    // 44-byte RIFF/WAV header + 2 bytes per sample.
+    assert.equal(captured.opts.body.length, 44 + makePcm().length * 2);
+  });
+
+  test('defaults confidence to null when the response omits it', async () => {
+    globalThis.fetch = async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ label: 'speech' }),
+    });
+    const result = await classifyExternal(makePcm());
+    assert.deepEqual(result, { label: 'speech', confidence: null });
+  });
+
+  test('throws when the response is not ok', async () => {
+    globalThis.fetch = async () => ({ ok: false, status: 503 });
+    await assert.rejects(() => classifyExternal(makePcm()), /503/);
+  });
+
+  test('throws when the response body is missing a string label', async () => {
+    globalThis.fetch = async () => ({ ok: true, status: 200, json: async () => ({}) });
+    await assert.rejects(() => classifyExternal(makePcm()), /missing label/);
+  });
+
+  test('propagates an abort/timeout error from fetch', async () => {
+    globalThis.fetch = async () => {
+      const err = new Error('The operation was aborted');
+      err.name = 'AbortError';
+      throw err;
+    };
+    await assert.rejects(() => classifyExternal(makePcm(), { timeoutMs: 10 }), /aborted/);
+  });
+
+  test('uses the default CLASSIFIER_TIMEOUT_MS when no override is given', async () => {
+    assert.equal(CLASSIFIER_TIMEOUT_MS, 3000);
+  });
+});

--- a/packages/plugins/lcyt-music/test/music-manager-calibration.test.js
+++ b/packages/plugins/lcyt-music/test/music-manager-calibration.test.js
@@ -1,0 +1,190 @@
+/**
+ * MusicManager Phase 4 tests — auto-calibration phase.
+ *
+ * Mirrors test/music-manager.test.js's mock.module() setup for
+ * pcm-extractor.js (extractPcm/probeFfmpegVersion), but uses a configurable
+ * mock DB row so getMusicConfig() can return auto_calibrate=1.
+ */
+import { test, describe, before, beforeEach, afterEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+
+const SAMPLE_RATE = 22050;
+const CALIBRATION_SECONDS = 5;
+const CALIBRATION_SAMPLE_THRESHOLD = SAMPLE_RATE * CALIBRATION_SECONDS;
+const CALIBRATION_MIN_THRESHOLD = 0.002;
+const CALIBRATION_MAX_THRESHOLD = 0.05;
+
+function makeQuietNoise(length, amplitude = 0.01, seed = 1) {
+  let s = seed;
+  const pcm = new Float64Array(length);
+  for (let i = 0; i < length; i++) {
+    s = (s * 9301 + 49297) % 233280;
+    pcm[i] = ((s / 233280) * 2 - 1) * amplitude;
+  }
+  return pcm;
+}
+
+function makeTone(freq, sampleRate, length) {
+  const pcm = new Float64Array(length);
+  for (let i = 0; i < length; i++) {
+    pcm[i] = Math.sin((2 * Math.PI * freq * i) / sampleRate);
+  }
+  return pcm;
+}
+
+/** Mock DB whose getMusicConfig() row can opt into auto_calibrate. */
+function makeMockDb({ autoCalibrate = false } = {}) {
+  return {
+    prepare() {
+      return {
+        get() {
+          return {
+            silence_threshold: 0.01,
+            flatness_threshold: 0.4,
+            zcr_threshold: 0.15,
+            confirm_segments: 2,
+            bpm_enabled: 1,
+            bpm_min: 40,
+            bpm_max: 200,
+            auto_start: 0,
+            auto_calibrate: autoCalibrate ? 1 : 0,
+          };
+        },
+        run() { return {}; },
+        all() { return []; },
+      };
+    },
+    exec() {},
+  };
+}
+
+function makeSoundProcessor() {
+  const calls = [];
+  const fn = (apiKey, text) => { calls.push({ apiKey, text }); return ''; };
+  fn.calls = calls;
+  return fn;
+}
+
+describe('MusicManager auto-calibration (Phase 4)', () => {
+  let MusicManager;
+  let pcmQueue;
+  let originalFetch;
+
+  before(async () => {
+    mock.module('../src/pcm-extractor.js', {
+      namedExports: {
+        extractPcm: async () => (pcmQueue.length > 0 ? pcmQueue.shift() : new Float32Array(0)),
+        probeFfmpegVersion: async () => null,
+      },
+    });
+    ({ MusicManager } = await import('../src/music-manager.js'));
+  });
+
+  beforeEach(() => {
+    pcmQueue = [];
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => ({ ok: false, status: 404 });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test('status.calibrating is false at start when autoCalibrate is off (default)', async () => {
+    const mgr = new MusicManager(makeMockDb({ autoCalibrate: false }), null, makeSoundProcessor());
+    await mgr.start('key1');
+    assert.equal(mgr.getStatus('key1').calibrating, false);
+    await mgr.stop('key1');
+  });
+
+  test('status.calibrating is true at start when autoCalibrate is on', async () => {
+    const mgr = new MusicManager(makeMockDb({ autoCalibrate: true }), null, makeSoundProcessor());
+    await mgr.start('key1');
+    assert.equal(mgr.getStatus('key1').calibrating, true);
+    await mgr.stop('key1');
+  });
+
+  test('classification is skipped while calibrating', async () => {
+    const soundProcessor = makeSoundProcessor();
+    const mgr = new MusicManager(makeMockDb({ autoCalibrate: true }), null, soundProcessor);
+    await mgr.start('key1');
+
+    // Push a loud tone during the calibration window — if classification ran,
+    // this would trigger a label_change after a couple of segments.
+    pcmQueue.push(makeTone(220, SAMPLE_RATE, 4096));
+    await mgr._processSegment('key1', Buffer.from('seg'));
+    pcmQueue.push(makeTone(220, SAMPLE_RATE, 4096));
+    await mgr._processSegment('key1', Buffer.from('seg'));
+
+    assert.equal(soundProcessor.calls.length, 0, 'no metacode should be synthesised while calibrating');
+    assert.equal(mgr.getStatus('key1').label, null);
+
+    await mgr.stop('key1');
+  });
+
+  test('emits "calibrated" once enough samples have been observed, then ends calibration', async () => {
+    const mgr = new MusicManager(makeMockDb({ autoCalibrate: true }), null, makeSoundProcessor());
+    const calibratedEvents = [];
+    mgr.on('calibrated', (e) => calibratedEvents.push(e));
+    await mgr.start('key1');
+
+    pcmQueue.push(makeQuietNoise(CALIBRATION_SAMPLE_THRESHOLD, 0.01));
+    await mgr._processSegment('key1', Buffer.from('seg'));
+
+    assert.equal(calibratedEvents.length, 1, 'calibrated should fire exactly once');
+    assert.equal(calibratedEvents[0].apiKey, 'key1');
+    assert.ok(calibratedEvents[0].silenceThreshold >= CALIBRATION_MIN_THRESHOLD);
+    assert.ok(calibratedEvents[0].silenceThreshold <= CALIBRATION_MAX_THRESHOLD);
+    assert.ok(typeof calibratedEvents[0].ts === 'number');
+
+    const status = mgr.getStatus('key1');
+    assert.equal(status.calibrating, false);
+    assert.equal(status.calibratedSilenceThreshold, calibratedEvents[0].silenceThreshold);
+
+    await mgr.stop('key1');
+  });
+
+  test('accumulates across multiple segments before crossing the calibration threshold', async () => {
+    const mgr = new MusicManager(makeMockDb({ autoCalibrate: true }), null, makeSoundProcessor());
+    const calibratedEvents = [];
+    mgr.on('calibrated', (e) => calibratedEvents.push(e));
+    await mgr.start('key1');
+
+    const half = Math.floor(CALIBRATION_SAMPLE_THRESHOLD / 2);
+    pcmQueue.push(makeQuietNoise(half, 0.01, 3));
+    await mgr._processSegment('key1', Buffer.from('seg'));
+    assert.equal(mgr.getStatus('key1').calibrating, true, 'half the window should not be enough yet');
+    assert.equal(calibratedEvents.length, 0);
+
+    pcmQueue.push(makeQuietNoise(CALIBRATION_SAMPLE_THRESHOLD - half + 100, 0.01, 5));
+    await mgr._processSegment('key1', Buffer.from('seg'));
+    assert.equal(mgr.getStatus('key1').calibrating, false);
+    assert.equal(calibratedEvents.length, 1);
+
+    await mgr.stop('key1');
+  });
+
+  test('classification resumes using the calibrated threshold after calibration ends', async () => {
+    const soundProcessor = makeSoundProcessor();
+    const labelEvents = [];
+    const mgr = new MusicManager(makeMockDb({ autoCalibrate: true }), null, soundProcessor);
+    mgr.on('label_change', (e) => labelEvents.push(e));
+    await mgr.start('key1');
+
+    pcmQueue.push(makeQuietNoise(CALIBRATION_SAMPLE_THRESHOLD, 0.01));
+    await mgr._processSegment('key1', Buffer.from('seg'));
+    assert.equal(mgr.getStatus('key1').calibrating, false);
+
+    // confirmSegments defaults to 2 — two sustained tone segments after
+    // calibration should produce exactly one label_change to "music".
+    pcmQueue.push(makeTone(220, SAMPLE_RATE, 8192));
+    await mgr._processSegment('key1', Buffer.from('seg'));
+    pcmQueue.push(makeTone(220, SAMPLE_RATE, 8192));
+    await mgr._processSegment('key1', Buffer.from('seg'));
+
+    assert.equal(labelEvents.length, 1);
+    assert.equal(labelEvents[0].label, 'music');
+
+    await mgr.stop('key1');
+  });
+});

--- a/packages/plugins/lcyt-music/test/music-manager-classifier-queue.test.js
+++ b/packages/plugins/lcyt-music/test/music-manager-classifier-queue.test.js
@@ -1,0 +1,184 @@
+/**
+ * MusicManager Phase 4 tests — RTMP processingQueue ordering when
+ * MUSIC_CLASSIFIER_URL is set.
+ *
+ * Two full windows arriving in a single ffmpeg stdout 'data' chunk must be
+ * classified (and their events emitted) in arrival order, not in whichever
+ * order their classifier fetch() calls happen to resolve. We verify this by
+ * holding the first window's fetch() pending (via a manually-resolved
+ * deferred) and asserting the second window's fetch() is not even invoked
+ * until the first one settles.
+ *
+ * Mirrors test/music-manager-rtmp.test.js's mock.module() setup for
+ * node:child_process + pcm-extractor.js.
+ */
+import { test, describe, beforeEach, afterEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+
+const SAMPLE_RATE = 22050;
+const RTMP_WINDOW_SECONDS = 6;
+const RTMP_WINDOW_BYTES = SAMPLE_RATE * RTMP_WINDOW_SECONDS * 2; // s16le mono
+
+function makeToneBuffer(freq, sampleRate, numSamples, amplitude = 32767 * 0.8) {
+  const buf = Buffer.alloc(numSamples * 2);
+  for (let i = 0; i < numSamples; i++) {
+    const sample = Math.round(amplitude * Math.sin((2 * Math.PI * freq * i) / sampleRate));
+    buf.writeInt16LE(sample, i * 2);
+  }
+  return buf;
+}
+
+function makeFakeProc() {
+  const proc = new EventEmitter();
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.killed = false;
+  proc.kill = function () {
+    this.killed = true;
+    setImmediate(() => this.emit('close', 0));
+  };
+  return proc;
+}
+
+const spawnCalls = [];
+
+await mock.module('node:child_process', {
+  namedExports: {
+    spawn: mock.fn((cmd, args, opts) => {
+      const proc = makeFakeProc();
+      spawnCalls.push({ cmd, args, opts, proc });
+      return proc;
+    }),
+  },
+});
+
+await mock.module('../src/pcm-extractor.js', {
+  namedExports: {
+    extractPcm: async () => new Float32Array(0),
+    probeFfmpegVersion: async () => null,
+  },
+});
+
+const { MusicManager } = await import('../src/music-manager.js');
+
+function makeMockDb() {
+  return {
+    prepare() {
+      return { get() { return undefined; }, run() { return {}; }, all() { return []; } };
+    },
+    exec() {},
+  };
+}
+
+function makeSoundProcessor() {
+  const calls = [];
+  const fn = (apiKey, text) => { calls.push({ apiKey, text }); return ''; };
+  fn.calls = calls;
+  return fn;
+}
+
+async function flushMicrotasks(times = 5) {
+  for (let i = 0; i < times; i++) await Promise.resolve();
+}
+
+/** Poll fetchEvents until it reaches the expected length, or time out. */
+async function waitForLength(arr, length, timeoutMs = 1000) {
+  const start = Date.now();
+  while (arr.length < length) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`timed out waiting for length ${length}, got ${JSON.stringify(arr)}`);
+    }
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}
+
+describe('MusicManager RTMP processingQueue ordering (MUSIC_CLASSIFIER_URL set)', () => {
+  let originalUrl;
+  let originalFetch;
+
+  beforeEach(() => {
+    spawnCalls.length = 0;
+    originalUrl = process.env.MUSIC_CLASSIFIER_URL;
+    process.env.MUSIC_CLASSIFIER_URL = 'http://classifier.example.test/classify';
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    if (originalUrl === undefined) delete process.env.MUSIC_CLASSIFIER_URL;
+    else process.env.MUSIC_CLASSIFIER_URL = originalUrl;
+    globalThis.fetch = originalFetch;
+  });
+
+  test('windows in the same data chunk are classified in arrival order, not resolution order', async () => {
+    const fetchEvents = [];
+    let callIndex = 0;
+    const deferreds = [];
+
+    globalThis.fetch = async () => {
+      const index = callIndex++;
+      fetchEvents.push(`start:${index}`);
+      let resolve;
+      const promise = new Promise((r) => { resolve = r; });
+      deferreds.push(resolve);
+      await promise;
+      fetchEvents.push(`end:${index}`);
+      const label = index === 0 ? 'speech' : 'music';
+      return { ok: true, status: 200, json: async () => ({ label, confidence: 0.9 }) };
+    };
+
+    const soundProcessor = makeSoundProcessor();
+    const labelEvents = [];
+    const mgr = new MusicManager(makeMockDb(), null, soundProcessor);
+    mgr.on('label_change', (e) => labelEvents.push(e));
+    await mgr.start('keyQ', { streamKey: 'x', audioSource: 'rtmp' });
+
+    const proc = spawnCalls[0].proc;
+    const numSamples = RTMP_WINDOW_BYTES / 2;
+    const window1 = makeToneBuffer(220, SAMPLE_RATE, numSamples);
+    const window2 = makeToneBuffer(440, SAMPLE_RATE, numSamples);
+
+    // Both windows arrive in a single 'data' chunk.
+    proc.stdout.emit('data', Buffer.concat([window1, window2]));
+
+    await waitForLength(fetchEvents, 1);
+    await flushMicrotasks(10);
+    assert.deepEqual(fetchEvents, ['start:0'], 'second window must not start classification until the first settles');
+
+    // Resolve the first window's classifier call — only then should the
+    // second window's classify() call (fetch) be invoked.
+    deferreds[0]();
+    await waitForLength(fetchEvents, 3);
+    await flushMicrotasks(10);
+    assert.deepEqual(fetchEvents, ['start:0', 'end:0', 'start:1']);
+
+    deferreds[1]();
+    await waitForLength(fetchEvents, 4);
+    assert.deepEqual(fetchEvents, ['start:0', 'end:0', 'start:1', 'end:1']);
+
+    await mgr.stop('keyQ');
+  });
+
+  test('falls back to the local heuristic when the classifier call fails', async () => {
+    globalThis.fetch = async () => ({ ok: false, status: 500 });
+
+    const soundProcessor = makeSoundProcessor();
+    const labelEvents = [];
+    const mgr = new MusicManager(makeMockDb(), null, soundProcessor);
+    mgr.on('label_change', (e) => labelEvents.push(e));
+    await mgr.start('keyF', { streamKey: 'x', audioSource: 'rtmp' });
+
+    const proc = spawnCalls[0].proc;
+    const numSamples = RTMP_WINDOW_BYTES / 2;
+    const fullWindow = makeToneBuffer(220, SAMPLE_RATE, numSamples);
+
+    proc.stdout.emit('data', fullWindow);
+    proc.stdout.emit('data', fullWindow);
+    await waitForLength(labelEvents, 1);
+
+    assert.equal(labelEvents.length, 1, 'heuristic fallback should still classify the sustained tone as music');
+    assert.equal(labelEvents[0].label, 'music');
+
+    await mgr.stop('keyF');
+  });
+});


### PR DESCRIPTION
- Add paginated GET /music/events/history endpoint and music_calibrated SSE
  event on GET /music/:key/live
- Add server-side auto-calibration phase to MusicManager, gated by a new
  music_config.auto_calibrate column (default off)
- Add an optional MUSIC_CLASSIFIER_URL hook so MusicManager can delegate
  classification to an external HTTP/ML endpoint, with WAV encoding and a
  serialized RTMP processing queue to preserve event ordering
- Mirror auto-calibration client-side in useMusicDetector, persisting the
  calibrated threshold to localStorage
- Add a self-fetching, paginated MusicHistoryPanel timeline UI in the Music
  Detection settings tab
- Update .env.example and the lcyt-music README for the new env var,
  routes, config field, and events