### PR TITLE
Fix incorrect OBSClient import path in mixer adapter

### DIFF
--- a/packages/plugins/lcyt-production/src/adapters/mixer/obs.js
+++ b/packages/plugins/lcyt-production/src/adapters/mixer/obs.js
@@ -27,7 +27,7 @@
  * ─────────────────────────────────────────────────────────────────────────────
  */
 
-import { OBSClient } from '../obs-client.js';
+import { OBSClient } from '../../obs-client.js';
 
 const CONNECT_TIMEOUT_MS = 3_000;
 


### PR DESCRIPTION
## Summary
- Fixed the relative import path for `OBSClient` in `packages/plugins/lcyt-production/src/adapters/mixer/obs.js`
- The import `../obs-client.js` resolved to a nonexistent `src/adapters/obs-client.js`; the file actually lives at `src/obs-client.js`, so it now imports `../../obs-client.js`
- This was breaking module resolution at Docker backend container startup

## Test plan
- [x] Verified the corrected relative path resolves to the existing `src/obs-client.js` file
- [x] Ran a direct ESM import of `obs.js` to confirm it loads without error


---
_Generated by [Claude Code](https://claude.ai/code/session_016mY1XDqtxTNobcD68HzjVB)_