### PR TITLE
Add AI models admin and setup hub cards

### DIFF
--- a/packages/lcyt-backend/src/server.js
+++ b/packages/lcyt-backend/src/server.js
@@ -56,7 +56,7 @@ try {
 }
 import { initCueEngine, createCueProcessor, createCueRouter, createSoundCueListener } from 'lcyt-cues';
 import {
-  initAgent, createAgentRouter, createAiRouter,
+  initAgent, createAgentRouter, createAiRouter, createAiModelsRouter, createMcpTokensRouter,
   isServerEmbeddingAvailable, getAiConfigRaw, computeEmbeddings,
 } from 'lcyt-agent';
 import {
@@ -303,10 +303,9 @@ const app = express();
 // Auth middleware instance — created here so /icons can be mounted before the
 // global express.json body parser (the icons upload route uses its own 400kb parser).
 const auth = createAuthMiddleware(jwtSecret);
-
+const userAuth = createUserAuthMiddleware(jwtSecret);
 // DSK routers require auth — must be created after auth is initialized.
 const { dskRouter, dskTemplatesRouter, dskViewportsRouter, imagesRouter, dskRtmpRouter } = createDskRouters(db, dskBus, auth, relayManager);
-
 // Dynamic CORS middleware — must run before all routers (including /icons) so
 // that OPTIONS preflight requests are handled and CORS headers are set.
 app.use(createCorsMiddleware(store));
@@ -415,6 +414,8 @@ app.get('/contact', (req, res) => {
 
 app.use(createSessionRouters(db, store, jwtSecret, auth, { relayManager, dskCaptionProcessor: _dskCaptionProcessor, soundCaptionProcessor: _soundCaptionProcessor, cueProcessor: _cueProcessor, resolveStorage }));
 app.use(createAccountRouters(db, jwtSecret, { loginEnabled }));
+app.use('/ai/models', createAiModelsRouter(db, userAuth));
+app.use('/mcp-tokens', createMcpTokensRouter(db, userAuth));
 app.use('/admin', createAdminRouter(db, jwtSecret));
 app.use('/images',   imagesRouter);
 app.use('/dsk',      dskRouter);

--- a/packages/lcyt-web/src/components/AdminAiModelsPage.jsx
+++ b/packages/lcyt-web/src/components/AdminAiModelsPage.jsx
@@ -1,0 +1,32 @@
+import { useSessionContext } from '../contexts/SessionContext.jsx';
+import { useUserAuth } from '../hooks/useUserAuth.js';
+import { AdminKeyGate } from './AdminKeyGate.jsx';
+import { AdminTabShell } from './AdminTabShell.jsx';
+import { AiModelsSection } from './setup-hub/AiModelsSection.jsx';
+import { McpAccessSection } from './setup-hub/McpAccessSection.jsx';
+
+export function AdminAiModelsPage() {
+  const session = useSessionContext();
+  const backendUrl = session?.backendUrl || '';
+  const { user } = useUserAuth();
+
+  return (
+    <AdminKeyGate backendUrl={backendUrl} userIsAdmin={!!user?.isAdmin}>
+      <AdminTabShell active="ai-models">
+        <div style={{ padding: 24, maxWidth: 1200, display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <div>
+            <h2 style={{ margin: '0 0 8px' }}>AI Models & MCP Access</h2>
+            <p style={{ margin: 0, color: 'var(--color-text-muted)' }}>
+              Manage role-based AI model defaults for this project and personal access tokens for MCP clients.
+            </p>
+          </div>
+
+          <div style={{ display: 'grid', gap: 16, gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))' }}>
+            <McpAccessSection />
+            <AiModelsSection />
+          </div>
+        </div>
+      </AdminTabShell>
+    </AdminKeyGate>
+  );
+}

--- a/packages/lcyt-web/src/components/AdminTabShell.jsx
+++ b/packages/lcyt-web/src/components/AdminTabShell.jsx
@@ -4,6 +4,7 @@ const TABS = [
   { id: 'users',         label: 'Users',         path: '/admin/users' },
   { id: 'projects',      label: 'Projects',      path: '/admin/projects' },
   { id: 'audit-log',     label: 'Audit Log',     path: '/admin/audit-log' },
+  { id: 'ai-models',     label: 'AI Models',     path: '/admin/ai-models' },
   { id: 'site-features', label: 'Site Features', path: '/admin/site-features', stub: true },
   { id: 'teams',         label: 'Teams',         path: '/admin/teams',         stub: true },
 ];

--- a/packages/lcyt-web/src/components/setup-hub/AiModelsSection.jsx
+++ b/packages/lcyt-web/src/components/setup-hub/AiModelsSection.jsx
@@ -1,56 +1,314 @@
-import { useState, useEffect, useCallback } from 'react';
-import { useSessionContext } from '../../contexts/SessionContext';
+import { useCallback, useEffect, useState } from 'react';
+import { useSessionContext } from '../../contexts/SessionContext.jsx';
+import { useUserAuth } from '../../hooks/useUserAuth.js';
+import { createAiModel, deleteAiModel, listAiModels, updateAiModel } from '../../lib/aiAdminApi.js';
+import { Dialog } from '../Dialog.jsx';
 import { SetupCard, SetupItemRow } from './SetupCard.jsx';
 import { ModelsIcon } from './icons.jsx';
 
-const PROVIDER_LABELS = { none: 'Disabled', server: 'Server-provided', openai: 'OpenAI', custom: 'Custom API' };
+const ROLE_LABELS = { assistant: 'Assistant' };
+const PROVIDER_LABELS = { api: 'API (BYOK)', ollama: 'Ollama' };
+const EMPTY_FORM = { roleCode: 'assistant', provider: 'api', modelName: '', apiUrl: 'http://localhost:11434', apiKeyValue: '', enabled: true };
 
-/**
- * AiModelsSection — shows the one real AI/embedding config slot that exists
- * today (`GET /ai/config`, same data as AiSettingsPage at /ai). The planned
- * role split (tracker / describer / planner assistant / production assistant
- * / graphics assistant — see docs/plans/plan_ai_roles_framework.md) has no
- * backend support yet and is labeled "Coming soon".
- */
 export function AiModelsSection() {
   const session = useSessionContext();
-  const [provider, setProvider] = useState(null);
+  const { token: userToken, backendUrl: userBackendUrl } = useUserAuth();
+  const backendUrl = userBackendUrl || session?.backendUrl || '';
+  const apiKey = session?.apiKey || '';
+  const [models, setModels] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [open, setOpen] = useState(false);
+  const [editingModel, setEditingModel] = useState(null);
+  const [form, setForm] = useState(EMPTY_FORM);
+  const [discovering, setDiscovering] = useState(false);
+  const [discoveredModels, setDiscoveredModels] = useState([]);
+  const [error, setError] = useState('');
 
   const load = useCallback(async () => {
-    if (!session?.connected || !session?.backendUrl) return;
+    if (!backendUrl || !userToken || !apiKey) {
+      setModels([]);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
     try {
-      const token = session.getSessionToken?.();
-      const r = await fetch(`${session.backendUrl}/ai/config`, {
-        headers: token ? { Authorization: `Bearer ${token}` } : {},
-      });
-      if (r.ok) {
-        const data = await r.json();
-        setProvider(data.config?.embeddingProvider || 'none');
-      }
-    } catch { /* ignore */ }
-  }, [session]);
+      const rows = await listAiModels({ backendUrl, token: userToken, apiKey });
+      setModels(rows);
+    } catch (err) {
+      setModels([]);
+      setError(err.message || 'Unable to load AI models');
+    } finally {
+      setLoading(false);
+    }
+  }, [apiKey, backendUrl, userToken]);
 
   useEffect(() => { load(); }, [load]);
 
+  function closeDialog() {
+    setOpen(false);
+    setEditingModel(null);
+    setForm(EMPTY_FORM);
+    setDiscoveredModels([]);
+    setError('');
+  }
+
+  function openCreate() {
+    setEditingModel(null);
+    setForm(EMPTY_FORM);
+    setDiscoveredModels([]);
+    setError('');
+    setOpen(true);
+  }
+
+  function openEdit(model) {
+    setEditingModel(model);
+    setForm({
+      roleCode: model.roleCode || 'assistant',
+      provider: model.provider || 'api',
+      modelName: model.modelName || '',
+      apiUrl: model.apiUrl || 'http://localhost:11434',
+      apiKeyValue: '',
+      enabled: model.enabled !== false,
+    });
+    setDiscoveredModels([]);
+    setError('');
+    setOpen(true);
+  }
+
+  async function handleDiscover() {
+    if (form.provider !== 'ollama') return;
+    const endpoint = (form.apiUrl || '').trim();
+    if (!endpoint) {
+      setError('Enter an Ollama endpoint first');
+      return;
+    }
+    setDiscovering(true);
+    setError('');
+    try {
+      const base = endpoint.replace(/\/$/, '');
+      const res = await fetch(`${base}/api/tags`);
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || 'Unable to discover models');
+      const names = Array.isArray(data.models) ? data.models.map(item => item.name).filter(Boolean) : [];
+      setDiscoveredModels(names);
+      if (names.length > 0 && !form.modelName) {
+        setForm(prev => ({ ...prev, modelName: names[0] }));
+      }
+    } catch (err) {
+      setError(err.message || 'Unable to discover models');
+    } finally {
+      setDiscovering(false);
+    }
+  }
+
+  async function handleSave(event) {
+    event.preventDefault();
+    if (!form.modelName.trim()) {
+      setError('Enter a model name');
+      return;
+    }
+    try {
+      if (editingModel) {
+        await updateAiModel({
+          backendUrl,
+          token: userToken,
+          apiKey,
+          id: editingModel.id,
+          roleCode: form.roleCode,
+          provider: form.provider,
+          modelName: form.modelName.trim(),
+          apiUrl: form.apiUrl.trim(),
+          apiKeyValue: form.apiKeyValue.trim(),
+          enabled: form.enabled,
+        });
+      } else {
+        await createAiModel({
+          backendUrl,
+          token: userToken,
+          apiKey,
+          roleCode: form.roleCode,
+          provider: form.provider,
+          modelName: form.modelName.trim(),
+          apiUrl: form.apiUrl.trim(),
+          apiKeyValue: form.apiKeyValue.trim(),
+          enabled: form.enabled,
+        });
+      }
+      await load();
+      closeDialog();
+    } catch (err) {
+      setError(err.message || 'Unable to save model');
+    }
+  }
+
+  async function handleToggle(model) {
+    try {
+      await updateAiModel({
+        backendUrl,
+        token: userToken,
+        apiKey,
+        id: model.id,
+        roleCode: model.roleCode || 'assistant',
+        provider: model.provider,
+        modelName: model.modelName,
+        apiUrl: model.apiUrl,
+        apiKeyValue: '',
+        enabled: !model.enabled,
+      });
+      await load();
+    } catch (err) {
+      setError(err.message || 'Unable to update model');
+    }
+  }
+
+  async function handleDelete(model) {
+    if (!confirm(`Remove ${model.modelName || model.roleCode}?`)) return;
+    try {
+      await deleteAiModel({ backendUrl, token: userToken, apiKey, id: model.id });
+      await load();
+      if (open) closeDialog();
+    } catch (err) {
+      setError(err.message || 'Unable to remove model');
+    }
+  }
+
+  const content = loading ? (
+    <p className="setup-card__empty">Loading AI models…</p>
+  ) : models.length > 0 ? (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.4rem' }}>
+      {models.map(model => (
+        <SetupItemRow
+          key={model.id}
+          name={ROLE_LABELS[model.roleCode] || model.roleCode || 'Assistant'}
+          meta={`${PROVIDER_LABELS[model.provider] || model.provider} • ${model.modelName || 'No model selected'}`}
+          badge={model.enabled ? 'Enabled' : 'Disabled'}
+          toggleOn={model.enabled}
+          onToggle={() => handleToggle(model)}
+          onSettings={() => openEdit(model)}
+          onDelete={() => handleDelete(model)}
+        />
+      ))}
+    </div>
+  ) : (
+    <p className="setup-card__empty">No AI models configured yet. Add one for the Assistant role.</p>
+  );
+
   return (
-    <SetupCard
-      id="ai-models"
-      icon={ModelsIcon}
-      color="purple"
-      title="AI models"
-      description="Embedding model for fuzzy/semantic cue matching. More roles coming soon."
-      status="partial"
-      statusLabel="1 of 5 roles"
-      headerAction={{ label: 'Open AI settings', href: '/ai' }}
-    >
-      <SetupItemRow
-        name="Embedding provider"
-        meta={
-          session?.connected && provider
-            ? `${PROVIDER_LABELS[provider] || provider} — used for fuzzy/semantic cue matching`
-            : 'Used for fuzzy/semantic cue matching'
-        }
-      />
-    </SetupCard>
+    <>
+      <SetupCard
+        id="ai-models"
+        icon={ModelsIcon}
+        color="purple"
+        title="AI models"
+        description="Choose which model the Assistant role can use, and whether it is enabled site-wide."
+        headerAction={{ label: 'Add model', onClick: openCreate }}
+        status="partial"
+        statusLabel="Role-based"
+      >
+        {content}
+      </SetupCard>
+
+      {open && (
+        <Dialog title={editingModel ? 'Edit AI model' : 'Add AI model'} onClose={closeDialog} width={600}>
+          <form onSubmit={handleSave}>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.85rem' }}>
+              <label style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+                <span style={{ fontWeight: 600 }}>Role</span>
+                <select
+                  value={form.roleCode}
+                  onChange={event => setForm(prev => ({ ...prev, roleCode: event.target.value }))}
+                  style={{ padding: '0.6rem 0.75rem', borderRadius: 6, border: '1px solid var(--color-border)', background: 'var(--color-surface)', color: 'var(--color-text)' }}
+                >
+                  <option value="assistant">Assistant</option>
+                </select>
+              </label>
+
+              <label style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+                <span style={{ fontWeight: 600 }}>Provider</span>
+                <select
+                  value={form.provider}
+                  onChange={event => setForm(prev => ({ ...prev, provider: event.target.value, modelName: '', apiUrl: prev.apiUrl || 'http://localhost:11434' }))}
+                  style={{ padding: '0.6rem 0.75rem', borderRadius: 6, border: '1px solid var(--color-border)', background: 'var(--color-surface)', color: 'var(--color-text)' }}
+                >
+                  <option value="api">API (BYOK)</option>
+                  <option value="ollama">Ollama</option>
+                </select>
+              </label>
+
+              {form.provider === 'ollama' && (
+                <label style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+                  <span style={{ fontWeight: 600 }}>Ollama endpoint</span>
+                  <div style={{ display: 'flex', gap: '0.5rem' }}>
+                    <input
+                      value={form.apiUrl}
+                      onChange={event => setForm(prev => ({ ...prev, apiUrl: event.target.value }))}
+                      placeholder="http://localhost:11434"
+                      style={{ flex: 1, padding: '0.6rem 0.75rem', borderRadius: 6, border: '1px solid var(--color-border)', background: 'var(--color-surface)', color: 'var(--color-text)' }}
+                    />
+                    <button type="button" className="btn btn--ghost btn--sm" onClick={handleDiscover} disabled={discovering}>
+                      {discovering ? 'Discovering…' : 'Discover models'}
+                    </button>
+                  </div>
+                </label>
+              )}
+
+              <label style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+                <span style={{ fontWeight: 600 }}>Model</span>
+                {form.provider === 'ollama' && discoveredModels.length > 0 ? (
+                  <select
+                    value={form.modelName}
+                    onChange={event => setForm(prev => ({ ...prev, modelName: event.target.value }))}
+                    style={{ padding: '0.6rem 0.75rem', borderRadius: 6, border: '1px solid var(--color-border)', background: 'var(--color-surface)', color: 'var(--color-text)' }}
+                  >
+                    {discoveredModels.map(name => <option key={name} value={name}>{name}</option>)}
+                  </select>
+                ) : (
+                  <input
+                    value={form.modelName}
+                    onChange={event => setForm(prev => ({ ...prev, modelName: event.target.value }))}
+                    placeholder={form.provider === 'ollama' ? 'llama3.2' : 'gpt-4o-mini'}
+                    style={{ padding: '0.6rem 0.75rem', borderRadius: 6, border: '1px solid var(--color-border)', background: 'var(--color-surface)', color: 'var(--color-text)' }}
+                  />
+                )}
+              </label>
+
+              {form.provider === 'api' && (
+                <label style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+                  <span style={{ fontWeight: 600 }}>API key</span>
+                  <input
+                    type="password"
+                    value={form.apiKeyValue}
+                    onChange={event => setForm(prev => ({ ...prev, apiKeyValue: event.target.value }))}
+                    placeholder="sk-..."
+                    style={{ padding: '0.6rem 0.75rem', borderRadius: 6, border: '1px solid var(--color-border)', background: 'var(--color-surface)', color: 'var(--color-text)' }}
+                  />
+                </label>
+              )}
+
+              <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                <input type="checkbox" checked={!!form.enabled} onChange={event => setForm(prev => ({ ...prev, enabled: event.target.checked }))} />
+                <span>Enabled</span>
+              </label>
+
+              {error && <div style={{ color: 'var(--color-danger, #c2410c)', fontSize: '0.9rem' }}>{error}</div>}
+            </div>
+
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '1rem' }}>
+              <div>
+                {editingModel && (
+                  <button type="button" className="btn btn--ghost btn--sm" onClick={() => handleDelete(editingModel)}>
+                    Remove
+                  </button>
+                )}
+              </div>
+              <div style={{ display: 'flex', gap: '0.5rem' }}>
+                <button type="button" className="btn btn--ghost btn--sm" onClick={closeDialog}>Cancel</button>
+                <button type="submit" className="btn btn--sm">Save</button>
+              </div>
+            </div>
+          </form>
+        </Dialog>
+      )}
+    </>
   );
 }

--- a/packages/lcyt-web/src/components/setup-hub/McpAccessSection.jsx
+++ b/packages/lcyt-web/src/components/setup-hub/McpAccessSection.jsx
@@ -1,0 +1,233 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useSessionContext } from '../../contexts/SessionContext.jsx';
+import { useUserAuth } from '../../hooks/useUserAuth.js';
+import { createMcpToken, deleteMcpToken, listMcpTokens, updateMcpToken } from '../../lib/aiAdminApi.js';
+import { Dialog } from '../Dialog.jsx';
+import { SetupCard, SetupItemRow } from './SetupCard.jsx';
+import { ApiConnectorsIcon } from './icons.jsx';
+
+const EMPTY_FORM = { label: '', active: true };
+
+export function McpAccessSection() {
+  const session = useSessionContext();
+  const { user, token: userToken, backendUrl: userBackendUrl } = useUserAuth();
+  const backendUrl = userBackendUrl || session?.backendUrl || '';
+  const apiKey = session?.apiKey || '';
+  const [tokens, setTokens] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [open, setOpen] = useState(false);
+  const [editingToken, setEditingToken] = useState(null);
+  const [form, setForm] = useState(EMPTY_FORM);
+  const [createdToken, setCreatedToken] = useState('');
+  const [error, setError] = useState('');
+
+  const creatorName = useMemo(() => user?.name || user?.email || 'You', [user]);
+
+  const load = useCallback(async () => {
+    if (!backendUrl || !userToken || !apiKey) {
+      setTokens([]);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    try {
+      const rows = await listMcpTokens({ backendUrl, token: userToken, apiKey });
+      setTokens(rows);
+    } catch (err) {
+      setTokens([]);
+      setError(err.message || 'Unable to load MCP tokens');
+    } finally {
+      setLoading(false);
+    }
+  }, [apiKey, backendUrl, userToken]);
+
+  useEffect(() => { load(); }, [load]);
+
+  function closeDialog() {
+    setOpen(false);
+    setEditingToken(null);
+    setCreatedToken('');
+    setForm(EMPTY_FORM);
+    setError('');
+  }
+
+  function openCreate() {
+    setEditingToken(null);
+    setCreatedToken('');
+    setForm({ label: '', active: true });
+    setError('');
+    setOpen(true);
+  }
+
+  function openEdit(token) {
+    setEditingToken(token);
+    setCreatedToken('');
+    setForm({ label: token.label, active: token.active });
+    setError('');
+    setOpen(true);
+  }
+
+  async function handleSave(event) {
+    event.preventDefault();
+    if (!form.label.trim()) {
+      setError('Enter a token name');
+      return;
+    }
+    try {
+      const payload = editingToken
+        ? await updateMcpToken({
+            backendUrl,
+            token: userToken,
+            apiKey,
+            id: editingToken.id,
+            label: form.label.trim(),
+            createdByName: creatorName,
+            active: form.active,
+          })
+        : await createMcpToken({
+            backendUrl,
+            token: userToken,
+            apiKey,
+            label: form.label.trim(),
+            createdByName: creatorName,
+            active: form.active,
+          });
+      if (!editingToken && payload?.token) {
+        setCreatedToken(payload.token);
+        await load();
+        return;
+      }
+      await load();
+      closeDialog();
+    } catch (err) {
+      setError(err.message || 'Unable to save token');
+    }
+  }
+
+  async function handleToggle(token) {
+    try {
+      await updateMcpToken({
+        backendUrl,
+        token: userToken,
+        apiKey,
+        id: token.id,
+        label: token.label,
+        createdByName: token.createdByName || creatorName,
+        active: !token.active,
+      });
+      await load();
+    } catch (err) {
+      setError(err.message || 'Unable to update token');
+    }
+  }
+
+  async function handleDelete(token) {
+    if (!confirm(`Revoke ${token.label}?`)) return;
+    try {
+      await deleteMcpToken({ backendUrl, token: userToken, apiKey, id: token.id });
+      await load();
+      if (open) closeDialog();
+    } catch (err) {
+      setError(err.message || 'Unable to revoke token');
+    }
+  }
+
+  const content = loading ? (
+    <p className="setup-card__empty">Loading MCP tokens…</p>
+  ) : tokens.length > 0 ? (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.4rem' }}>
+      {tokens.map(token => (
+        <SetupItemRow
+          key={token.id}
+          name={token.label}
+          meta={`Created by ${token.createdByName || 'Unknown'}`}
+          badge={token.active ? 'Active' : 'Revoked'}
+          toggleOn={token.active}
+          onToggle={() => handleToggle(token)}
+          onSettings={() => openEdit(token)}
+          onDelete={() => handleDelete(token)}
+        />
+      ))}
+    </div>
+  ) : (
+    <p className="setup-card__empty">No MCP tokens yet. Create one to connect Claude Desktop or Code.</p>
+  );
+
+  return (
+    <>
+      <SetupCard
+        id="mcp-access"
+        icon={ApiConnectorsIcon}
+        color="teal"
+        title="MCP access"
+        description="Personal access tokens for MCP clients such as Claude Desktop or Code."
+        headerAction={{ label: 'Add token', onClick: openCreate }}
+      >
+        {content}
+      </SetupCard>
+
+      {open && (
+        <Dialog title={editingToken ? 'Edit MCP token' : 'Create MCP token'} onClose={closeDialog} width={560}>
+          {createdToken ? (
+            <div>
+              <p style={{ marginBottom: '0.75rem' }}>
+                Copy this token now. It will not be shown again.
+              </p>
+              <div style={{ padding: '0.75rem 0.9rem', background: 'var(--color-surface-alt)', borderRadius: 8, fontFamily: 'monospace', wordBreak: 'break-all' }}>
+                {createdToken}
+              </div>
+              <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.5rem', marginTop: '1rem' }}>
+                <button type="button" className="btn btn--ghost btn--sm" onClick={() => navigator.clipboard?.writeText(createdToken).catch(() => {})}>Copy</button>
+                <button type="button" className="btn btn--sm" onClick={closeDialog}>Done</button>
+              </div>
+            </div>
+          ) : (
+            <form onSubmit={handleSave}>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '0.85rem' }}>
+                <label style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+                  <span style={{ fontWeight: 600 }}>Token name</span>
+                  <input
+                    value={form.label}
+                    onChange={event => setForm(prev => ({ ...prev, label: event.target.value }))}
+                    placeholder="Claude Desktop"
+                    style={{ padding: '0.6rem 0.75rem', borderRadius: 6, border: '1px solid var(--color-border)', background: 'var(--color-surface)', color: 'var(--color-text)' }}
+                  />
+                </label>
+
+                <label style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+                  <span style={{ fontWeight: 600 }}>Created by</span>
+                  <input
+                    value={creatorName}
+                    readOnly
+                    style={{ padding: '0.6rem 0.75rem', borderRadius: 6, border: '1px solid var(--color-border)', background: 'var(--color-surface-alt)', color: 'var(--color-text-muted)' }}
+                  />
+                </label>
+
+                <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                  <input type="checkbox" checked={!!form.active} onChange={event => setForm(prev => ({ ...prev, active: event.target.checked }))} />
+                  <span>Active</span>
+                </label>
+
+                {error && <div style={{ color: 'var(--color-danger, #c2410c)', fontSize: '0.9rem' }}>{error}</div>}
+              </div>
+
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '1rem' }}>
+                <div>
+                  {editingToken && (
+                    <button type="button" className="btn btn--ghost btn--sm" onClick={() => handleDelete(editingToken)}>
+                      Revoke token
+                    </button>
+                  )}
+                </div>
+                <div style={{ display: 'flex', gap: '0.5rem' }}>
+                  <button type="button" className="btn btn--ghost btn--sm" onClick={closeDialog}>Cancel</button>
+                  <button type="submit" className="btn btn--sm">Save</button>
+                </div>
+              </div>
+            </form>
+          )}
+        </Dialog>
+      )}
+    </>
+  );
+}

--- a/packages/lcyt-web/src/components/setup-hub/SetupHubPage.jsx
+++ b/packages/lcyt-web/src/components/setup-hub/SetupHubPage.jsx
@@ -14,6 +14,7 @@ import { LanguagesSection } from './LanguagesSection.jsx';
 import { SttSection } from './SttSection.jsx';
 import { StorageSection } from './StorageSection.jsx';
 import { AiModelsSection } from './AiModelsSection.jsx';
+import { McpAccessSection } from './McpAccessSection.jsx';
 import { ConnectorsSection } from './ConnectorsSection.jsx';
 import { useCardFavorites } from '../../lib/cardFavorites.js';
 import { useUserAuth } from '../../hooks/useUserAuth.js';
@@ -113,6 +114,7 @@ export function SetupHubPage() {
 
         {/* ── AI & integrations ── */}
         {isVisible('ai-models') && <AiModelsSection />}
+        {isVisible('mcp-access') && <McpAccessSection />}
         {isVisible('connectors') && <ConnectorsSection />}
 
         {/* ── Workflows — always visible regardless of the active filter

--- a/packages/lcyt-web/src/lib/aiAdminApi.js
+++ b/packages/lcyt-web/src/lib/aiAdminApi.js
@@ -1,0 +1,80 @@
+function makeAuthHeaders({ token, apiKey }) {
+  const headers = {};
+  if (token) headers.Authorization = `Bearer ${token}`;
+  if (apiKey) headers['X-Api-Key'] = apiKey;
+  return headers;
+}
+
+async function requestJson(backendUrl, path, { token, apiKey, method = 'GET', body } = {}) {
+  const headers = { ...(body ? { 'Content-Type': 'application/json' } : {}), ...makeAuthHeaders({ token, apiKey }) };
+  const res = await fetch(`${backendUrl}${path}`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(data.error || 'Request failed');
+  return data;
+}
+
+export async function listMcpTokens({ backendUrl, token, apiKey }) {
+  const data = await requestJson(backendUrl, '/mcp-tokens', { token, apiKey });
+  return data.tokens || [];
+}
+
+export async function createMcpToken({ backendUrl, token, apiKey, label, createdByName, active = true }) {
+  return requestJson(backendUrl, '/mcp-tokens', {
+    token,
+    apiKey,
+    method: 'POST',
+    body: { label, createdByName, active },
+  });
+}
+
+export async function updateMcpToken({ backendUrl, token, apiKey, id, label, createdByName, active }) {
+  return requestJson(backendUrl, `/mcp-tokens/${id}`, {
+    token,
+    apiKey,
+    method: 'PATCH',
+    body: { label, createdByName, active },
+  });
+}
+
+export async function deleteMcpToken({ backendUrl, token, apiKey, id }) {
+  return requestJson(backendUrl, `/mcp-tokens/${id}`, {
+    token,
+    apiKey,
+    method: 'DELETE',
+  });
+}
+
+export async function listAiModels({ backendUrl, token, apiKey }) {
+  const data = await requestJson(backendUrl, '/ai/models', { token, apiKey });
+  return data.models || [];
+}
+
+export async function createAiModel({ backendUrl, token, apiKey, roleCode = 'assistant', provider, modelName, apiUrl, apiKeyValue, enabled = true }) {
+  return requestJson(backendUrl, '/ai/models', {
+    token,
+    apiKey,
+    method: 'POST',
+    body: { roleCode, provider, modelName, apiUrl, apiKeyValue, enabled },
+  });
+}
+
+export async function updateAiModel({ backendUrl, token, apiKey, id, roleCode, provider, modelName, apiUrl, apiKeyValue, enabled }) {
+  return requestJson(backendUrl, `/ai/models/${id}`, {
+    token,
+    apiKey,
+    method: 'PATCH',
+    body: { roleCode, provider, modelName, apiUrl, apiKeyValue, enabled },
+  });
+}
+
+export async function deleteAiModel({ backendUrl, token, apiKey, id }) {
+  return requestJson(backendUrl, `/ai/models/${id}`, {
+    token,
+    apiKey,
+    method: 'DELETE',
+  });
+}

--- a/packages/lcyt-web/src/main.jsx
+++ b/packages/lcyt-web/src/main.jsx
@@ -64,6 +64,7 @@ const AdminUserDetailPage    = lazyImport(() => import('./components/AdminUserDe
 const AdminProjectsPage      = lazyImport(() => import('./components/AdminProjectsPage').then(m => ({ default: m.AdminProjectsPage })));
 const AdminProjectDetailPage = lazyImport(() => import('./components/AdminProjectDetailPage').then(m => ({ default: m.AdminProjectDetailPage })));
 const AdminAuditLogPage      = lazyImport(() => import('./components/AdminAuditLogPage').then(m => ({ default: m.AdminAuditLogPage })));
+const AdminAiModelsPage      = lazyImport(() => import('./components/AdminAiModelsPage.jsx').then(m => ({ default: m.AdminAiModelsPage })));
 const AdminSiteFeaturesPage  = lazyImport(() => import('./components/AdminSiteFeaturesPage').then(m => ({ default: m.AdminSiteFeaturesPage })));
 const AdminTeamsPage         = lazyImport(() => import('./components/AdminTeamsPage').then(m => ({ default: m.AdminTeamsPage })));
 
@@ -207,6 +208,7 @@ function SidebarApp() {
             <Route path="/admin/projects/:key" component={AdminProjectDetailPage} />
             <Route path="/admin/projects" component={AdminProjectsPage} />
             <Route path="/admin/audit-log" component={AdminAuditLogPage} />
+            <Route path="/admin/ai-models" component={AdminAiModelsPage} />
             <Route path="/admin/site-features" component={AdminSiteFeaturesPage} />
             <Route path="/admin/teams" component={AdminTeamsPage} />
             <Route path="/projects" component={ProjectsPage} />

--- a/packages/lcyt-web/test/components/AdminAiModelsPage.test.jsx
+++ b/packages/lcyt-web/test/components/AdminAiModelsPage.test.jsx
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SessionContext } from '../../src/contexts/SessionContext.jsx';
+
+vi.mock('../../src/components/AdminKeyGate.jsx', () => ({ AdminKeyGate: ({ children }) => <div>{children}</div> }));
+vi.mock('../../src/components/AdminTabShell.jsx', () => ({ AdminTabShell: ({ children }) => <div>{children}</div> }));
+vi.mock('../../src/components/setup-hub/AiModelsSection.jsx', () => ({ AiModelsSection: () => <div data-testid="admin-ai-models-section" /> }));
+vi.mock('../../src/components/setup-hub/McpAccessSection.jsx', () => ({ McpAccessSection: () => <div data-testid="admin-mcp-access-section" /> }));
+
+import { AdminAiModelsPage } from '../../src/components/AdminAiModelsPage.jsx';
+
+describe('AdminAiModelsPage', () => {
+  it('renders the shared AI models and MCP access sections', () => {
+    render(
+      <SessionContext.Provider value={{ backendUrl: 'http://localhost:3000' }}>
+        <AdminAiModelsPage />
+      </SessionContext.Provider>
+    );
+
+    expect(screen.getByText('AI Models & MCP Access')).toBeInTheDocument();
+    expect(screen.getByTestId('admin-ai-models-section')).toBeInTheDocument();
+    expect(screen.getByTestId('admin-mcp-access-section')).toBeInTheDocument();
+  });
+});

--- a/packages/lcyt-web/test/components/SetupHubPage.test.jsx
+++ b/packages/lcyt-web/test/components/SetupHubPage.test.jsx
@@ -17,6 +17,7 @@ vi.mock('../../src/components/setup-hub/LanguagesSection.jsx', () => ({ Language
 vi.mock('../../src/components/setup-hub/SttSection.jsx', () => ({ SttSection: () => <div data-testid="stt-section" /> }));
 vi.mock('../../src/components/setup-hub/StorageSection.jsx', () => ({ StorageSection: () => <div data-testid="storage-section" /> }));
 vi.mock('../../src/components/setup-hub/AiModelsSection.jsx', () => ({ AiModelsSection: () => <div data-testid="ai-models-section" /> }));
+vi.mock('../../src/components/setup-hub/McpAccessSection.jsx', () => ({ McpAccessSection: () => <div data-testid="mcp-access-section" /> }));
 vi.mock('../../src/components/setup-hub/ConnectorsSection.jsx', () => ({ ConnectorsSection: () => <div data-testid="connectors-section" /> }));
 
 import { SetupHubPage } from '../../src/components/setup-hub/SetupHubPage.jsx';
@@ -54,6 +55,7 @@ describe('SetupHubPage', () => {
     expect(screen.getByTestId('stt-section')).toBeInTheDocument();
     expect(screen.getByTestId('storage-section')).toBeInTheDocument();
     expect(screen.getByTestId('ai-models-section')).toBeInTheDocument();
+    expect(screen.getByTestId('mcp-access-section')).toBeInTheDocument();
     expect(screen.getByTestId('connectors-section')).toBeInTheDocument();
     expect(screen.getByTestId('languages-section')).toBeInTheDocument();
   });

--- a/packages/plugins/lcyt-agent/src/ai-models.js
+++ b/packages/plugins/lcyt-agent/src/ai-models.js
@@ -1,0 +1,185 @@
+import { createHash, randomBytes } from 'node:crypto';
+
+export function runAiModelMigrations(db) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS ai_model_configs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      api_key TEXT NOT NULL,
+      role_code TEXT NOT NULL DEFAULT 'assistant',
+      provider TEXT NOT NULL DEFAULT 'api',
+      model_name TEXT NOT NULL DEFAULT '',
+      api_url TEXT NOT NULL DEFAULT '',
+      api_key_ref TEXT NOT NULL DEFAULT '',
+      enabled INTEGER NOT NULL DEFAULT 1,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_ai_model_configs_api_key
+      ON ai_model_configs(api_key);
+  `);
+}
+
+export function listAiModelConfigs(db, apiKey) {
+  const rows = db.prepare(`
+    SELECT id, role_code, provider, model_name, api_url, api_key_ref, enabled, created_at, updated_at
+    FROM ai_model_configs
+    WHERE api_key = ?
+    ORDER BY id ASC
+  `).all(apiKey);
+
+  return rows.map(row => ({
+    id: row.id,
+    roleCode: row.role_code,
+    provider: row.provider,
+    modelName: row.model_name,
+    apiUrl: row.api_url,
+    apiKey: '',
+    enabled: row.enabled === 1,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }));
+}
+
+export function getAiModelConfig(db, apiKey, roleCode) {
+  const row = db.prepare(`
+    SELECT id, role_code, provider, model_name, api_url, api_key_ref, enabled, created_at, updated_at
+    FROM ai_model_configs
+    WHERE api_key = ? AND role_code = ?
+    LIMIT 1
+  `).get(apiKey, roleCode);
+
+  if (!row) return null;
+  return {
+    id: row.id,
+    roleCode: row.role_code,
+    provider: row.provider,
+    modelName: row.model_name,
+    apiUrl: row.api_url,
+    apiKey: '',
+    enabled: row.enabled === 1,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export function setAiModelConfig(db, apiKey, opts = {}) {
+  const roleCode = opts.roleCode || 'assistant';
+  const provider = opts.provider || 'api';
+  const modelName = opts.modelName || '';
+  const apiUrl = opts.apiUrl || '';
+  const apiKeyRef = opts.apiKey || '';
+  const enabled = opts.enabled === undefined ? 1 : (opts.enabled ? 1 : 0);
+
+  const existing = db.prepare('SELECT id FROM ai_model_configs WHERE api_key = ? AND role_code = ?').get(apiKey, roleCode);
+  if (existing) {
+    db.prepare(`
+      UPDATE ai_model_configs
+      SET provider = ?, model_name = ?, api_url = ?, api_key_ref = ?, enabled = ?, updated_at = datetime('now')
+      WHERE id = ?
+    `).run(provider, modelName, apiUrl, apiKeyRef, enabled, existing.id);
+    return getAiModelConfig(db, apiKey, roleCode);
+  }
+
+  const info = db.prepare(`
+    INSERT INTO ai_model_configs (api_key, role_code, provider, model_name, api_url, api_key_ref, enabled)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).run(apiKey, roleCode, provider, modelName, apiUrl, apiKeyRef, enabled);
+
+  return getAiModelConfig(db, apiKey, roleCode);
+}
+
+export function deleteAiModelConfig(db, apiKey, id) {
+  const existing = db.prepare('SELECT id FROM ai_model_configs WHERE api_key = ? AND id = ?').get(apiKey, id);
+  if (!existing) return false;
+  db.prepare('DELETE FROM ai_model_configs WHERE api_key = ? AND id = ?').run(apiKey, id);
+  return true;
+}
+
+export function runMcpTokenMigrations(db) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS mcp_tokens (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      api_key TEXT NOT NULL,
+      label TEXT NOT NULL DEFAULT '',
+      token_hash TEXT NOT NULL,
+      active INTEGER NOT NULL DEFAULT 1,
+      created_by_user_id INTEGER,
+      created_by_name TEXT NOT NULL DEFAULT '',
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      last_used_at TEXT,
+      revoked_at TEXT
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_mcp_tokens_api_key
+      ON mcp_tokens(api_key);
+  `);
+}
+
+export function createMcpToken(db, apiKey, opts = {}) {
+  const label = (opts.label || '').trim();
+  if (!label) throw new Error('label is required');
+  const token = `lcytmcp_${randomBytes(32).toString('hex')}`;
+  const tokenHash = createHash('sha256').update(token).digest('hex');
+  const active = opts.active === undefined ? 1 : (opts.active ? 1 : 0);
+  const createdByName = (opts.createdByName || '').trim() || (opts.createdByEmail || '').trim() || 'Unknown';
+  const createdByUserId = opts.createdByUserId ?? null;
+
+  const info = db.prepare(`
+    INSERT INTO mcp_tokens (api_key, label, token_hash, active, created_by_user_id, created_by_name)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `).run(apiKey, label, tokenHash, active, createdByUserId, createdByName);
+
+  return {
+    id: info.lastInsertRowid,
+    token,
+    label,
+    active: active === 1,
+    createdByName,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+export function listMcpTokens(db, apiKey) {
+  const rows = db.prepare(`
+    SELECT id, label, active, created_by_name, created_at, last_used_at, revoked_at
+    FROM mcp_tokens
+    WHERE api_key = ? AND revoked_at IS NULL
+    ORDER BY id ASC
+  `).all(apiKey);
+
+  return rows.map(row => ({
+    id: row.id,
+    label: row.label,
+    active: row.active === 1,
+    createdByName: row.created_by_name,
+    createdAt: row.created_at,
+    lastUsedAt: row.last_used_at,
+    revokedAt: row.revoked_at,
+  }));
+}
+
+export function updateMcpToken(db, apiKey, id, opts = {}) {
+  const existing = db.prepare('SELECT id FROM mcp_tokens WHERE api_key = ? AND id = ? AND revoked_at IS NULL').get(apiKey, id);
+  if (!existing) return null;
+
+  const parts = [];
+  const values = [];
+  if (opts.label !== undefined) { parts.push('label = ?'); values.push((opts.label || '').trim()); }
+  if (opts.active !== undefined) { parts.push('active = ?'); values.push(opts.active ? 1 : 0); }
+  if (opts.createdByName !== undefined) { parts.push('created_by_name = ?'); values.push((opts.createdByName || '').trim()); }
+
+  if (parts.length === 0) return listMcpTokens(db, apiKey).find(item => item.id === id) || null;
+
+  values.push(id);
+  values.unshift(apiKey);
+  db.prepare(`UPDATE mcp_tokens SET ${parts.join(', ')} WHERE api_key = ? AND id = ?`).run(...values);
+  return listMcpTokens(db, apiKey).find(item => item.id === id) || null;
+}
+
+export function revokeMcpToken(db, apiKey, id) {
+  const existing = db.prepare('SELECT id FROM mcp_tokens WHERE api_key = ? AND id = ? AND revoked_at IS NULL').get(apiKey, id);
+  if (!existing) return false;
+  db.prepare("UPDATE mcp_tokens SET revoked_at = datetime('now'), active = 0 WHERE api_key = ? AND id = ?").run(apiKey, id);
+  return true;
+}

--- a/packages/plugins/lcyt-agent/src/api.js
+++ b/packages/plugins/lcyt-agent/src/api.js
@@ -27,6 +27,8 @@
 export { AgentEngine } from './agent-engine.js';
 export { createAgentRouter } from './routes/agent.js';
 export { createAiRouter } from './routes/ai.js';
+export { createAiModelsRouter } from './routes/ai-models.js';
+export { createMcpTokensRouter } from './routes/mcp-tokens.js';
 export { runMigrations } from './db.js';
 
 // Re-export AI config and embedding utilities so the backend can use them
@@ -44,6 +46,19 @@ export {
   isServerEmbeddingAvailable,
 } from './embeddings.js';
 
+export {
+  runAiModelMigrations,
+  listAiModelConfigs,
+  getAiModelConfig,
+  setAiModelConfig,
+  deleteAiModelConfig,
+  runMcpTokenMigrations,
+  createMcpToken,
+  listMcpTokens,
+  updateMcpToken,
+  revokeMcpToken,
+} from './ai-models.js';
+
 /**
  * Run DB migrations and create the AgentEngine instance.
  * Call once at backend startup before mounting any routes.
@@ -59,6 +74,10 @@ export async function initAgent(db, opts = {}) {
   // AI config table migrations (embedding provider config per user)
   const { runAiMigrations } = await import('./ai-config.js');
   runAiMigrations(db);
+
+  const { runAiModelMigrations, runMcpTokenMigrations } = await import('./ai-models.js');
+  runAiModelMigrations(db);
+  runMcpTokenMigrations(db);
 
   const { AgentEngine } = await import('./agent-engine.js');
   const agent = new AgentEngine(db, opts);

--- a/packages/plugins/lcyt-agent/src/routes/ai-models.js
+++ b/packages/plugins/lcyt-agent/src/routes/ai-models.js
@@ -1,0 +1,76 @@
+import { Router } from 'express';
+import { listAiModelConfigs, setAiModelConfig, deleteAiModelConfig } from '../ai-models.js';
+
+function resolveApiKey(req) {
+  const header = req.headers['x-api-key'];
+  if (typeof header === 'string' && header.trim()) return header.trim();
+  const bodyKey = req.body?.apiKey || req.body?.api_key;
+  if (typeof bodyKey === 'string' && bodyKey.trim()) return bodyKey.trim();
+  const queryKey = req.query?.apiKey || req.query?.api_key;
+  if (typeof queryKey === 'string' && queryKey.trim()) return queryKey.trim();
+  return null;
+}
+
+export function createAiModelsRouter(db, auth) {
+  const router = Router();
+
+  router.use(auth);
+
+  router.get('/', (req, res) => {
+    const apiKey = resolveApiKey(req);
+    if (!apiKey) return res.status(400).json({ error: 'x-api-key header or apiKey body field is required' });
+    return res.json({ models: listAiModelConfigs(db, apiKey) });
+  });
+
+  router.post('/', (req, res) => {
+    const apiKey = resolveApiKey(req);
+    if (!apiKey) return res.status(400).json({ error: 'x-api-key header or apiKey body field is required' });
+
+    const model = setAiModelConfig(db, apiKey, {
+      roleCode: req.body?.roleCode || req.body?.role_code || 'assistant',
+      provider: req.body?.provider,
+      modelName: req.body?.modelName || req.body?.model_name,
+      apiUrl: req.body?.apiUrl || req.body?.api_url,
+      apiKey: req.body?.apiKeyValue || req.body?.api_key_value || req.body?.apiKey || req.body?.api_key,
+      enabled: req.body?.enabled,
+    });
+
+    return res.status(201).json({ model });
+  });
+
+  router.patch('/:id', (req, res) => {
+    const apiKey = resolveApiKey(req);
+    if (!apiKey) return res.status(400).json({ error: 'x-api-key header or apiKey body field is required' });
+
+    const id = Number(req.params.id);
+    if (!Number.isFinite(id)) return res.status(400).json({ error: 'Invalid id' });
+
+    const existing = db.prepare('SELECT id FROM ai_model_configs WHERE api_key = ? AND id = ?').get(apiKey, id);
+    if (!existing) return res.status(404).json({ error: 'Model not found' });
+
+    const updated = setAiModelConfig(db, apiKey, {
+      roleCode: req.body?.roleCode || req.body?.role_code,
+      provider: req.body?.provider,
+      modelName: req.body?.modelName || req.body?.model_name,
+      apiUrl: req.body?.apiUrl || req.body?.api_url,
+      apiKey: req.body?.apiKeyValue || req.body?.api_key_value || req.body?.apiKey || req.body?.api_key,
+      enabled: req.body?.enabled,
+    });
+
+    return res.json({ model: updated });
+  });
+
+  router.delete('/:id', (req, res) => {
+    const apiKey = resolveApiKey(req);
+    if (!apiKey) return res.status(400).json({ error: 'x-api-key header or apiKey body field is required' });
+
+    const id = Number(req.params.id);
+    if (!Number.isFinite(id)) return res.status(400).json({ error: 'Invalid id' });
+
+    const deleted = deleteAiModelConfig(db, apiKey, id);
+    if (!deleted) return res.status(404).json({ error: 'Model not found' });
+    return res.json({ ok: true });
+  });
+
+  return router;
+}

--- a/packages/plugins/lcyt-agent/src/routes/mcp-tokens.js
+++ b/packages/plugins/lcyt-agent/src/routes/mcp-tokens.js
@@ -1,0 +1,73 @@
+import { Router } from 'express';
+import { createMcpToken, listMcpTokens, updateMcpToken, revokeMcpToken } from '../ai-models.js';
+
+function resolveApiKey(req) {
+  const header = req.headers['x-api-key'];
+  if (typeof header === 'string' && header.trim()) return header.trim();
+  const bodyKey = req.body?.apiKey || req.body?.api_key;
+  if (typeof bodyKey === 'string' && bodyKey.trim()) return bodyKey.trim();
+  const queryKey = req.query?.apiKey || req.query?.api_key;
+  if (typeof queryKey === 'string' && queryKey.trim()) return queryKey.trim();
+  return null;
+}
+
+export function createMcpTokensRouter(db, auth) {
+  const router = Router();
+
+  router.use(auth);
+
+  router.get('/', (req, res) => {
+    const apiKey = resolveApiKey(req);
+    if (!apiKey) return res.status(400).json({ error: 'x-api-key header or apiKey body field is required' });
+    return res.json({ tokens: listMcpTokens(db, apiKey) });
+  });
+
+  router.post('/', (req, res) => {
+    const apiKey = resolveApiKey(req);
+    if (!apiKey) return res.status(400).json({ error: 'x-api-key header or apiKey body field is required' });
+
+    try {
+      const created = createMcpToken(db, apiKey, {
+        label: req.body?.label,
+        active: req.body?.active,
+        createdByName: req.body?.createdByName || req.body?.created_by_name,
+        createdByEmail: req.user?.email,
+        createdByUserId: req.user?.userId ?? null,
+      });
+      return res.status(201).json(created);
+    } catch (err) {
+      return res.status(400).json({ error: err.message });
+    }
+  });
+
+  router.patch('/:id', (req, res) => {
+    const apiKey = resolveApiKey(req);
+    if (!apiKey) return res.status(400).json({ error: 'x-api-key header or apiKey body field is required' });
+
+    const id = Number(req.params.id);
+    if (!Number.isFinite(id)) return res.status(400).json({ error: 'Invalid id' });
+
+    const updated = updateMcpToken(db, apiKey, id, {
+      label: req.body?.label,
+      active: req.body?.active,
+      createdByName: req.body?.createdByName || req.body?.created_by_name,
+    });
+
+    if (!updated) return res.status(404).json({ error: 'Token not found' });
+    return res.json({ token: updated });
+  });
+
+  router.delete('/:id', (req, res) => {
+    const apiKey = resolveApiKey(req);
+    if (!apiKey) return res.status(400).json({ error: 'x-api-key header or apiKey body field is required' });
+
+    const id = Number(req.params.id);
+    if (!Number.isFinite(id)) return res.status(400).json({ error: 'Invalid id' });
+
+    const revoked = revokeMcpToken(db, apiKey, id);
+    if (!revoked) return res.status(404).json({ error: 'Token not found' });
+    return res.json({ ok: true });
+  });
+
+  return router;
+}


### PR DESCRIPTION
## Summary
- Adds a new admin page for AI models and MCP access
- Adds Setup Hub cards for AI model configuration and MCP personal tokens
- Wires new backend routes/storage for role-based AI model configs and MCP tokens

## Testing
- npm run test:components -w packages/lcyt-web -- test/components/SetupHubPage.test.jsx test/components/AdminAiModelsPage.test.jsx
- npm run build -w packages/lcyt-web