### PR TITLE
Add permissive CORS for /auth routes (login/register/me)

### DIFF
--- a/packages/lcyt-backend/src/middleware/cors.js
+++ b/packages/lcyt-backend/src/middleware/cors.js
@@ -51,6 +51,9 @@ export function createCorsMiddleware(store) {
       (method === 'POST' && path === '/live') ||
       (method === 'GET' && path === '/health') ||
       (method === 'GET' && path === '/contact') ||
+      // /auth/*: login/register happen before any session exists, so there is no
+      // session domain to match against yet — the password/JWT is the real gate
+      path.startsWith('/auth') ||
       // DSK routes: authenticated by X-API-Key or Bearer JWT, not by session domain
       path.startsWith('/dsk') ||
       path.startsWith('/images') ||

--- a/packages/lcyt-backend/test/cors.test.js
+++ b/packages/lcyt-backend/test/cors.test.js
@@ -73,6 +73,51 @@ describe('cors — /keys routes', () => {
 });
 
 // ---------------------------------------------------------------------------
+// /auth routes — permissive CORS (no session exists yet at login/register time)
+// ---------------------------------------------------------------------------
+
+describe('cors — /auth routes', () => {
+  it('sets CORS headers for POST /auth/login from any origin', () => {
+    const mw = createCorsMiddleware(makeStore());
+    const req = makeReq({ method: 'POST', path: '/auth/login', origin: 'https://app.lcyt.fi' });
+    const res = makeRes();
+    let nextCalled = false;
+    mw(req, res, () => { nextCalled = true; });
+    assert.equal(res.headers['Access-Control-Allow-Origin'], 'https://app.lcyt.fi');
+    assert.equal(nextCalled, true);
+  });
+
+  it('sets CORS headers for POST /auth/register', () => {
+    const mw = createCorsMiddleware(makeStore());
+    const req = makeReq({ method: 'POST', path: '/auth/register', origin: 'https://app.lcyt.fi' });
+    const res = makeRes();
+    let nextCalled = false;
+    mw(req, res, () => { nextCalled = true; });
+    assert.equal(res.headers['Access-Control-Allow-Origin'], 'https://app.lcyt.fi');
+    assert.equal(nextCalled, true);
+  });
+
+  it('sets CORS headers for GET /auth/me', () => {
+    const mw = createCorsMiddleware(makeStore());
+    const req = makeReq({ method: 'GET', path: '/auth/me', origin: 'https://app.lcyt.fi' });
+    const res = makeRes();
+    let nextCalled = false;
+    mw(req, res, () => { nextCalled = true; });
+    assert.equal(res.headers['Access-Control-Allow-Origin'], 'https://app.lcyt.fi');
+    assert.equal(nextCalled, true);
+  });
+
+  it('returns 204 for OPTIONS /auth/login with CORS headers', () => {
+    const mw = createCorsMiddleware(makeStore());
+    const req = makeReq({ method: 'OPTIONS', path: '/auth/login', origin: 'https://app.lcyt.fi' });
+    const res = makeRes();
+    mw(req, res, () => {});
+    assert.equal(res.statusCode, 204);
+    assert.equal(res.headers['Access-Control-Allow-Origin'], 'https://app.lcyt.fi');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Free-tier signup: POST /keys?freetier
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Extends CORS middleware to allow cross-origin requests to authentication endpoints (`/auth/login`, `/auth/register`, `/auth/me`). These routes require permissive CORS because they operate before any session exists — authentication is secured by password/JWT, not by session domain matching.

## Changes
- **`src/middleware/cors.js`**: Added `path.startsWith('/auth')` condition to the permissive CORS allowlist with explanatory comment noting that auth endpoints are secured by credentials (password/JWT) rather than session domain validation
- **`test/cors.test.js`**: Added comprehensive test suite for `/auth` routes covering:
  - `POST /auth/login` with CORS headers
  - `POST /auth/register` with CORS headers  
  - `GET /auth/me` with CORS headers
  - `OPTIONS /auth/login` preflight request returning 204 with CORS headers

## Implementation Details
The auth routes are treated similarly to existing permissive endpoints (`/dsk`, `/images`, `/keys`) because they use alternative authentication mechanisms (password/JWT) rather than relying on session domain validation. This allows frontend applications on different origins to authenticate users without CORS restrictions.

https://claude.ai/code/session_01W6cfYzGPWcqKc8gs5mGnMV