### PR TITLE
Viewer icon toggle + Icons setup-hub card

### DIFF
--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -67,6 +67,7 @@ All planning documents live in [`docs/plans/`](plans/). This index lists each pl
 
 ### Pending
 | [plan_help.md](plans/plan_help.md) | Help Page Screenshot Capture | Programmatic Playwright screenshot capture of all significant lcyt-web UI views for the user-facing help page. | |
+| [plan_viewer_icons.md](plans/plan_viewer_icons.md) | Viewer Icon Toggle + Icons Setup-Hub Card | Operator-side "show icon" enable/disable toggle plus the existing which-icon picker in Targets → Viewer, persisted server-side by new `caption_targets.icon_id`/`icon_enabled` columns (fixing the current silent drop of `iconId` on the `/targets` path), and a new Setup-Hub "Icons" card wrapping the existing upload/list/delete icon management. Operator-only; no viewer-page end-user control. | |
 
 ### Draft
 

--- a/docs/plans/plan_viewer_icons.md
+++ b/docs/plans/plan_viewer_icons.md
@@ -1,0 +1,88 @@
+# Plan — Viewer Icon Toggle + Icons Setup-Hub Card
+
+**Status:** pending
+**Scope:** `lcyt-backend` (caption_targets schema/db/routes), `lcyt-web` (TargetRow, Setup Hub, i18n)
+
+## Motivation
+
+Icons brand the public viewer page (`/view/:key`). Today an operator picks
+*which* icon in **CC → Targets → Viewer** (`TargetRow.jsx`): a dropdown with a
+"None" option, whose `iconId` is baked into the generated viewer URL as
+`?icon=<id>` and rendered by `ViewerPage.jsx`.
+
+Two problems:
+
+1. **No explicit enable/disable.** "None" implicitly means off, but toggling
+   branding off loses the chosen icon — you must re-pick it to turn it back on.
+   The operator wants a clear "show icon" toggle *plus* the which-icon picker.
+
+2. **`iconId` doesn't persist server-side.** The config is edited in two places
+   that share `TargetRow` but persist differently:
+   - **CCModal / TargetsPanel** → `targetConfig.js` (localStorage, whole-array
+     `JSON.stringify`) — `iconId` survives (no field whitelist).
+   - **CaptionTargetsManager + Setup-hub "Caption targets" card** → server
+     `/targets` (`caption_targets` table) — **`iconId` is silently dropped**;
+     the table has no icon column and `createTarget`/`updateTarget` ignore it.
+
+   So the icon selection only sticks in the localStorage editor and evaporates
+   in the server-backed one. A reliable toggle requires fixing the server path.
+
+Separately, icon management currently only lives in `SettingsModal`'s "Icons"
+tab; there is no Setup-Hub card for it. We want an **Icons** hub card.
+
+## Decisions (settled with the user)
+
+- **Operator config only.** No viewer-page end-user control, no public
+  icon-list endpoint. The toggle lives in the operator's Targets → Viewer editor.
+- Add the Setup-Hub **Icons** card as part of this work.
+
+## A. Backend — persist icon config on `caption_targets`
+
+1. `src/db/schema.js`: additive migration adding to `caption_targets`:
+   - `icon_id INTEGER` (nullable)
+   - `icon_enabled INTEGER NOT NULL DEFAULT 0`
+   Existing rows are unaffected (nullable / defaulted).
+2. `src/db/caption-targets.js`:
+   - `formatRow()` exposes `iconId` / `iconEnabled`.
+   - `createTarget` / `updateTarget` accept and write both (meaningful only for
+     `type='viewer'`, mirroring how `viewerKey` is gated).
+3. `src/routes/targets.js`: pass the two fields through the request body.
+4. Test: round-trip `iconId` / `iconEnabled` through create → get → update in
+   `test/targets.test.js`.
+
+## B. Frontend — operator toggle in `TargetRow` (viewer section)
+
+1. Add a **"Show icon on viewer page"** toggle bound to `entry.iconEnabled`,
+   above the existing which-icon dropdown.
+2. Gate the dropdown on the toggle (disabled/dimmed when off) and **preserve
+   `iconId`** when toggled off, so re-enabling keeps the choice.
+3. Viewer-URL builder: append `&icon=` only when `iconEnabled && iconId`
+   (currently keys off `iconId` alone).
+4. i18n: `settings.targets.viewerIconEnabled` label + hint in `en` / `fi` / `sv`.
+5. Both editors then round-trip the fields (localStorage already generic;
+   server covered by A).
+
+## C. Setup Hub — new "Icons" card
+
+1. `setup-hub/icons.jsx`: add an `IconsIcon` (stroke, 16×16, matching the set).
+2. New `setup-hub/IconsSection.jsx`, modeled on `StorageSection`: a `SetupCard`
+   + `Dialog` that lists icons (`session.listIcons()` → `GET /icons`), uploads
+   (`POST /icons`, PNG/SVG ≤ 200 KB), and deletes (`DELETE /icons/:id`) —
+   reusing the logic already in `SettingsModal`'s icons tab. Summary row shows
+   the icon count.
+3. `SetupHubPage.jsx`: import + render `{isVisible('icons') && <IconsSection />}`
+   in the appropriate category group. Icons aren't feature-gated, so the card is
+   always visible; left out of `cardIdsForEnabledFeatures` ("Workflow") unless a
+   feature tie is requested. `/setup/icons` deep-linking works from the card id.
+4. Update `packages/lcyt-web/CLAUDE.md` (setup-hub section list + note).
+
+## Out of scope
+
+- Viewer-page end-user icon control and any public icon-list endpoint (per the
+  "operator config only" decision).
+
+## Test / verification
+
+- Backend: `caption-targets` icon-field round-trip; `/targets` route passthrough.
+- Frontend: `TargetRow` toggle behavior — viewer URL includes `&icon=` only when
+  enabled *and* an icon is selected; toggling off preserves `iconId`.

--- a/packages/lcyt-backend/src/db/caption-targets.js
+++ b/packages/lcyt-backend/src/db/caption-targets.js
@@ -10,22 +10,36 @@ import { randomUUID } from 'node:crypto';
 const VALID_TYPES = new Set(['youtube', 'generic', 'viewer']);
 
 /**
+ * Normalise an incoming icon id to a positive integer or null.
+ * Accepts numbers or numeric strings; anything else (or <= 0) becomes null.
+ * @param {*} v
+ * @returns {number|null}
+ */
+function normalizeIconId(v) {
+  if (v === null || v === undefined || v === '') return null;
+  const n = Math.trunc(Number(v));
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+/**
  * @param {object} row
  * @returns {object}
  */
 function formatRow(row) {
   return {
-    id:        row.id,
-    type:      row.type,
-    enabled:   row.enabled === 1,
-    sortOrder: row.sort_order,
-    streamKey: row.stream_key ?? null,
-    url:       row.url ?? null,
-    headers:   row.headers ? JSON.parse(row.headers) : null,
-    viewerKey: row.viewer_key ?? null,
-    noBatch:   row.no_batch === 1,
-    createdAt: row.created_at,
-    updatedAt: row.updated_at,
+    id:          row.id,
+    type:        row.type,
+    enabled:     row.enabled === 1,
+    sortOrder:   row.sort_order,
+    streamKey:   row.stream_key ?? null,
+    url:         row.url ?? null,
+    headers:     row.headers ? JSON.parse(row.headers) : null,
+    viewerKey:   row.viewer_key ?? null,
+    iconId:      row.icon_id ?? null,
+    iconEnabled: row.icon_enabled === 1,
+    noBatch:     row.no_batch === 1,
+    createdAt:   row.created_at,
+    updatedAt:   row.updated_at,
   };
 }
 
@@ -87,11 +101,11 @@ function validateTypeFields(type, { streamKey, url, viewerKey }) {
  * Create a caption target for an API key.
  * @param {import('better-sqlite3').Database} db
  * @param {string} apiKey
- * @param {{ id?: string, type: string, enabled?: boolean, streamKey?: string, url?: string, headers?: object, viewerKey?: string, noBatch?: boolean }} fields
+ * @param {{ id?: string, type: string, enabled?: boolean, streamKey?: string, url?: string, headers?: object, viewerKey?: string, iconId?: number|null, iconEnabled?: boolean, noBatch?: boolean }} fields
  * @returns {{ ok: true, target: object }|{ ok: false, error: string }}
  */
 export function createCaptionTarget(db, apiKey, fields = {}) {
-  const { id = randomUUID(), type, enabled = true, streamKey = null, url = null, headers = null, viewerKey = null, noBatch = false } = fields;
+  const { id = randomUUID(), type, enabled = true, streamKey = null, url = null, headers = null, viewerKey = null, iconId = null, iconEnabled = false, noBatch = false } = fields;
 
   const error = validateTypeFields(type, { streamKey, url, viewerKey });
   if (error) return { ok: false, error };
@@ -99,14 +113,16 @@ export function createCaptionTarget(db, apiKey, fields = {}) {
   const { maxOrder } = db.prepare('SELECT COALESCE(MAX(sort_order), -1) AS maxOrder FROM caption_targets WHERE api_key = ?').get(apiKey);
 
   db.prepare(`
-    INSERT INTO caption_targets (id, api_key, type, enabled, sort_order, stream_key, url, headers, viewer_key, no_batch)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO caption_targets (id, api_key, type, enabled, sort_order, stream_key, url, headers, viewer_key, icon_id, icon_enabled, no_batch)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
     id, apiKey, type, enabled ? 1 : 0, maxOrder + 1,
     type === 'youtube' ? streamKey.trim() : null,
     type === 'generic' ? url : null,
     type === 'generic' && headers && typeof headers === 'object' ? JSON.stringify(headers) : null,
     type === 'viewer' ? viewerKey : null,
+    type === 'viewer' ? normalizeIconId(iconId) : null,
+    type === 'viewer' && iconEnabled ? 1 : 0,
     noBatch ? 1 : 0,
   );
   return { ok: true, target: getCaptionTarget(db, apiKey, id) };
@@ -117,7 +133,7 @@ export function createCaptionTarget(db, apiKey, fields = {}) {
  * @param {import('better-sqlite3').Database} db
  * @param {string} apiKey
  * @param {string} id
- * @param {{ enabled?: boolean, streamKey?: string, url?: string, headers?: object, viewerKey?: string, noBatch?: boolean }} patch
+ * @param {{ enabled?: boolean, streamKey?: string, url?: string, headers?: object, viewerKey?: string, iconId?: number|null, iconEnabled?: boolean, noBatch?: boolean }} patch
  * @returns {{ ok: true, target: object }|{ ok: false, error: string, status?: number }}
  */
 export function updateCaptionTarget(db, apiKey, id, patch = {}) {
@@ -135,15 +151,20 @@ export function updateCaptionTarget(db, apiKey, id, patch = {}) {
     ? (patch.headers && typeof patch.headers === 'object' ? JSON.stringify(patch.headers) : null)
     : existing.headers;
 
+  const iconId = patch.iconId !== undefined ? normalizeIconId(patch.iconId) : existing.icon_id;
+  const iconEnabled = patch.iconEnabled !== undefined ? (patch.iconEnabled ? 1 : 0) : existing.icon_enabled;
+
   db.prepare(`
     UPDATE caption_targets SET
-      enabled    = ?,
-      stream_key = ?,
-      url        = ?,
-      headers    = ?,
-      viewer_key = ?,
-      no_batch   = ?,
-      updated_at = datetime('now')
+      enabled      = ?,
+      stream_key   = ?,
+      url          = ?,
+      headers      = ?,
+      viewer_key   = ?,
+      icon_id      = ?,
+      icon_enabled = ?,
+      no_batch     = ?,
+      updated_at   = datetime('now')
     WHERE api_key = ? AND id = ?
   `).run(
     patch.enabled !== undefined ? (patch.enabled ? 1 : 0) : existing.enabled,
@@ -151,6 +172,8 @@ export function updateCaptionTarget(db, apiKey, id, patch = {}) {
     existing.type === 'generic' ? url : null,
     existing.type === 'generic' ? headers : null,
     existing.type === 'viewer' ? viewerKey : null,
+    existing.type === 'viewer' ? iconId : null,
+    existing.type === 'viewer' ? iconEnabled : 0,
     patch.noBatch !== undefined ? (patch.noBatch ? 1 : 0) : existing.no_batch,
     apiKey, id,
   );

--- a/packages/lcyt-backend/src/db/schema.js
+++ b/packages/lcyt-backend/src/db/schema.js
@@ -346,6 +346,22 @@ export function initDb(dbPath) {
   `);
   db.exec('CREATE INDEX IF NOT EXISTS idx_caption_targets_api_key ON caption_targets(api_key)');
 
+  // Additive migration: per-viewer-target icon branding.
+  // icon_id references an icons(id) row (nullable — no icon chosen); icon_enabled
+  // is an explicit show/hide toggle so operators can turn branding off without
+  // losing the selected icon. Only meaningful for type='viewer'.
+  {
+    const captionTargetsCols = new Set(
+      db.prepare('PRAGMA table_info(caption_targets)').all().map(c => c.name)
+    );
+    if (!captionTargetsCols.has('icon_id')) {
+      db.exec('ALTER TABLE caption_targets ADD COLUMN icon_id INTEGER');
+    }
+    if (!captionTargetsCols.has('icon_enabled')) {
+      db.exec('ALTER TABLE caption_targets ADD COLUMN icon_enabled INTEGER NOT NULL DEFAULT 0');
+    }
+  }
+
   db.exec(`
     CREATE TABLE IF NOT EXISTS translation_vendor_config (
       api_key        TEXT PRIMARY KEY REFERENCES api_keys(key) ON DELETE CASCADE,

--- a/packages/lcyt-backend/src/routes/targets.js
+++ b/packages/lcyt-backend/src/routes/targets.js
@@ -33,8 +33,8 @@ export function createTargetsRouter(auth, db) {
   });
 
   router.post('/', auth, (req, res) => {
-    const { id, type, enabled, streamKey, url, headers, viewerKey, noBatch } = req.body || {};
-    const result = createCaptionTarget(db, req.session.apiKey, { id, type, enabled, streamKey, url, headers, viewerKey, noBatch });
+    const { id, type, enabled, streamKey, url, headers, viewerKey, iconId, iconEnabled, noBatch } = req.body || {};
+    const result = createCaptionTarget(db, req.session.apiKey, { id, type, enabled, streamKey, url, headers, viewerKey, iconId, iconEnabled, noBatch });
     if (!result.ok) return res.status(400).json({ error: result.error });
     res.status(201).json({ ok: true, target: result.target });
   });
@@ -48,8 +48,8 @@ export function createTargetsRouter(auth, db) {
   });
 
   router.put('/:id', auth, (req, res) => {
-    const { enabled, streamKey, url, headers, viewerKey, noBatch } = req.body || {};
-    const result = updateCaptionTarget(db, req.session.apiKey, req.params.id, { enabled, streamKey, url, headers, viewerKey, noBatch });
+    const { enabled, streamKey, url, headers, viewerKey, iconId, iconEnabled, noBatch } = req.body || {};
+    const result = updateCaptionTarget(db, req.session.apiKey, req.params.id, { enabled, streamKey, url, headers, viewerKey, iconId, iconEnabled, noBatch });
     if (!result.ok) return res.status(result.status || 400).json({ error: result.error });
     res.json({ ok: true, target: result.target });
   });

--- a/packages/lcyt-backend/test/targets.test.js
+++ b/packages/lcyt-backend/test/targets.test.js
@@ -173,3 +173,55 @@ describe('/targets', () => {
     assert.deepEqual(body.targets, []);
   });
 });
+
+describe('/targets — viewer icon config', () => {
+  it('defaults iconId=null and iconEnabled=false on a new viewer target', async () => {
+    const body = await (await post('/targets', { type: 'viewer', viewerKey: 'icon-default' })).json();
+    assert.equal(body.target.iconId, null);
+    assert.equal(body.target.iconEnabled, false);
+  });
+
+  it('persists iconId + iconEnabled through create', async () => {
+    const body = await (await post('/targets', { type: 'viewer', viewerKey: 'icon-create', iconId: 7, iconEnabled: true })).json();
+    assert.equal(body.target.iconId, 7);
+    assert.equal(body.target.iconEnabled, true);
+  });
+
+  it('round-trips iconId + iconEnabled through GET', async () => {
+    const created = await (await post('/targets', { type: 'viewer', viewerKey: 'icon-get', iconId: 3, iconEnabled: true })).json();
+    const list = await (await get()).json();
+    const found = list.targets.find(t => t.id === created.target.id);
+    assert.equal(found.iconId, 3);
+    assert.equal(found.iconEnabled, true);
+  });
+
+  it('updates iconId + iconEnabled and preserves iconId when only toggling off', async () => {
+    const created = await (await post('/targets', { type: 'viewer', viewerKey: 'icon-update', iconId: 5, iconEnabled: true })).json();
+    const id = created.target.id;
+
+    // Toggle off without sending iconId — the chosen icon must be preserved.
+    let body = await (await put(`/targets/${id}`, { iconEnabled: false })).json();
+    assert.equal(body.target.iconEnabled, false);
+    assert.equal(body.target.iconId, 5);
+
+    // Re-enable and change the icon.
+    body = await (await put(`/targets/${id}`, { iconEnabled: true, iconId: 9 })).json();
+    assert.equal(body.target.iconEnabled, true);
+    assert.equal(body.target.iconId, 9);
+
+    // Clearing the icon.
+    body = await (await put(`/targets/${id}`, { iconId: null })).json();
+    assert.equal(body.target.iconId, null);
+  });
+
+  it('normalizes invalid iconId to null', async () => {
+    const body = await (await post('/targets', { type: 'viewer', viewerKey: 'icon-bad', iconId: 'abc', iconEnabled: true })).json();
+    assert.equal(body.target.iconId, null);
+  });
+
+  it('ignores icon fields on non-viewer targets', async () => {
+    const body = await (await post('/targets', { type: 'youtube', streamKey: 'yt-icon', iconId: 4, iconEnabled: true })).json();
+    assert.equal(body.target.iconId, null);
+    assert.equal(body.target.iconEnabled, false);
+  });
+});

--- a/packages/lcyt-web/CLAUDE.md
+++ b/packages/lcyt-web/CLAUDE.md
@@ -43,7 +43,7 @@ Browser-based React app using Vite and **wouter** for routing. Uses sidebar navi
 | `/team` | `TeamPage` | Organization/team management (backed by the `/orgs` backend routes: members, roles, org projects) |
 | `/setup` | `SetupHubPage` | Persistent device/service catalog — every card has an `id` and is deep-linkable |
 | `/setup/wizard` | `SetupWizardPage` | Guided one-time setup wizard (superseded by the hub as the default `/setup` destination, still reachable) |
-| `/setup/:card` | `SetupHubPage` | Deep link — same page as `/setup`, with the card whose `id` matches `:card` (e.g. `connectors`, `cameras`, `stt`, `storage`) scrolled into view and highlighted for 10s |
+| `/setup/:card` | `SetupHubPage` | Deep link — same page as `/setup`, with the card whose `id` matches `:card` (e.g. `connectors`, `cameras`, `stt`, `storage`, `icons`) scrolled into view and highlighted for 10s |
 | `/setup/:card/page` | `SetupStandalonePage` | Full-page equivalent of a card (`cameras`\|`mixers`\|`encoders`\|`bridges`\|`viewports`\|`caption-targets` only) with a banner linking back to the hub card — device/config-manager cards render the same manager component non-embedded; `viewports` renders the full `DskViewportsPage` editor (text layers, present-to-screen) since those don't fit the card's item-row model. Cards without a real standalone-page duplicate (Egress — `/broadcast` covers more than just relay targets — Storage, STT, etc.) don't route here. |
 | `/account` | `AccountPage` | Login/register or user profile |
 | `/settings` | `SettingsPage` | Unified settings (General, CC, I/O tabs) |

--- a/packages/lcyt-web/src/components/TargetCaptionsPage.jsx
+++ b/packages/lcyt-web/src/components/TargetCaptionsPage.jsx
@@ -101,8 +101,8 @@ export const CaptionTargetsManager = forwardRef(function CaptionTargetsManager({
     }
     const isNew = editing === 'new';
     const body = isNew
-      ? { type: draft.type, streamKey: draft.streamKey, url: draft.url, headers, viewerKey: draft.viewerKey, noBatch: draft.noBatch }
-      : { enabled: draft.enabled, streamKey: draft.streamKey, url: draft.url, headers, viewerKey: draft.viewerKey, noBatch: draft.noBatch };
+      ? { type: draft.type, streamKey: draft.streamKey, url: draft.url, headers, viewerKey: draft.viewerKey, iconId: draft.iconId, iconEnabled: draft.iconEnabled, noBatch: draft.noBatch }
+      : { enabled: draft.enabled, streamKey: draft.streamKey, url: draft.url, headers, viewerKey: draft.viewerKey, iconId: draft.iconId, iconEnabled: draft.iconEnabled, noBatch: draft.noBatch };
     try {
       const r = await authedFetch(isNew ? '/targets' : `/targets/${editing.id}`, {
         method: isNew ? 'POST' : 'PUT',

--- a/packages/lcyt-web/src/components/panels/TargetRow.jsx
+++ b/packages/lcyt-web/src/components/panels/TargetRow.jsx
@@ -61,8 +61,13 @@ export function TargetRow({
   }
 
   const isValidViewerKey = entry.type === 'viewer' && entry.viewerKey && /^[a-zA-Z0-9_-]{3,}$/.test(entry.viewerKey);
+  // Effective "show icon" flag. `iconEnabled` is the explicit toggle; when it's
+  // never been set (legacy configs saved before the toggle existed) fall back to
+  // the old implicit rule "on if an icon is selected" so branding doesn't vanish
+  // on upgrade.
+  const iconOn = entry.iconEnabled ?? (entry.iconId != null);
   const viewerPageUrl = (isValidViewerKey && backendUrl)
-    ? `${window.location.origin}/view/${encodeURIComponent(entry.viewerKey)}?server=${encodeURIComponent(backendUrl)}${entry.iconId ? `&icon=${entry.iconId}` : ''}`
+    ? `${window.location.origin}/view/${encodeURIComponent(entry.viewerKey)}?server=${encodeURIComponent(backendUrl)}${iconOn && entry.iconId ? `&icon=${entry.iconId}` : ''}`
     : null;
   const headersValue = typeof entry.headers === 'string'
     ? entry.headers
@@ -182,11 +187,19 @@ export function TargetRow({
           {viewerKeyError && <span className="settings-field__hint" style={{ color: 'var(--color-error, #c00)' }}>{viewerKeyError}</span>}
           <span className="settings-field__hint">{t('settings.targets.viewerKeyHint')}</span>
 
-          <label className="settings-field__label" style={{ marginTop: 8 }}>{t('settings.targets.viewerIcon')}</label>
+          <label className="settings-field__label" style={{ marginTop: 8, display: 'flex', alignItems: 'center', gap: 8 }}>
+            <input
+              type="checkbox"
+              checked={iconOn}
+              onChange={e => onChange({ ...entry, iconEnabled: e.target.checked })}
+            />
+            {t('settings.targets.viewerIconEnabled')}
+          </label>
           <select
             className="settings-field__input"
-            style={{ width: 'auto' }}
+            style={{ width: 'auto', marginTop: 4 }}
             value={entry.iconId || ''}
+            disabled={!iconOn}
             onChange={e => onChange({ ...entry, iconId: e.target.value ? Number(e.target.value) : null })}
           >
             <option value="">{t('settings.targets.viewerIconNone')}</option>

--- a/packages/lcyt-web/src/components/setup-hub/IconsSection.jsx
+++ b/packages/lcyt-web/src/components/setup-hub/IconsSection.jsx
@@ -1,0 +1,145 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useSessionContext } from '../../contexts/SessionContext';
+import { useToast } from '../../hooks/useToast.js';
+import { SetupCard, SetupItemRow } from './SetupCard.jsx';
+import { IconsIcon } from './icons.jsx';
+import { Dialog } from '../Dialog.jsx';
+
+const ALLOWED_TYPES = ['image/png', 'image/svg+xml'];
+const MAX_BYTES = 200 * 1024;
+
+/**
+ * IconsSection — viewer-branding icon management (PNG/SVG), wrapping the same
+ * `GET/POST/DELETE /icons` endpoints as the Settings → Icons tab. Icons uploaded
+ * here are chosen per viewer target in CC → Targets → Viewer (see `TargetRow`).
+ * Upload/list/delete open in a Dialog off the card's summary row.
+ */
+export function IconsSection() {
+  const session = useSessionContext();
+  const connected = session?.connected;
+  const backendUrl = session?.backendUrl;
+  const { showToast } = useToast();
+
+  const [icons, setIcons] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [open, setOpen] = useState(false);
+  const fileRef = useRef(null);
+
+  const load = useCallback(async () => {
+    if (!connected) return;
+    setLoading(true);
+    try {
+      const data = await session.listIcons();
+      setIcons(data.icons || []);
+    } catch {
+      setIcons([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [connected, session]);
+
+  useEffect(() => { load(); }, [load]);
+
+  async function handleUpload(e) {
+    const file = e.target.files?.[0];
+    if (fileRef.current) fileRef.current.value = '';
+    if (!file) return;
+
+    if (!ALLOWED_TYPES.includes(file.type)) {
+      showToast('Only PNG and SVG icons are allowed', 'error');
+      return;
+    }
+    if (file.size > MAX_BYTES) {
+      showToast('Icon must be 200 KB or smaller', 'error');
+      return;
+    }
+    try {
+      const arrayBuf = await file.arrayBuffer();
+      const base64 = btoa(String.fromCharCode(...new Uint8Array(arrayBuf)));
+      const result = await session.uploadIcon({ filename: file.name, mimeType: file.type, data: base64 });
+      setIcons(prev => [{ id: result.id, filename: result.filename, mimeType: result.mimeType, sizeBytes: result.sizeBytes }, ...prev]);
+      showToast(`${result.filename} uploaded`, 'success');
+    } catch (err) {
+      showToast(err.message || 'Upload failed', 'error');
+    }
+  }
+
+  async function handleDelete(id) {
+    if (!window.confirm('Delete this icon?')) return;
+    try {
+      await session.deleteIcon(id);
+      setIcons(prev => prev.filter(ic => ic.id !== id));
+    } catch (err) {
+      showToast(err.message || 'Failed to delete icon', 'error');
+    }
+  }
+
+  const count = icons.length;
+
+  return (
+    <SetupCard
+      id="icons"
+      icon={IconsIcon}
+      color="teal"
+      title="Icons"
+      description="PNG/SVG logos for branding the public viewer page. Pick one per viewer target in CC → Targets → Viewer."
+      status="ready"
+      statusLabel={connected ? `${count} icon${count === 1 ? '' : 's'}` : undefined}
+      headerAction={{ label: 'Manage', onClick: () => setOpen(true) }}
+    >
+      {!connected ? (
+        <p className="setup-card__empty">Connect to a project to manage icons.</p>
+      ) : loading ? (
+        <p className="setup-card__empty">Loading…</p>
+      ) : count === 0 ? (
+        <p className="setup-card__empty">No icons uploaded yet.</p>
+      ) : (
+        <SetupItemRow
+          name={count === 1 ? icons[0].filename : `${count} icons`}
+          meta={count === 1 ? 'Uploaded' : 'Uploaded'}
+          onSettings={() => setOpen(true)}
+        />
+      )}
+
+      {open && (
+        <Dialog title="Icons" onClose={() => setOpen(false)}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+            {!connected ? (
+              <p style={{ color: 'var(--color-text-muted)' }}>Connect to a project to manage icons.</p>
+            ) : (
+              <>
+                <div className="settings-field">
+                  <label className="settings-field__label">Upload icon (PNG or SVG, ≤ 200 KB)</label>
+                  <input
+                    ref={fileRef}
+                    type="file"
+                    accept="image/png,image/svg+xml"
+                    onChange={handleUpload}
+                  />
+                </div>
+
+                {icons.length === 0 ? (
+                  <p style={{ color: 'var(--color-text-muted)', margin: 0 }}>No icons uploaded yet.</p>
+                ) : (
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                    {icons.map(icon => (
+                      <div key={icon.id} style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                        <img
+                          src={`${backendUrl}/icons/${icon.id}`}
+                          alt=""
+                          style={{ width: 28, height: 28, objectFit: 'contain', borderRadius: 4, background: 'var(--color-surface-alt)', flexShrink: 0 }}
+                        />
+                        <span style={{ flex: 1, minWidth: 0, wordBreak: 'break-all', fontSize: '0.9em' }}>{icon.filename}</span>
+                        <button type="button" className="btn btn--ghost btn--sm" onClick={() => handleDelete(icon.id)}>Delete</button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+        </Dialog>
+      )}
+    </SetupCard>
+  );
+}

--- a/packages/lcyt-web/src/components/setup-hub/SetupHubPage.jsx
+++ b/packages/lcyt-web/src/components/setup-hub/SetupHubPage.jsx
@@ -10,6 +10,7 @@ import { IngestionSection } from './IngestionSection.jsx';
 import { WebRadioSection } from './WebRadioSection.jsx';
 import { ViewportsSection } from './ViewportsSection.jsx';
 import { CaptionTargetsSection } from './CaptionTargetsSection.jsx';
+import { IconsSection } from './IconsSection.jsx';
 import { LanguagesSection } from './LanguagesSection.jsx';
 import { SttSection } from './SttSection.jsx';
 import { StorageSection } from './StorageSection.jsx';
@@ -106,6 +107,7 @@ export function SetupHubPage() {
 
         {/* ── Captions & language ── */}
         {isVisible('caption-targets') && <CaptionTargetsSection />}
+        {isVisible('icons') && <IconsSection />}
         {isVisible('languages') && <LanguagesSection />}
 
         {/* ── Speech & storage ── */}

--- a/packages/lcyt-web/src/components/setup-hub/icons.jsx
+++ b/packages/lcyt-web/src/components/setup-hub/icons.jsx
@@ -134,6 +134,16 @@ export function StorageIcon() {
   );
 }
 
+export function IconsIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+      <rect x="2" y="2.5" width="12" height="11" rx="1.5" stroke="currentColor" strokeWidth="1.3" />
+      <circle cx="5.5" cy="6" r="1.1" stroke="currentColor" strokeWidth="1.2" />
+      <path d="M2.5 11.5L6 8.5L8.5 10.5L11 7.5L13.5 10" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
 export function ModelsIcon() {
   return (
     <svg width="16" height="16" viewBox="0 0 16 16" fill="none">

--- a/packages/lcyt-web/src/locales/en.js
+++ b/packages/lcyt-web/src/locales/en.js
@@ -224,6 +224,7 @@ export default {
       viewerQrTitle: 'QR code',
       viewerQrHint: 'Scan to open the viewer page',
       viewerIcon: 'Icon',
+      viewerIconEnabled: 'Show icon on viewer page',
       viewerIconNone: 'None',
       viewerIconHint: 'Choose an icon to display in the top-right corner of the viewer page. Upload icons in Settings → Icons.',
       noBatch: 'Disable batch sending for this target',

--- a/packages/lcyt-web/src/locales/fi.js
+++ b/packages/lcyt-web/src/locales/fi.js
@@ -202,6 +202,7 @@ export default {
       viewerQrTitle: 'QR-koodi',
       viewerQrHint: 'Skannaa avataksesi katsojan sivun',
       viewerIcon: 'Kuvake',
+      viewerIconEnabled: 'Näytä kuvake katsojan sivulla',
       viewerIconNone: 'Ei mitään',
       viewerIconHint: 'Valitse kuvake, joka näytetään katsojan sivun oikeassa yläkulmassa. Lataa kuvakkeita Asetukset → Kuvakkeet.',
       noBatch: 'Poista erälähetys käytöstä tässä kohteessa',

--- a/packages/lcyt-web/src/locales/sv.js
+++ b/packages/lcyt-web/src/locales/sv.js
@@ -203,6 +203,7 @@ export default {
       viewerQrTitle: 'QR-kod',
       viewerQrHint: 'Skanna för att öppna tittar-sidan',
       viewerIcon: 'Ikon',
+      viewerIconEnabled: 'Visa ikon på tittar-sidan',
       viewerIconNone: 'Ingen',
       viewerIconHint: 'Välj en ikon att visa i övre högra hörnet på tittar-sidan. Ladda upp ikoner i Inställningar → Ikoner.',
       noBatch: 'Inaktivera batchsändning för detta mål',

--- a/packages/lcyt-web/test/components/TargetRow.test.jsx
+++ b/packages/lcyt-web/test/components/TargetRow.test.jsx
@@ -1,0 +1,73 @@
+/**
+ * Tests for TargetRow — focus on the viewer icon toggle (iconEnabled) and its
+ * effect on the generated viewer URL and the icon dropdown.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TargetRow } from '../../src/components/panels/TargetRow.jsx';
+import { LangProvider } from '../../src/contexts/LangContext.jsx';
+
+const BACKEND = 'https://api.example.com';
+const ICONS = [{ id: 1, filename: 'logo.png' }, { id: 2, filename: 'mark.svg' }];
+
+function renderRow(entry, onChange = vi.fn()) {
+  const utils = render(
+    <LangProvider>
+      <TargetRow entry={entry} onChange={onChange} onRemove={vi.fn()} backendUrl={BACKEND} icons={ICONS} />
+    </LangProvider>,
+  );
+  return { onChange, ...utils };
+}
+
+function viewerLink() {
+  return [...document.querySelectorAll('a')].find(a => a.href.includes('/view/'));
+}
+
+// TargetRow renders two <select>s for a viewer target (type + icon); the icon
+// one is the select that lists the uploaded icon filenames.
+function iconSelect() {
+  return [...document.querySelectorAll('select')].find(
+    s => [...s.options].some(o => o.textContent === 'logo.png'),
+  );
+}
+
+describe('TargetRow — viewer icon toggle', () => {
+  const base = { id: 't1', type: 'viewer', enabled: true, viewerKey: 'my-viewer' };
+
+  it('omits &icon from the viewer URL when the icon is disabled', () => {
+    renderRow({ ...base, iconId: 1, iconEnabled: false });
+    expect(viewerLink().href).not.toContain('icon=');
+  });
+
+  it('includes &icon when enabled and an icon is selected', () => {
+    renderRow({ ...base, iconId: 2, iconEnabled: true });
+    expect(viewerLink().href).toContain('icon=2');
+  });
+
+  it('omits &icon when enabled but no icon is selected', () => {
+    renderRow({ ...base, iconId: null, iconEnabled: true });
+    expect(viewerLink().href).not.toContain('icon=');
+  });
+
+  it('legacy config (iconId set, iconEnabled undefined) still shows the icon', () => {
+    renderRow({ ...base, iconId: 1 });
+    expect(viewerLink().href).toContain('icon=1');
+  });
+
+  it('checkbox toggles iconEnabled without clearing iconId', () => {
+    const { onChange } = renderRow({ ...base, iconId: 1, iconEnabled: true });
+    fireEvent.click(screen.getByLabelText('Show icon on viewer page'));
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ iconEnabled: false, iconId: 1 }));
+  });
+
+  it('disables the icon dropdown when the toggle is off', () => {
+    renderRow({ ...base, iconId: 1, iconEnabled: false });
+    expect(iconSelect()).toBeDisabled();
+  });
+
+  it('enables the icon dropdown when the toggle is on', () => {
+    renderRow({ ...base, iconId: 1, iconEnabled: true });
+    expect(iconSelect()).not.toBeDisabled();
+  });
+});


### PR DESCRIPTION
Operator-side control for viewer-page icon branding, plus a Setup-Hub card for icon management. Implements `docs/plans/plan_viewer_icons.md`.

## What changed

**A. Backend — persist icon config on `caption_targets`**
- Additive migration: `icon_id INTEGER` + `icon_enabled INTEGER NOT NULL DEFAULT 0`.
- `db/caption-targets.js` round-trips both through `formatRow` / `createCaptionTarget` / `updateCaptionTarget` (viewer-type only; `iconId` normalised to a positive int or null).
- `routes/targets.js` passes the fields through on POST/PUT.
- **Fixes** the prior silent drop of `iconId` on the server-backed `/targets` path — the selection now persists in both the localStorage and server-backed editors.

**B. Frontend — operator toggle in `TargetRow`**
- New "Show icon on viewer page" checkbox (`iconEnabled`) above the which-icon dropdown; dropdown is disabled when off and the chosen `iconId` is preserved.
- Viewer URL appends `&icon=` only when enabled **and** an icon is selected.
- Legacy configs (`iconId` set, `iconEnabled` unset) keep showing the icon via a fallback, so nothing regresses on upgrade.
- `CaptionTargetsManager` forwards the new fields; i18n added for en/fi/sv.

**C. Setup Hub — new "Icons" card**
- `IconsSection.jsx` (+ `IconsIcon`): list / upload (PNG/SVG ≤ 200 KB) / delete via the existing `/icons` endpoints, wired into `SetupHubPage` next to the caption-targets card. Deep-linkable at `/setup/icons`.

## Out of scope (per decision)

Operator-only — no viewer-page end-user control and no public icon-list endpoint.

## Testing

- Backend `test/targets.test.js`: icon-config round-trip (create/get/update, preserve-on-toggle-off, invalid-id normalisation, non-viewer ignored). Backend suite: **911 pass**.
- New `test/components/TargetRow.test.jsx` (7): URL include/exclude, legacy fallback, toggle preserves `iconId`, dropdown gating. Web: **345 node + 378 vitest pass**.
- `vite build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QM67sCyiX3QDGzdDnc1LCb