### PR TITLE
Vertical crop rendition — plan_vertical_crop Phases 1–2 (schema, CropManager, /crop routes, live reposition)

### DIFF
--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -68,6 +68,7 @@ All planning documents live in [`docs/plans/`](plans/). This index lists each pl
 | [plan_viewer_icons.md](plans/plan_viewer_icons.md) | Viewer Icon Toggle + Icons Setup-Hub Card | Operator-side icon enable/disable toggle and Setup Hub card for icon configuration. |
 | [plan_translate.md](plans/plan_translate.md) | Server-Side Translation Plugin (`lcyt-translate`) | Exploratory: server-side translation to close STT and CLI translation gap. |
 | [TODO_plan.md](plans/TODO_plan.md) | Implement TODO.md items | Python stderr logging, MCP auto-sync + time field, docs reorganisation. |
+| [plan_vertical_crop.md](plans/plan_vertical_crop.md) | Vertical Crop Output — Live-Repositionable Landscape→Portrait Crop | Phases 1–2 implemented (schema, CropManager + {key}-crop path, /crop routes, relay sourceView, zmq live reposition with restart fallback); UI + production-follow phases remain. |
 
 ### Pending
 
@@ -86,7 +87,6 @@ All planning documents live in [`docs/plans/`](plans/). This index lists each pl
 | [plan_mixer_feed_sources.md](plans/plan_mixer_feed_sources.md) | Mixer Feed Sources — Encoder & File Sources, Low-Latency Preview Tiles | Generalizes software mixer program bus beyond video to include encoder/file sources. |
 | [plan_postgres_option.md](plans/plan_postgres_option.md) | PostgreSQL as an Optional Backend | Adds PostgreSQL as optional backend for Node.js backend and plugin-owned DB layers. |
 | [plan_metacode_refactor.md](plans/plan_metacode_refactor.md) | Metacode Refactor Plan | Mechanical relocation of scattered metacode handling into dedicated files (clarity refactor). |
-| [plan_vertical_crop.md](plans/plan_vertical_crop.md) | Vertical Crop Output — Live-Repositionable Landscape→Portrait Crop | Per-project 9:16 crop rendition cut at incoming resolution (`{key}-crop` MediaMTX path, relay `sourceView: 'crop'`); preset positions in switchable sets (banks) with per-set editing UI, shifted live via ffmpeg `zmq` filter commands (no restart/black gap) and following mixer/PTZ switches via `crop_source_map`. |
 
 ### Reference
 

--- a/docs/plans/plan_vertical_crop.md
+++ b/docs/plans/plan_vertical_crop.md
@@ -1,7 +1,7 @@
 ---
 id: plan/vertical-crop
 title: "Vertical Crop Output — Live-Repositionable Landscape→Portrait Crop"
-status: draft
+status: in-progress
 summary: "Adds a per-project cropped rendition of the landscape RTMP ingest (typically 16:9 → 9:16 vertical) produced by one long-running ffmpeg at the incoming resolution, published to a {key}-crop MediaMTX path and consumable by relay slots (sourceView: 'crop') and the HLS proxy. Crop positions are named presets organised into switchable preset SETS (banks) — with dedicated UI for editing positions per set (set selector, sources×sets overview grid, activate-set control) — shifted live via runtime ffmpeg filter commands (zmq), no process restart and no black gap, with optional animated transitions, and can automatically follow mixer program switches and camera PTZ preset recalls (camera 1/preset 1 → camera 2 → camera 1/preset 2, each with its own crop position)."
 ---
 
@@ -317,13 +317,21 @@ convention (cf. `sttManager.setDeliveryHelpers()`):
 
 ## Phases
 
-1. **Static crop rendition** — schema (`crop_config`, `crop_presets`,
-   `crop_preset_sets`), CropManager start/stop at publish, `{key}-crop` path, relay
-   `source_view`, `/crop/config` + preset/set CRUD routes. Position changes restart
-   the renderer (correct, not yet gapless).
-2. **Live reposition** — `hasZmq` probe, zmq command client, `applyPosition` with
-   clamped instant + eased transitions, `overridePublisher` double-run fallback,
-   `/crop/position`, `/crop/presets/:id/activate`, `/crop/status`.
+1. **Static crop rendition** ✅ (implemented 2026-07-13) — schema (`crop_config`,
+   `crop_presets`, `crop_preset_sets`, `crop_source_map` in
+   `packages/plugins/lcyt-rtmp/src/db/crop.js`), CropManager
+   (`src/crop-manager.js`) started/stopped from the `/rtmp` publish callbacks,
+   `{key}-crop` path, relay `source_view` column + crop-slot fan-out in
+   `rtmp-manager.js`, `/crop` router (`src/routes/crop.js`) mounted by
+   lcyt-backend, `crop` feature code (dep: `ingest`).
+2. **Live reposition** ✅ core (implemented 2026-07-13) — `hasZmq` probe in
+   `probeFfmpeg()`, lazy-imported `zeromq` REQ client (optional dep — absence
+   downgrades to restart mode), `applyPosition` with clamped instant moves +
+   eased transitions, restart fallback (position carried across the swap),
+   `/crop/position`, `/crop/presets/:id/activate`, `/crop/sets/:id/activate`
+   (re-applies the same-named preset from the new set), `/crop/status`.
+   Remaining from this phase: the `overridePublisher` pre-config on the
+   `{key}-crop` path for a cleaner splice in restart mode.
 3. **Web UI** — settings card, draggable preset editor, preset switcher, the
    preset-set UI (set selector, duplicate-set, sources×sets overview grid,
    operate-surface "Activate set" control), vertical monitor tile.

--- a/packages/lcyt-backend/CLAUDE.md
+++ b/packages/lcyt-backend/CLAUDE.md
@@ -63,6 +63,8 @@ HTTP relay: clients authenticate with API keys + JWT tokens, backend sends capti
 | `MEDIAMTX_API_USER` | Basic-auth username for the MediaMTX API | none |
 | `MEDIAMTX_API_PASSWORD` | Basic-auth password for the MediaMTX API | none |
 | `MEDIAMTX_WEBRTC_BASE_URL` | MediaMTX WebRTC HTTP base URL (WHEP audio source for STT, WebRTC preview) | `http://127.0.0.1:8889` |
+| `CROP_ZMQ_PORT_BASE` | First 127.0.0.1 port for per-process zmq binds (vertical-crop live repositioning) | `5560` |
+| `CROP_OUTPUT_DEFAULT` | Vertical-crop delivery size when crop_config out_w/out_h are NULL | `1080x1920` |
 | `PREVIEW_ROOT` | Directory for JPEG thumbnail files | `/tmp/previews` |
 | `PREVIEW_INTERVAL_S` | Seconds between thumbnail updates | `5` |
 | `GRAPHICS_DIR` | Image storage directory for DSK overlays | `/data/images` |
@@ -141,6 +143,16 @@ GET  /radio/:key/*        — audio-only HLS segments and playlist (public, rate
 GET  /radio/config        — Web Radio self-service metadata: { title, description, coverImageUrl, autoplay, enabled, live } (Bearer token)
 PUT  /radio/config        — update title/description/coverImageUrl/autoplay (Bearer token)
 GET  /preview/:key/incoming.jpg — latest RTMP → JPEG thumbnail (public)
+
+GET  /crop/config         — vertical-crop config + renderer status (Bearer token; RTMP_RELAY_ACTIVE=1)
+PUT  /crop/config         — update aspect/output/bitrate/transition/follow; starts/stops renderer mid-publish (Bearer token)
+GET  /crop/status         — renderer state, active position/preset, repositionMode live|restart (Bearer token)
+POST /crop/position       — { xNorm, yNorm, transitionMs? } free crop positioning (Bearer token)
+GET/POST/PUT/DELETE /crop/presets[/:id] — crop preset CRUD; ?setId= filter (Bearer token)
+POST /crop/presets/:id/activate — apply a preset live (Bearer token)
+GET/POST/PUT/DELETE /crop/sets[/:id]    — preset-set (bank) CRUD; POST supports cloneFromSetId (Bearer token)
+POST /crop/sets/:id/activate    — switch active set; re-applies same-named preset live (Bearer token)
+GET/POST/DELETE /crop/source-map[/:id]  — production-follow mapping CRUD (Bearer token)
 
 GET  /dsk/:apikey/images           — list DSK overlay images for an API key (public)
 GET  /dsk/:apikey/events           — SSE stream of graphics events for DSK page (public)

--- a/packages/lcyt-backend/src/db/project-features.js
+++ b/packages/lcyt-backend/src/db/project-features.js
@@ -34,6 +34,7 @@ export const KNOWN_FEATURE_CODES = new Set([
   'device-control',
   'graphics-server',
   'cea-captions',
+  'crop',
 ]);
 
 export const BINARY_ONLY_FEATURES = new Set([
@@ -45,6 +46,7 @@ export const BINARY_ONLY_FEATURES = new Set([
   'device-control',
   'graphics-server',
   'cea-captions',
+  'crop',
 ]);
 
 export const FEATURE_DEPS = {
@@ -53,6 +55,8 @@ export const FEATURE_DEPS = {
   'radio':                 ['ingest'],
   'hls-stream':            ['ingest'],
   'preview':               ['ingest'],
+  // Vertical crop rendition (plan_vertical_crop.md) — cut from the RTMP ingest
+  'crop':                  ['ingest'],
   // File storage modes — each requires the base file-saving capability.
   // At most one storage mode should be enabled at a time per project.
   //   files-local          → save to the server's local filesystem (default)

--- a/packages/lcyt-backend/src/server.js
+++ b/packages/lcyt-backend/src/server.js
@@ -572,7 +572,7 @@ app.use('/production', createProductionRouter(db, productionRegistry, production
 
 // RTMP relay routes — only mounted when RTMP_RELAY_ACTIVE=1
 if (process.env.RTMP_RELAY_ACTIVE === '1') {
-  const { rtmpRouter, ingestionRouter, streamRouter, streamHlsRouter, radioRouter, previewRouter } =
+  const { rtmpRouter, ingestionRouter, streamRouter, streamHlsRouter, radioRouter, previewRouter, cropRouter } =
     createRtmpRouters(db, auth, rtmp, { allowedRtmpDomains: _allowedRtmpDomains });
   app.use('/rtmp',       rtmpRouter);
   app.use('/ingestion',  ingestionRouter);
@@ -580,6 +580,7 @@ if (process.env.RTMP_RELAY_ACTIVE === '1') {
   app.use('/stream-hls', streamHlsRouter);
   app.use('/radio',      radioRouter);
   app.use('/preview',    previewRouter);
+  app.use('/crop',       cropRouter);
 }
 
 // Music detection (server-side HLS audio analysis) routes — only mounted when

--- a/packages/plugins/lcyt-rtmp/CLAUDE.md
+++ b/packages/plugins/lcyt-rtmp/CLAUDE.md
@@ -43,10 +43,13 @@ await rtmp.stop();
 - `stt-adapters/openai.js` — `OpenAiAdapter`: sends audio to OpenAI-compatible STT endpoint.
 - `stt-adapters/pcm-buffer.js` — `PcmSilenceBuffer`: accumulates PCM frames and detects silence; `buildWav()` helper constructs WAV from raw PCM bytes.
 - `db/relay.js` — RTMP relay DB helpers: `isRelayAllowed()`, `isRadioEnabled()`, `resolveApiKeyFromIngestStreamKey()` (resolves a rotated ingest stream key back to its owning api_key, falling back to treating the name as the literal api_key — `plan_selfservice_config_backend.md` §2), per-key relay config CRUD.
+- `crop-manager.js` — `CropManager`: vertical-crop rendition (plan_vertical_crop.md) — one long-running ffmpeg per key reads the raw ingest via RTSP, cuts a `crop@vcrop` window at incoming resolution, publishes to the `{key}-crop` MediaMTX path. Live repositioning via zmq runtime filter commands when `ffmpegCaps.hasZmq` AND the optional `zeromq` npm package import succeeds (not a declared dependency — its absence downgrades to restart-mode repositioning, position carried across the swap). Exports pure geometry helpers (`computeCropGeometry`, `normToPixels`, `buildEaseSteps`).
+- `db/crop.js` — crop migrations + helpers: `crop_config` (aspect/output/transition/active set), `crop_preset_sets` (banks), `crop_presets` (normalised 0..1 positions), `crop_source_map` + `resolveCropPresetForSource()` (most-specific wins: camera+PTZ-preset > camera > mixer input; scoped to the active set). Manual delete cascades (FK enforcement is off repo-wide).
+- `routes/crop.js` — `/crop` router (session Bearer; feature-gated on `crop` when `FEATURE_GATE_ENFORCE=1`): config, status, free `POST /position`, preset CRUD + `POST /presets/:id/activate`, set CRUD + `POST /sets/:id/activate` (re-applies the same-named preset from the new set live), source-map CRUD.
 - `db/radio.js` — `runRadioMigrations()` + `getRadioConfig()`/`setRadioConfig()`: Web Radio metadata (`radio_config` table — title/description/coverImageUrl/autoplay, plus `radio_enabled` surfaced read-only as `enabled`) — §3.
 - `routes/rtmp.js` — `POST /rtmp` — nginx-rtmp `on_publish`/`on_publish_done` callback for the primary video app. Resolves the incoming stream name through `resolveApiKeyFromIngestStreamKey()` before treating it as an api_key.
 - `routes/ingestion.js` — `GET/PATCH /ingestion/config`, `POST /ingestion/config/rotate` — self-service ingest status/enable/rotate (session Bearer). Nested `{ video, dsk }` shape: `video.enabled` flips `relay_allowed` (feature-gated on `ingest` when `FEATURE_GATE_ENFORCE=1`); `dsk.enabled` is read-only (`graphics_enabled`) and `PATCH .../dsk` is `501` until a real DSK-ingest gate exists (§2/§2a).
-- `routes/stream.js` — `GET/POST/PUT/DELETE /stream` — RTMP relay egress slot management (domain allowlist enforced).
+- `routes/stream.js` — `GET/POST/PUT/DELETE /stream` — RTMP relay egress slot management (domain allowlist enforced). Slots carry `sourceView: 'program'|'crop'` — crop-view slots fan out the `{key}-crop` vertical rendition via a MediaMTX runOnPublish hook on that path instead of the raw ingest (never part of CEA-708/transcode/DSK modes).
 - `routes/stream-hls.js` — `GET /stream-hls/:key/*` — HLS video+audio proxy (public, rate-limited).
 - `routes/radio.js` — `GET /radio/:key/*` — audio-only HLS proxy (public, rate-limited); `GET/PUT /radio/config` — self-service Web Radio metadata (session Bearer, §3/§3a); resolves nginx-rtmp callback stream names through `resolveApiKeyFromIngestStreamKey()`.
 - `routes/preview.js` — `GET /preview/:key/incoming.jpg` — RTMP → JPEG thumbnail serving (public).
@@ -91,6 +94,10 @@ The HTTP routes for STT (`/stt/*`) live in `packages/lcyt-backend/src/routes/stt
 - `test/stt-manager.test.js` — `SttManager`: session lifecycle (start/stop), transcript routing to session send queue.
 - `test/stt-manager-rtmp.test.js` — `SttManager` RTMP/WHEP audio source paths (ffmpeg-based).
 - `test/hetzner.integration.test.js` — Hetzner client integration test (uses mock HTTP server).
+- `test/crop-geometry.test.js` — pure crop geometry: window derivation, even rounding, clamping, ease steps.
+- `test/crop-db.test.js` — crop config/presets/sets (incl. clone)/source-map helpers + follow-resolution specificity.
+- `test/crop-manager.test.js` — CropManager lifecycle with mock worker daemon; restart-mode repositioning; crop-slot fan-out registration in RtmpRelayManager.
+- `test/crop-routes.test.js` — /crop router CRUD, activate flows, feature gate.
 
 **Gaps (Medium):**
 - gRPC streaming path in `GoogleSttAdapter` (requires `@google-cloud/speech` to be installed).

--- a/packages/plugins/lcyt-rtmp/package.json
+++ b/packages/plugins/lcyt-rtmp/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "src/api.js",
   "scripts": {
-    "test": "node --experimental-test-module-mocks --test test/rtmp-manager.test.js test/dsk-composite-filter.test.js test/nginx-manager.test.js test/hls-segment-fetcher.test.js test/google-stt.test.js test/stt-manager.test.js test/whisper-http.test.js test/openai-stt.test.js test/pcm-buffer.test.js test/stt-manager-rtmp.test.js test/rtmp-manager-restart.test.js test/rtmp-manager.unit.test.js test/preview-route.test.js"
+    "test": "node --experimental-test-module-mocks --test test/rtmp-manager.test.js test/dsk-composite-filter.test.js test/nginx-manager.test.js test/hls-segment-fetcher.test.js test/google-stt.test.js test/stt-manager.test.js test/whisper-http.test.js test/openai-stt.test.js test/pcm-buffer.test.js test/stt-manager-rtmp.test.js test/rtmp-manager-restart.test.js test/rtmp-manager.unit.test.js test/preview-route.test.js test/crop-geometry.test.js test/crop-db.test.js test/crop-manager.test.js test/crop-routes.test.js"
   },
   "dependencies": {
     "express": "^4.21",

--- a/packages/plugins/lcyt-rtmp/src/api.js
+++ b/packages/plugins/lcyt-rtmp/src/api.js
@@ -45,7 +45,9 @@ import { RadioManager } from './radio-manager.js';
 import { PreviewManager } from './preview-manager.js';
 import { HlsSubsManager } from './hls-subs-manager.js';
 import { SttManager } from './stt-manager.js';
+import { CropManager } from './crop-manager.js';
 import { createRtmpRouter } from './routes/rtmp.js';
+import { createCropRouter } from './routes/crop.js';
 import { createIngestionRouter } from './routes/ingestion.js';
 import { createStreamRouter } from './routes/stream.js';
 import { createStreamHlsRouter } from './routes/stream-hls.js';
@@ -84,7 +86,7 @@ export async function initRtmpControl(db, store = null) {
 
   const ffmpegCaps = process.env.RTMP_RELAY_ACTIVE === '1'
     ? probeFfmpeg()
-    : { available: false, hasLibx264: false, hasEia608: false, hasSubrip: false };
+    : { available: false, hasLibx264: false, hasEia608: false, hasSubrip: false, hasZmq: false };
 
   // Stat tracking: map from `${apiKey}:${slot}` → rtmp_stream_stats row id
   const _rtmpStatIds = new Map();
@@ -143,6 +145,7 @@ export async function initRtmpControl(db, store = null) {
   const hlsSubsManager = new HlsSubsManager();
   const previewManager = new PreviewManager({ mediamtxClient });
   const sttManager     = new SttManager(store, db);
+  const cropManager    = new CropManager({ ffmpegCaps, mediamtxClient });
 
   if (nginxManager.isEnabled) {
     logger.info(`[lcyt-rtmp] NginxManager active → ${process.env.NGINX_RADIO_CONFIG_PATH}`);
@@ -158,10 +161,11 @@ export async function initRtmpControl(db, store = null) {
       radioManager.stopAll(),
       previewManager.stopAll(),
       sttManager.stopAll(),
+      cropManager.stopAll(),
     ]);
   }
 
-  return { relayManager, hlsManager, radioManager, previewManager, hlsSubsManager, sttManager, stop };
+  return { relayManager, hlsManager, radioManager, previewManager, hlsSubsManager, sttManager, cropManager, stop };
 }
 
 /**
@@ -182,13 +186,14 @@ export async function initRtmpControl(db, store = null) {
  *   previewRouter: import('express').Router
  * }}
  */
-export function createRtmpRouters(db, auth, { relayManager, hlsManager, radioManager, previewManager, sttManager }, { allowedRtmpDomains } = {}) {
+export function createRtmpRouters(db, auth, { relayManager, hlsManager, radioManager, previewManager, sttManager, cropManager }, { allowedRtmpDomains } = {}) {
   return {
-    rtmpRouter:      createRtmpRouter(db, relayManager),
+    rtmpRouter:      createRtmpRouter(db, relayManager, cropManager),
     ingestionRouter: createIngestionRouter(db, auth, relayManager),
     streamRouter:    createStreamRouter(db, auth, relayManager, allowedRtmpDomains),
     streamHlsRouter: createStreamHlsRouter(db, hlsManager),
     radioRouter:     createRadioRouter(db, radioManager, sttManager, auth),
     previewRouter:   createPreviewRouter(previewManager),
+    cropRouter:      createCropRouter(db, auth, cropManager, relayManager),
   };
 }

--- a/packages/plugins/lcyt-rtmp/src/crop-manager.js
+++ b/packages/plugins/lcyt-rtmp/src/crop-manager.js
@@ -1,0 +1,396 @@
+/**
+ * CropManager — vertical crop rendition of the landscape ingest
+ * (plan_vertical_crop.md §2).
+ *
+ * One long-running ffmpeg per api_key reads the raw ingest back from MediaMTX
+ * over RTSP, cuts a fixed-size crop window (default 9:16) from the
+ * full-resolution frames with a named `crop@vcrop` filter, optionally scales
+ * to the delivery size, and publishes H.264/AAC back into MediaMTX on the
+ * `{key}-crop` path. Downstream consumption (relay slots with
+ * sourceView:'crop', the /stream-hls proxy, thumbnails) reads that path.
+ *
+ * Crop POSITION changes are applied without restarting the process when the
+ * ffmpeg build has the `zmq` filter (ffmpegCaps.hasZmq) and the optional
+ * `zeromq` npm package is importable: runtime filter commands
+ * (`crop@vcrop x <px>`) land on the next frame — no black gap. Otherwise the
+ * manager falls back to a restart per position change (`repositionMode:
+ * 'restart'`), relying on MediaMTX to keep serving the path across the swap.
+ *
+ * Environment variables:
+ *   MEDIAMTX_RTSP_BASE_URL — RTSP base for reading the raw ingest (default rtsp://127.0.0.1:8554)
+ *   MEDIAMTX_RTMP_BASE_URL — RTMP base for publishing {key}-crop (default rtmp://127.0.0.1:1935)
+ *   CROP_ZMQ_PORT_BASE     — first 127.0.0.1 port for per-process zmq binds (default 5560)
+ *   CROP_OUTPUT_DEFAULT    — delivery size when config out_w/out_h are NULL (default 1080x1920)
+ */
+import { spawn } from 'node:child_process';
+import { createFfmpegRunner } from 'lcyt-backend/ffmpeg';
+import logger from 'lcyt/logger';
+
+const DEFAULT_MEDIAMTX_RTSP = (process.env.MEDIAMTX_RTSP_BASE_URL || 'rtsp://127.0.0.1:8554').replace(/\/$/, '');
+const DEFAULT_MEDIAMTX_RTMP = (process.env.MEDIAMTX_RTMP_BASE_URL || 'rtmp://127.0.0.1:1935').replace(/\/$/, '');
+const ZMQ_PORT_BASE = Number(process.env.CROP_ZMQ_PORT_BASE ?? 5560);
+const TRANSITION_TICK_MS = 33;
+
+// ── pure geometry helpers (unit-tested) ─────────────────────────────────────
+
+const roundEven = v => 2 * Math.round(v / 2);
+export const clampNorm = v => (Number.isFinite(Number(v)) ? Math.max(0, Math.min(1, Number(v))) : 0);
+
+/**
+ * Derive the crop window and travel range from the input resolution and the
+ * configured aspect. The window always uses the full available height (or
+ * width, when the source is taller than the target aspect) so the crop is cut
+ * at incoming quality.
+ *
+ * @returns {{ cropW: number, cropH: number, maxX: number, maxY: number }}
+ */
+export function computeCropGeometry({ inW, inH, aspectW = 9, aspectH = 16 }) {
+  let cropH = inH;
+  let cropW = roundEven(inH * aspectW / aspectH);
+  if (cropW > inW) {
+    // Source narrower than the target aspect — pin width, shrink height.
+    cropW = roundEven(inW);
+    cropH = roundEven(inW * aspectH / aspectW);
+    if (cropH > inH) cropH = roundEven(inH);
+  }
+  return { cropW, cropH, maxX: Math.max(0, inW - cropW), maxY: Math.max(0, inH - cropH) };
+}
+
+/**
+ * Convert a normalised position (0..1 of the travel range) to even pixel
+ * offsets for the crop filter.
+ */
+export function normToPixels({ xNorm, yNorm }, { maxX, maxY }) {
+  return {
+    x: Math.min(maxX, Math.max(0, roundEven(clampNorm(xNorm) * maxX))),
+    y: Math.min(maxY, Math.max(0, roundEven(clampNorm(yNorm) * maxY))),
+  };
+}
+
+/**
+ * Cubic ease-in-out interpolation steps between two normalised positions.
+ * Returns the intermediate + final positions (never the starting point).
+ * @returns {Array<{ xNorm: number, yNorm: number }>}
+ */
+export function buildEaseSteps(from, to, transitionMs, tickMs = TRANSITION_TICK_MS) {
+  const n = Math.max(1, Math.round(transitionMs / tickMs));
+  const ease = t => (t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2);
+  const steps = [];
+  for (let i = 1; i <= n; i++) {
+    const t = ease(i / n);
+    steps.push({
+      xNorm: from.xNorm + (to.xNorm - from.xNorm) * t,
+      yNorm: from.yNorm + (to.yNorm - from.yNorm) * t,
+    });
+  }
+  return steps;
+}
+
+// ── ffprobe input-resolution probe ──────────────────────────────────────────
+
+/**
+ * Probe the input resolution of the raw ingest via ffprobe.
+ * Resolves { inW, inH } or null when ffprobe is unavailable / fails.
+ */
+export function probeInputResolution(url, { timeoutMs = 8000 } = {}) {
+  return new Promise(resolve => {
+    let out = '';
+    let proc;
+    try {
+      proc = spawn('ffprobe', [
+        '-v', 'error', '-select_streams', 'v:0',
+        '-show_entries', 'stream=width,height', '-of', 'json',
+        '-rtsp_transport', 'tcp', url,
+      ], { stdio: ['ignore', 'pipe', 'ignore'] });
+    } catch {
+      resolve(null);
+      return;
+    }
+    const timer = setTimeout(() => { try { proc.kill('SIGKILL'); } catch {} }, timeoutMs);
+    if (timer.unref) timer.unref();
+    proc.stdout.on('data', d => { out += d; });
+    proc.on('error', () => { clearTimeout(timer); resolve(null); });
+    proc.on('close', () => {
+      clearTimeout(timer);
+      try {
+        const s = JSON.parse(out)?.streams?.[0];
+        if (s?.width > 0 && s?.height > 0) return resolve({ inW: s.width, inH: s.height });
+      } catch {}
+      resolve(null);
+    });
+  });
+}
+
+// ── manager ─────────────────────────────────────────────────────────────────
+
+export class CropManager {
+  /**
+   * @param {{
+   *   ffmpegCaps?: { available?: boolean, hasZmq?: boolean }|null,
+   *   mediamtxClient?: import('./mediamtx-client.js').MediaMtxClient|null,
+   *   probeResolution?: Function,   // test injection; defaults to probeInputResolution
+   * }} [opts]
+   */
+  constructor({ ffmpegCaps = null, mediamtxClient = null, probeResolution } = {}) {
+    this._ffmpegCaps = ffmpegCaps;
+    this._mediamtx = mediamtxClient;
+    this._probeResolution = probeResolution ?? probeInputResolution;
+
+    /**
+     * Per-key session state:
+     * { handle, geometry: {inW,inH,cropW,cropH,maxX,maxY}, config, position:
+     *   {xNorm,yNorm}, activePresetId, zmq: {socket,port}|null, startedAt,
+     *   transitionTimer }
+     * @type {Map<string, object>}
+     */
+    this._sessions = new Map();
+    this._nextZmqOffset = 0;
+  }
+
+  /** MediaMTX path name of the crop rendition. */
+  static cropPathName(apiKey) { return `${apiKey}-crop`; }
+
+  isRunning(apiKey) { return this._sessions.has(apiKey); }
+
+  /**
+   * `'live'` when position changes go over runtime filter commands,
+   * `'restart'` when they need a process swap.
+   */
+  repositionMode() {
+    return this._ffmpegCaps?.hasZmq ? 'live' : 'restart';
+  }
+
+  getStatus(apiKey) {
+    const s = this._sessions.get(apiKey);
+    if (!s) return { running: false, repositionMode: this.repositionMode() };
+    return {
+      running:        true,
+      repositionMode: s.zmq ? 'live' : 'restart',
+      activePresetId: s.activePresetId ?? null,
+      xNorm:          s.position.xNorm,
+      yNorm:          s.position.yNorm,
+      inW:            s.geometry.inW,
+      inH:            s.geometry.inH,
+      cropW:          s.geometry.cropW,
+      cropH:          s.geometry.cropH,
+      startedAt:      s.startedAt,
+    };
+  }
+
+  /**
+   * Start (or restart) the crop renderer for a key.
+   *
+   * @param {string} apiKey
+   * @param {object} config   crop_config shape from db/crop.js (getCropConfig)
+   * @param {{ position?: { xNorm: number, yNorm: number }, activePresetId?: string|null }} [opts]
+   */
+  async start(apiKey, config, { position, activePresetId = null } = {}) {
+    if (this._ffmpegCaps?.available === false) {
+      throw new Error('ffmpeg is not installed or not available in PATH. Vertical crop requires ffmpeg.');
+    }
+    const previous = this._sessions.get(apiKey);
+    // Carry the last position across restarts unless explicitly overridden.
+    const pos = {
+      xNorm: clampNorm(position?.xNorm ?? previous?.position.xNorm ?? 0.5),
+      yNorm: clampNorm(position?.yNorm ?? previous?.position.yNorm ?? 0),
+    };
+    await this.stop(apiKey);
+
+    const srcUrl = `${DEFAULT_MEDIAMTX_RTSP}/${encodeURIComponent(apiKey)}`;
+    // Reuse the previous session's successfully-probed resolution on restarts
+    // (restart-mode repositioning would otherwise pay the probe on every move).
+    let inW, inH, probed;
+    if (previous?.geometry?.probed) {
+      ({ inW, inH } = previous.geometry);
+      probed = true;
+    } else {
+      const res = await this._probeResolution(srcUrl).catch(() => null);
+      probed = !!res;
+      inW = res?.inW ?? 1920;
+      inH = res?.inH ?? 1080;
+      if (!res) {
+        logger.warn(`[crop:${apiKey.slice(0, 8)}] input resolution probe failed — assuming ${inW}x${inH}`);
+      }
+    }
+
+    const geometry = { inW, inH, probed, ...computeCropGeometry({ inW, inH, aspectW: config.aspectW, aspectH: config.aspectH }) };
+    const { x, y } = normToPixels(pos, geometry);
+    const outW = config.outW ?? Number((process.env.CROP_OUTPUT_DEFAULT || '1080x1920').split('x')[0]);
+    const outH = config.outH ?? Number((process.env.CROP_OUTPUT_DEFAULT || '1080x1920').split('x')[1]);
+
+    // zmq lands in the graph only when both the ffmpeg build and the node
+    // client side are available — a bind without a client is dead weight.
+    const zmqPort = this._ffmpegCaps?.hasZmq ? ZMQ_PORT_BASE + (this._nextZmqOffset++ % 1000) : null;
+    let filter = `[0:v]crop@vcrop=${geometry.cropW}:${geometry.cropH}:${x}:${y},scale=${outW}:${outH}`;
+    // Args go through spawn (no shell); only the filtergraph parser needs the
+    // ':' inside the bind address escaped, so a single literal backslash.
+    if (zmqPort) filter += `,zmq=bind_address=tcp\\://127.0.0.1\\:${zmqPort}`;
+    filter += '[v]';
+
+    const args = [
+      '-rtsp_transport', 'tcp', '-i', srcUrl,
+      '-filter_complex', filter,
+      '-map', '[v]', '-map', '0:a?',
+      '-c:v', 'libx264', '-preset', 'veryfast', '-tune', 'zerolatency',
+    ];
+    if (config.videoBitrate) args.push('-b:v', config.videoBitrate);
+    args.push('-c:a', 'copy');
+    // Bare path — MediaMTX uses the full URL path as the path name.
+    args.push('-f', 'flv', `${DEFAULT_MEDIAMTX_RTMP}/${CropManager.cropPathName(apiKey)}`);
+
+    const tag = `[crop:${apiKey.slice(0, 8)}]`;
+    const runner = createFfmpegRunner({
+      runner: process.env.FFMPEG_RUNNER ?? 'spawn',
+      cmd: 'ffmpeg',
+      args,
+      name: tag,
+      stdin: 'ignore',
+    });
+    const handle = await runner.start();
+
+    const session = {
+      handle,
+      geometry,
+      config,
+      position: pos,
+      activePresetId,
+      zmq: null,
+      zmqPort,
+      startedAt: new Date(),
+      transitionTimer: null,
+    };
+    this._sessions.set(apiKey, session);
+
+    if (zmqPort) {
+      session.zmq = await this._openZmq(apiKey, zmqPort);
+    }
+
+    if (handle?.stderr) handle.stderr.on('data', d => process.stderr.write(`${tag} ${d}`));
+
+    runner.on('error', err => {
+      if (this._sessions.get(apiKey) === session) this._cleanupSession(apiKey, session);
+      logger.error(`${tag} ffmpeg error: ${err.message}`);
+    });
+    runner.on('close', info => {
+      if (this._sessions.get(apiKey) === session) this._cleanupSession(apiKey, session);
+      logger.info(`${tag} crop renderer exited${info?.code != null ? ` (code ${info.code})` : ''}`);
+    });
+
+    logger.info(`${tag} crop renderer started ${geometry.cropW}x${geometry.cropH}@${x},${y} → ${outW}x${outH} (${session.zmq ? 'live' : 'restart'} repositioning)`);
+  }
+
+  /**
+   * Move the crop window. In live mode the change lands on the next frame
+   * (optionally eased over transitionMs); in restart mode the renderer is
+   * restarted at the new position.
+   *
+   * @returns {{ ok: boolean, mode: 'live'|'restart', xNorm: number, yNorm: number }}
+   */
+  async applyPosition(apiKey, { xNorm, yNorm, transitionMs = 0, activePresetId } = {}) {
+    const session = this._sessions.get(apiKey);
+    if (!session) throw new Error('Crop renderer is not running for this key');
+
+    const target = { xNorm: clampNorm(xNorm), yNorm: clampNorm(yNorm) };
+    if (activePresetId !== undefined) session.activePresetId = activePresetId;
+
+    if (session.transitionTimer) {
+      clearInterval(session.transitionTimer);
+      session.transitionTimer = null;
+    }
+
+    if (session.zmq) {
+      if (transitionMs > 0) {
+        const steps = buildEaseSteps({ ...session.position }, target, transitionMs);
+        let i = 0;
+        await this._sendZmqPosition(session, steps.length ? steps[0] : target);
+        session.position = steps.length ? { ...steps[0] } : target;
+        i = 1;
+        if (steps.length > 1) {
+          session.transitionTimer = setInterval(() => {
+            const cur = this._sessions.get(apiKey);
+            if (cur !== session || i >= steps.length) {
+              clearInterval(session.transitionTimer);
+              session.transitionTimer = null;
+              return;
+            }
+            const step = steps[i++];
+            session.position = { ...step };
+            this._sendZmqPosition(session, step).catch(() => {});
+          }, TRANSITION_TICK_MS);
+          if (session.transitionTimer.unref) session.transitionTimer.unref();
+        }
+      } else {
+        await this._sendZmqPosition(session, target);
+        session.position = target;
+      }
+      return { ok: true, mode: 'live', xNorm: target.xNorm, yNorm: target.yNorm };
+    }
+
+    // Restart fallback — MediaMTX keeps the path alive across the swap.
+    await this.start(apiKey, session.config, { position: target, activePresetId: session.activePresetId });
+    return { ok: true, mode: 'restart', xNorm: target.xNorm, yNorm: target.yNorm };
+  }
+
+  async stop(apiKey) {
+    const session = this._sessions.get(apiKey);
+    if (!session) return;
+    this._cleanupSession(apiKey, session);
+    try {
+      if (typeof session.handle?.stop === 'function') await session.handle.stop(3000);
+    } catch {}
+  }
+
+  async stopAll() {
+    await Promise.all([...this._sessions.keys()].map(k => this.stop(k)));
+  }
+
+  // ── internals ─────────────────────────────────────────────────────────────
+
+  _cleanupSession(apiKey, session) {
+    if (this._sessions.get(apiKey) === session) this._sessions.delete(apiKey);
+    if (session.transitionTimer) {
+      clearInterval(session.transitionTimer);
+      session.transitionTimer = null;
+    }
+    if (session.zmq) {
+      try { session.zmq.close(); } catch {}
+      session.zmq = null;
+    }
+  }
+
+  /**
+   * Open a ZeroMQ REQ socket to the process's zmq filter. Returns null (and
+   * downgrades the session to restart mode) when the optional `zeromq`
+   * package is not installed.
+   */
+  async _openZmq(apiKey, port) {
+    let zmqMod;
+    try {
+      zmqMod = await import('zeromq');
+    } catch {
+      logger.warn(`[crop:${apiKey.slice(0, 8)}] optional dependency "zeromq" not installed — falling back to restart-based repositioning`);
+      return null;
+    }
+    try {
+      const socket = new zmqMod.Request({ sendTimeout: 500, receiveTimeout: 500 });
+      socket.connect(`tcp://127.0.0.1:${port}`);
+      return {
+        async send(cmd) {
+          await socket.send(cmd);
+          const [reply] = await socket.receive();
+          return String(reply);
+        },
+        close() { try { socket.close(); } catch {} },
+      };
+    } catch (err) {
+      logger.warn(`[crop:${apiKey.slice(0, 8)}] zmq socket setup failed (${err.message}) — falling back to restart-based repositioning`);
+      return null;
+    }
+  }
+
+  async _sendZmqPosition(session, pos) {
+    const { x, y } = normToPixels(pos, session.geometry);
+    await session.zmq.send(`crop@vcrop x ${x}`);
+    await session.zmq.send(`crop@vcrop y ${y}`);
+  }
+}

--- a/packages/plugins/lcyt-rtmp/src/db.js
+++ b/packages/plugins/lcyt-rtmp/src/db.js
@@ -7,9 +7,11 @@
  * @param {import('better-sqlite3').Database} db
  */
 import { runRadioMigrations } from './db/radio.js';
+import { runCropMigrations } from './db/crop.js';
 
 export function runMigrations(db) {
   runRadioMigrations(db);
+  runCropMigrations(db);
   // ── api_keys additive columns ──────────────────────────────────────────────
   const existingCols = new Set(
     db.prepare('PRAGMA table_info(api_keys)').all().map(c => c.name)
@@ -84,6 +86,9 @@ export function runMigrations(db) {
       if (!latestCols.has('fps'))           db.exec('ALTER TABLE rtmp_relays ADD COLUMN fps INTEGER');
       if (!latestCols.has('video_bitrate')) db.exec('ALTER TABLE rtmp_relays ADD COLUMN video_bitrate TEXT');
       if (!latestCols.has('audio_bitrate')) db.exec('ALTER TABLE rtmp_relays ADD COLUMN audio_bitrate TEXT');
+      // Which rendition this slot forwards: 'program' (raw ingest, default)
+      // or 'crop' (the {key}-crop vertical rendition — plan_vertical_crop.md)
+      if (!latestCols.has('source_view'))   db.exec("ALTER TABLE rtmp_relays ADD COLUMN source_view TEXT NOT NULL DEFAULT 'program'");
     }
   }
 
@@ -323,3 +328,4 @@ export function deleteSttSourceLanguage(db, apiKey, id) {
 
 export * from './db/relay.js';
 export * from './db/radio.js';
+export * from './db/crop.js';

--- a/packages/plugins/lcyt-rtmp/src/db/crop.js
+++ b/packages/plugins/lcyt-rtmp/src/db/crop.js
@@ -1,0 +1,406 @@
+/**
+ * Vertical-crop DB migrations and helpers (plan_vertical_crop.md §1).
+ *
+ * Tables:
+ *   crop_config       — one row per api_key: output geometry + behaviour flags
+ *   crop_preset_sets  — named "banks" of crop positions
+ *   crop_presets      — named positions (normalised 0..1 of the travel range)
+ *   crop_source_map   — production-follow mapping (mixer input / camera+PTZ
+ *                       preset → crop preset); most-specific row wins
+ *
+ * Positions are stored NORMALISED (0..1 of the max travel range) so presets
+ * survive an input-resolution change; pixel conversion happens in
+ * crop-manager.js at apply time.
+ *
+ * NOTE: `PRAGMA foreign_keys` is not enabled repo-wide (see CONSIDER.md), so
+ * ON DELETE CASCADE declarations are inert — deletes cascade manually here.
+ */
+import { randomUUID } from 'node:crypto';
+
+export function runCropMigrations(db) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS crop_config (
+      api_key         TEXT PRIMARY KEY,
+      enabled         INTEGER NOT NULL DEFAULT 0,
+      aspect_w        INTEGER NOT NULL DEFAULT 9,
+      aspect_h        INTEGER NOT NULL DEFAULT 16,
+      out_w           INTEGER,
+      out_h           INTEGER,
+      video_bitrate   TEXT,
+      follow_program  INTEGER NOT NULL DEFAULT 1,
+      transition_ms   INTEGER NOT NULL DEFAULT 0,
+      active_set_id   TEXT,
+      updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
+    )
+  `);
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS crop_preset_sets (
+      id          TEXT PRIMARY KEY,
+      api_key     TEXT NOT NULL,
+      name        TEXT NOT NULL,
+      sort_order  INTEGER NOT NULL DEFAULT 0,
+      created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+      UNIQUE (api_key, name)
+    )
+  `);
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS crop_presets (
+      id          TEXT PRIMARY KEY,
+      api_key     TEXT NOT NULL,
+      set_id      TEXT REFERENCES crop_preset_sets(id) ON DELETE CASCADE,
+      name        TEXT NOT NULL,
+      x_norm      REAL NOT NULL DEFAULT 0.5,
+      y_norm      REAL NOT NULL DEFAULT 0.0,
+      sort_order  INTEGER NOT NULL DEFAULT 0,
+      created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+      UNIQUE (api_key, set_id, name)
+    )
+  `);
+  db.exec('CREATE INDEX IF NOT EXISTS idx_crop_presets_key ON crop_presets(api_key, set_id)');
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS crop_source_map (
+      id             TEXT PRIMARY KEY,
+      api_key        TEXT NOT NULL,
+      mixer_id       TEXT,
+      mixer_input    INTEGER,
+      camera_id      TEXT,
+      camera_preset  INTEGER,
+      preset_id      TEXT NOT NULL REFERENCES crop_presets(id) ON DELETE CASCADE
+    )
+  `);
+  db.exec('CREATE INDEX IF NOT EXISTS idx_crop_source_map_key ON crop_source_map(api_key)');
+}
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+const clamp01 = v => Math.max(0, Math.min(1, Number(v)));
+
+function formatConfig(row) {
+  return {
+    enabled:       row.enabled === 1,
+    aspectW:       row.aspect_w,
+    aspectH:       row.aspect_h,
+    outW:          row.out_w ?? null,
+    outH:          row.out_h ?? null,
+    videoBitrate:  row.video_bitrate ?? null,
+    followProgram: row.follow_program === 1,
+    transitionMs:  row.transition_ms,
+    activeSetId:   row.active_set_id ?? null,
+  };
+}
+
+const DEFAULT_CONFIG = Object.freeze({
+  enabled: false, aspectW: 9, aspectH: 16, outW: null, outH: null,
+  videoBitrate: null, followProgram: true, transitionMs: 0, activeSetId: null,
+});
+
+/**
+ * @returns {object} config (defaults when no row exists)
+ */
+export function getCropConfig(db, apiKey) {
+  const row = db.prepare('SELECT * FROM crop_config WHERE api_key = ?').get(apiKey);
+  return row ? formatConfig(row) : { ...DEFAULT_CONFIG };
+}
+
+/**
+ * Upsert crop config. Only provided fields change.
+ * @returns {{ ok: true, config: object } | { ok: false, error: string }}
+ */
+export function setCropConfig(db, apiKey, patch = {}) {
+  const { enabled, aspectW, aspectH, outW, outH, videoBitrate, followProgram, transitionMs, activeSetId } = patch;
+
+  const isPosInt = v => Number.isInteger(v) && v > 0;
+  if (aspectW !== undefined && !isPosInt(aspectW)) return { ok: false, error: 'aspectW must be a positive integer' };
+  if (aspectH !== undefined && !isPosInt(aspectH)) return { ok: false, error: 'aspectH must be a positive integer' };
+  if (outW !== undefined && outW !== null && !isPosInt(outW)) return { ok: false, error: 'outW must be a positive integer or null' };
+  if (outH !== undefined && outH !== null && !isPosInt(outH)) return { ok: false, error: 'outH must be a positive integer or null' };
+  if (transitionMs !== undefined && (!Number.isInteger(transitionMs) || transitionMs < 0 || transitionMs > 10_000)) {
+    return { ok: false, error: 'transitionMs must be an integer 0-10000' };
+  }
+  if (videoBitrate !== undefined && videoBitrate !== null && !/^\d+[kKmM]?$/.test(String(videoBitrate))) {
+    return { ok: false, error: "videoBitrate must look like '4500k'" };
+  }
+  if (activeSetId !== undefined && activeSetId !== null) {
+    const set = db.prepare('SELECT id FROM crop_preset_sets WHERE api_key = ? AND id = ?').get(apiKey, activeSetId);
+    if (!set) return { ok: false, error: 'activeSetId does not reference one of this project\'s sets' };
+  }
+
+  const existing = db.prepare('SELECT * FROM crop_config WHERE api_key = ?').get(apiKey);
+  const cur = existing ? formatConfig(existing) : { ...DEFAULT_CONFIG };
+  const next = {
+    enabled:       enabled       !== undefined ? Boolean(enabled)       : cur.enabled,
+    aspectW:       aspectW       !== undefined ? aspectW                : cur.aspectW,
+    aspectH:       aspectH       !== undefined ? aspectH                : cur.aspectH,
+    outW:          outW          !== undefined ? outW                   : cur.outW,
+    outH:          outH          !== undefined ? outH                   : cur.outH,
+    videoBitrate:  videoBitrate  !== undefined ? videoBitrate           : cur.videoBitrate,
+    followProgram: followProgram !== undefined ? Boolean(followProgram) : cur.followProgram,
+    transitionMs:  transitionMs  !== undefined ? transitionMs           : cur.transitionMs,
+    activeSetId:   activeSetId   !== undefined ? activeSetId            : cur.activeSetId,
+  };
+
+  db.prepare(`
+    INSERT INTO crop_config (api_key, enabled, aspect_w, aspect_h, out_w, out_h, video_bitrate, follow_program, transition_ms, active_set_id, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+    ON CONFLICT(api_key) DO UPDATE SET
+      enabled = excluded.enabled, aspect_w = excluded.aspect_w, aspect_h = excluded.aspect_h,
+      out_w = excluded.out_w, out_h = excluded.out_h, video_bitrate = excluded.video_bitrate,
+      follow_program = excluded.follow_program, transition_ms = excluded.transition_ms,
+      active_set_id = excluded.active_set_id, updated_at = datetime('now')
+  `).run(
+    apiKey, next.enabled ? 1 : 0, next.aspectW, next.aspectH, next.outW, next.outH,
+    next.videoBitrate, next.followProgram ? 1 : 0, next.transitionMs, next.activeSetId,
+  );
+  return { ok: true, config: getCropConfig(db, apiKey) };
+}
+
+// ── preset sets ─────────────────────────────────────────────────────────────
+
+function formatSet(row) {
+  return { id: row.id, name: row.name, sortOrder: row.sort_order, createdAt: row.created_at };
+}
+
+export function listCropSets(db, apiKey) {
+  return db.prepare('SELECT * FROM crop_preset_sets WHERE api_key = ? ORDER BY sort_order, created_at')
+    .all(apiKey).map(formatSet);
+}
+
+/**
+ * Create a preset set; optionally clone all presets (and their source-map
+ * rows) from another set as a starting point.
+ * @returns {{ ok: true, set: object } | { ok: false, error: string }}
+ */
+export function createCropSet(db, apiKey, { name, sortOrder = 0, cloneFromSetId = null } = {}) {
+  if (!name || typeof name !== 'string' || !name.trim()) return { ok: false, error: 'name is required' };
+  const id = randomUUID();
+  try {
+    db.transaction(() => {
+      db.prepare('INSERT INTO crop_preset_sets (id, api_key, name, sort_order) VALUES (?, ?, ?, ?)')
+        .run(id, apiKey, name.trim(), sortOrder);
+      if (cloneFromSetId) {
+        const source = db.prepare('SELECT * FROM crop_presets WHERE api_key = ? AND set_id = ? ORDER BY sort_order, created_at')
+          .all(apiKey, cloneFromSetId);
+        for (const p of source) {
+          const newPresetId = randomUUID();
+          db.prepare('INSERT INTO crop_presets (id, api_key, set_id, name, x_norm, y_norm, sort_order) VALUES (?, ?, ?, ?, ?, ?, ?)')
+            .run(newPresetId, apiKey, id, p.name, p.x_norm, p.y_norm, p.sort_order);
+          const maps = db.prepare('SELECT * FROM crop_source_map WHERE api_key = ? AND preset_id = ?').all(apiKey, p.id);
+          for (const m of maps) {
+            db.prepare('INSERT INTO crop_source_map (id, api_key, mixer_id, mixer_input, camera_id, camera_preset, preset_id) VALUES (?, ?, ?, ?, ?, ?, ?)')
+              .run(randomUUID(), apiKey, m.mixer_id, m.mixer_input, m.camera_id, m.camera_preset, newPresetId);
+          }
+        }
+      }
+    })();
+  } catch (err) {
+    if (/UNIQUE/.test(err.message)) return { ok: false, error: `A set named "${name.trim()}" already exists` };
+    return { ok: false, error: err.message };
+  }
+  const row = db.prepare('SELECT * FROM crop_preset_sets WHERE id = ?').get(id);
+  return { ok: true, set: formatSet(row) };
+}
+
+export function updateCropSet(db, apiKey, id, { name, sortOrder } = {}) {
+  const existing = db.prepare('SELECT * FROM crop_preset_sets WHERE api_key = ? AND id = ?').get(apiKey, id);
+  if (!existing) return { ok: false, error: 'Set not found', status: 404 };
+  try {
+    db.prepare('UPDATE crop_preset_sets SET name = ?, sort_order = ? WHERE api_key = ? AND id = ?')
+      .run(
+        typeof name === 'string' && name.trim() ? name.trim() : existing.name,
+        sortOrder ?? existing.sort_order,
+        apiKey, id,
+      );
+  } catch (err) {
+    if (/UNIQUE/.test(err.message)) return { ok: false, error: `A set named "${name}" already exists` };
+    return { ok: false, error: err.message };
+  }
+  return { ok: true, set: formatSet(db.prepare('SELECT * FROM crop_preset_sets WHERE id = ?').get(id)) };
+}
+
+/** Deletes a set with its presets and their source-map rows (manual cascade). */
+export function deleteCropSet(db, apiKey, id) {
+  const existing = db.prepare('SELECT id FROM crop_preset_sets WHERE api_key = ? AND id = ?').get(apiKey, id);
+  if (!existing) return false;
+  db.transaction(() => {
+    db.prepare('DELETE FROM crop_source_map WHERE api_key = ? AND preset_id IN (SELECT id FROM crop_presets WHERE api_key = ? AND set_id = ?)')
+      .run(apiKey, apiKey, id);
+    db.prepare('DELETE FROM crop_presets WHERE api_key = ? AND set_id = ?').run(apiKey, id);
+    db.prepare('DELETE FROM crop_preset_sets WHERE api_key = ? AND id = ?').run(apiKey, id);
+    db.prepare('UPDATE crop_config SET active_set_id = NULL WHERE api_key = ? AND active_set_id = ?').run(apiKey, id);
+  })();
+  return true;
+}
+
+// ── presets ─────────────────────────────────────────────────────────────────
+
+function formatPreset(row) {
+  return {
+    id:        row.id,
+    setId:     row.set_id ?? null,
+    name:      row.name,
+    xNorm:     row.x_norm,
+    yNorm:     row.y_norm,
+    sortOrder: row.sort_order,
+    createdAt: row.created_at,
+  };
+}
+
+/**
+ * List presets. When `setId` is undefined the project's ACTIVE set is used
+ * (null = the implicit default set, i.e. presets with set_id IS NULL).
+ */
+export function listCropPresets(db, apiKey, { setId } = {}) {
+  const effectiveSetId = setId !== undefined ? setId : getCropConfig(db, apiKey).activeSetId;
+  const rows = effectiveSetId === null
+    ? db.prepare('SELECT * FROM crop_presets WHERE api_key = ? AND set_id IS NULL ORDER BY sort_order, created_at').all(apiKey)
+    : db.prepare('SELECT * FROM crop_presets WHERE api_key = ? AND set_id = ? ORDER BY sort_order, created_at').all(apiKey, effectiveSetId);
+  return rows.map(formatPreset);
+}
+
+export function getCropPreset(db, apiKey, id) {
+  const row = db.prepare('SELECT * FROM crop_presets WHERE api_key = ? AND id = ?').get(apiKey, id);
+  return row ? formatPreset(row) : null;
+}
+
+export function createCropPreset(db, apiKey, { name, xNorm = 0.5, yNorm = 0, setId = null, sortOrder = 0 } = {}) {
+  if (!name || typeof name !== 'string' || !name.trim()) return { ok: false, error: 'name is required' };
+  if (!Number.isFinite(Number(xNorm)) || !Number.isFinite(Number(yNorm))) {
+    return { ok: false, error: 'xNorm and yNorm must be numbers' };
+  }
+  if (setId !== null) {
+    const set = db.prepare('SELECT id FROM crop_preset_sets WHERE api_key = ? AND id = ?').get(apiKey, setId);
+    if (!set) return { ok: false, error: 'setId does not reference one of this project\'s sets' };
+  }
+  const id = randomUUID();
+  try {
+    db.prepare('INSERT INTO crop_presets (id, api_key, set_id, name, x_norm, y_norm, sort_order) VALUES (?, ?, ?, ?, ?, ?, ?)')
+      .run(id, apiKey, setId, name.trim(), clamp01(xNorm), clamp01(yNorm), sortOrder);
+  } catch (err) {
+    if (/UNIQUE/.test(err.message)) return { ok: false, error: `A preset named "${name.trim()}" already exists in this set` };
+    return { ok: false, error: err.message };
+  }
+  return { ok: true, preset: getCropPreset(db, apiKey, id) };
+}
+
+export function updateCropPreset(db, apiKey, id, { name, xNorm, yNorm, sortOrder } = {}) {
+  const existing = db.prepare('SELECT * FROM crop_presets WHERE api_key = ? AND id = ?').get(apiKey, id);
+  if (!existing) return { ok: false, error: 'Preset not found', status: 404 };
+  if ((xNorm !== undefined && !Number.isFinite(Number(xNorm))) || (yNorm !== undefined && !Number.isFinite(Number(yNorm)))) {
+    return { ok: false, error: 'xNorm and yNorm must be numbers' };
+  }
+  try {
+    db.prepare('UPDATE crop_presets SET name = ?, x_norm = ?, y_norm = ?, sort_order = ? WHERE api_key = ? AND id = ?')
+      .run(
+        typeof name === 'string' && name.trim() ? name.trim() : existing.name,
+        xNorm !== undefined ? clamp01(xNorm) : existing.x_norm,
+        yNorm !== undefined ? clamp01(yNorm) : existing.y_norm,
+        sortOrder ?? existing.sort_order,
+        apiKey, id,
+      );
+  } catch (err) {
+    if (/UNIQUE/.test(err.message)) return { ok: false, error: `A preset named "${name}" already exists in this set` };
+    return { ok: false, error: err.message };
+  }
+  return { ok: true, preset: getCropPreset(db, apiKey, id) };
+}
+
+/** Deletes a preset and its source-map rows (manual cascade). */
+export function deleteCropPreset(db, apiKey, id) {
+  const existing = db.prepare('SELECT id FROM crop_presets WHERE api_key = ? AND id = ?').get(apiKey, id);
+  if (!existing) return false;
+  db.transaction(() => {
+    db.prepare('DELETE FROM crop_source_map WHERE api_key = ? AND preset_id = ?').run(apiKey, id);
+    db.prepare('DELETE FROM crop_presets WHERE api_key = ? AND id = ?').run(apiKey, id);
+  })();
+  return true;
+}
+
+// ── source map ──────────────────────────────────────────────────────────────
+
+function formatMapRow(row) {
+  return {
+    id:           row.id,
+    mixerId:      row.mixer_id ?? null,
+    mixerInput:   row.mixer_input ?? null,
+    cameraId:     row.camera_id ?? null,
+    cameraPreset: row.camera_preset ?? null,
+    presetId:     row.preset_id,
+  };
+}
+
+export function listCropSourceMap(db, apiKey) {
+  return db.prepare('SELECT * FROM crop_source_map WHERE api_key = ?').all(apiKey).map(formatMapRow);
+}
+
+export function createCropSourceMapEntry(db, apiKey, { mixerId = null, mixerInput = null, cameraId = null, cameraPreset = null, presetId } = {}) {
+  if (!presetId) return { ok: false, error: 'presetId is required' };
+  const preset = db.prepare('SELECT id FROM crop_presets WHERE api_key = ? AND id = ?').get(apiKey, presetId);
+  if (!preset) return { ok: false, error: 'presetId does not reference one of this project\'s presets' };
+  const hasMixer = mixerId !== null || mixerInput !== null;
+  const hasCamera = cameraId !== null;
+  if (!hasMixer && !hasCamera) {
+    return { ok: false, error: 'At least one of mixerId/mixerInput or cameraId must be set' };
+  }
+  const id = randomUUID();
+  db.prepare('INSERT INTO crop_source_map (id, api_key, mixer_id, mixer_input, camera_id, camera_preset, preset_id) VALUES (?, ?, ?, ?, ?, ?, ?)')
+    .run(id, apiKey, mixerId, mixerInput, cameraId, cameraPreset, presetId);
+  return { ok: true, entry: formatMapRow(db.prepare('SELECT * FROM crop_source_map WHERE id = ?').get(id)) };
+}
+
+export function deleteCropSourceMapEntry(db, apiKey, id) {
+  return db.prepare('DELETE FROM crop_source_map WHERE api_key = ? AND id = ?').run(apiKey, id).changes > 0;
+}
+
+/**
+ * Resolve which preset should be active for a program-source change.
+ * Most-specific row wins: (camera_id + camera_preset) beats (camera_id) beats
+ * (mixer_id + mixer_input) beats (mixer_input only). Resolution is scoped to
+ * the project's ACTIVE preset set — a map row pointing at a preset from a
+ * different set is ignored.
+ *
+ * @param {object} src { mixerId?, mixerInput?, cameraId?, cameraPreset? }
+ * @returns {object|null} the winning preset (formatPreset shape) or null
+ */
+export function resolveCropPresetForSource(db, apiKey, { mixerId = null, mixerInput = null, cameraId = null, cameraPreset = null } = {}) {
+  const activeSetId = getCropConfig(db, apiKey).activeSetId;
+  const rows = db.prepare('SELECT * FROM crop_source_map WHERE api_key = ?').all(apiKey);
+
+  let best = null;
+  let bestScore = -1;
+  for (const row of rows) {
+    let score = 0;
+    if (row.camera_id !== null) {
+      if (row.camera_id !== cameraId) continue;
+      score += 4;
+      if (row.camera_preset !== null) {
+        if (row.camera_preset !== cameraPreset) continue;
+        score += 4;
+      }
+    }
+    if (row.mixer_input !== null) {
+      if (row.mixer_input !== mixerInput) continue;
+      score += 2;
+      if (row.mixer_id !== null) {
+        if (row.mixer_id !== mixerId) continue;
+        score += 1;
+      }
+    } else if (row.mixer_id !== null) {
+      if (row.mixer_id !== mixerId) continue;
+      score += 1;
+    }
+    if (score === 0) continue;
+
+    const preset = db.prepare('SELECT * FROM crop_presets WHERE api_key = ? AND id = ?').get(apiKey, row.preset_id);
+    if (!preset) continue;
+    if ((preset.set_id ?? null) !== activeSetId) continue;
+
+    if (score > bestScore) {
+      bestScore = score;
+      best = preset;
+    }
+  }
+  return best ? formatPreset(best) : null;
+}

--- a/packages/plugins/lcyt-rtmp/src/db/relay.js
+++ b/packages/plugins/lcyt-rtmp/src/db/relay.js
@@ -132,6 +132,8 @@ function formatRelayRow(row) {
     fps:          row.fps          ?? null,
     videoBitrate: row.video_bitrate || null,
     audioBitrate: row.audio_bitrate || null,
+    // 'program' (raw ingest, default) or 'crop' ({key}-crop vertical rendition)
+    sourceView:   row.source_view  || 'program',
     createdAt:    row.created_at,
     updatedAt:    row.updated_at,
   };
@@ -191,13 +193,16 @@ export function buildRelayFfmpegUrl(relay) {
  * @param {{ targetName?: string|null, captionMode?: string, scale?: string|null, fps?: number|null, videoBitrate?: string|null, audioBitrate?: string|null }} [opts]
  * @returns {object}
  */
-export function upsertRelay(db, apiKey, slot, targetUrl, { targetName = null, captionMode = 'http', scale = null, fps = null, videoBitrate = null, audioBitrate = null } = {}) {
+export function upsertRelay(db, apiKey, slot, targetUrl, { targetName = null, captionMode = 'http', scale = null, fps = null, videoBitrate = null, audioBitrate = null, sourceView = 'program' } = {}) {
   if (!Number.isInteger(slot) || slot < 1 || slot > MAX_RELAY_SLOTS) {
     throw new RangeError(`slot must be an integer 1-${MAX_RELAY_SLOTS}, got ${slot}`);
   }
+  if (sourceView !== 'program' && sourceView !== 'crop') {
+    throw new RangeError(`sourceView must be 'program' or 'crop', got ${sourceView}`);
+  }
   db.prepare(`
-    INSERT INTO rtmp_relays (api_key, slot, target_url, target_name, caption_mode, scale, fps, video_bitrate, audio_bitrate)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO rtmp_relays (api_key, slot, target_url, target_name, caption_mode, scale, fps, video_bitrate, audio_bitrate, source_view)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(api_key, slot) DO UPDATE SET
       target_url   = excluded.target_url,
       target_name  = excluded.target_name,
@@ -206,8 +211,9 @@ export function upsertRelay(db, apiKey, slot, targetUrl, { targetName = null, ca
       fps          = excluded.fps,
       video_bitrate = excluded.video_bitrate,
       audio_bitrate = excluded.audio_bitrate,
+      source_view  = excluded.source_view,
       updated_at   = datetime('now')
-  `).run(apiKey, slot, targetUrl, targetName || null, captionMode || 'http', scale || null, fps ?? null, videoBitrate || null, audioBitrate || null);
+  `).run(apiKey, slot, targetUrl, targetName || null, captionMode || 'http', scale || null, fps ?? null, videoBitrate || null, audioBitrate || null, sourceView);
   return getRelaySlot(db, apiKey, slot);
 }
 

--- a/packages/plugins/lcyt-rtmp/src/routes/crop.js
+++ b/packages/plugins/lcyt-rtmp/src/routes/crop.js
@@ -1,0 +1,243 @@
+/**
+ * Factory for the /crop router (plan_vertical_crop.md §3).
+ *
+ * Session-Bearer routes managing the vertical-crop rendition:
+ *
+ *   GET    /crop/config                — config + { running, repositionMode, ... }
+ *   PUT    /crop/config                — update config; starts/stops the renderer on enable flips while publishing
+ *   GET    /crop/status                — renderer state + active position
+ *   POST   /crop/position              — { xNorm, yNorm, transitionMs? } free positioning
+ *   GET/POST/PUT/DELETE /crop/presets[/:id]     — preset CRUD (?setId= filter; default = active set)
+ *   POST   /crop/presets/:id/activate  — { transitionMs? } apply a preset live
+ *   GET/POST/PUT/DELETE /crop/sets[/:id]        — preset-set (bank) CRUD; POST supports { cloneFromSetId }
+ *   POST   /crop/sets/:id/activate     — switch the active set; re-applies the current position from it
+ *   GET/POST/DELETE /crop/source-map[/:id]      — production-follow mapping CRUD
+ *
+ * Feature-gated on the `crop` project feature when FEATURE_GATE_ENFORCE=1
+ * (same inline pattern as routes/ingestion.js — plugins query core tables
+ * directly instead of importing lcyt-backend middleware).
+ */
+import { Router } from 'express';
+import {
+  getCropConfig, setCropConfig,
+  listCropPresets, getCropPreset, createCropPreset, updateCropPreset, deleteCropPreset,
+  listCropSets, createCropSet, updateCropSet, deleteCropSet,
+  listCropSourceMap, createCropSourceMapEntry, deleteCropSourceMapEntry,
+} from '../db.js';
+import logger from 'lcyt/logger';
+
+function isFeatureGateEnforced() {
+  const v = process.env.FEATURE_GATE_ENFORCE;
+  return v === '1' || v === 'true';
+}
+
+function hasCropFeature(db, apiKey) {
+  const row = db.prepare(
+    "SELECT enabled FROM project_features WHERE api_key = ? AND feature_code = 'crop'"
+  ).get(apiKey);
+  return row?.enabled === 1;
+}
+
+/**
+ * @param {import('better-sqlite3').Database} db
+ * @param {import('express').RequestHandler} auth  Session JWT Bearer middleware
+ * @param {import('../crop-manager.js').CropManager} cropManager
+ * @param {import('../rtmp-manager.js').RtmpRelayManager} [relayManager]  For isPublishing()
+ * @returns {Router}
+ */
+export function createCropRouter(db, auth, cropManager, relayManager = null) {
+  const router = Router();
+  router.use(auth);
+
+  router.use((req, res, next) => {
+    if (isFeatureGateEnforced() && !hasCropFeature(db, req.session.apiKey)) {
+      return res.status(403).json({ error: "Feature 'crop' is not enabled for this project", feature: 'crop' });
+    }
+    next();
+  });
+
+  // ── config ────────────────────────────────────────────────────────────────
+
+  router.get('/config', (req, res) => {
+    const apiKey = req.session.apiKey;
+    res.json({
+      ...getCropConfig(db, apiKey),
+      ...cropManager.getStatus(apiKey),
+    });
+  });
+
+  router.put('/config', async (req, res) => {
+    const apiKey = req.session.apiKey;
+    const wasEnabled = getCropConfig(db, apiKey).enabled;
+    const result = setCropConfig(db, apiKey, req.body || {});
+    if (!result.ok) return res.status(400).json({ error: result.error });
+
+    // Start/stop the renderer to match the new config while the source is live.
+    const nowEnabled = result.config.enabled;
+    try {
+      if (nowEnabled && !cropManager.isRunning(apiKey) && relayManager?.isPublishing(apiKey)) {
+        await cropManager.start(apiKey, result.config);
+      } else if (!nowEnabled && wasEnabled && cropManager.isRunning(apiKey)) {
+        await cropManager.stop(apiKey);
+      }
+    } catch (err) {
+      logger.warn(`[crop] renderer start/stop after config change failed for ${apiKey.slice(0, 8)}: ${err.message}`);
+    }
+
+    res.json({ ...result.config, ...cropManager.getStatus(apiKey) });
+  });
+
+  router.get('/status', (req, res) => {
+    res.json(cropManager.getStatus(req.session.apiKey));
+  });
+
+  // ── free positioning ──────────────────────────────────────────────────────
+
+  router.post('/position', async (req, res) => {
+    const apiKey = req.session.apiKey;
+    const { xNorm, yNorm, transitionMs } = req.body || {};
+    if (!Number.isFinite(Number(xNorm)) || !Number.isFinite(Number(yNorm))) {
+      return res.status(400).json({ error: 'xNorm and yNorm are required numbers (0-1)' });
+    }
+    if (!cropManager.isRunning(apiKey)) {
+      return res.status(409).json({ error: 'Crop renderer is not running' });
+    }
+    try {
+      const result = await cropManager.applyPosition(apiKey, {
+        xNorm: Number(xNorm),
+        yNorm: Number(yNorm),
+        transitionMs: Number(transitionMs) > 0 ? Number(transitionMs) : 0,
+        activePresetId: null, // free move — no longer "on" a preset
+      });
+      res.json(result);
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  // ── presets ───────────────────────────────────────────────────────────────
+
+  router.get('/presets', (req, res) => {
+    const setId = req.query.setId !== undefined
+      ? (req.query.setId === '' || req.query.setId === 'null' ? null : String(req.query.setId))
+      : undefined;
+    res.json({ presets: listCropPresets(db, req.session.apiKey, { setId }) });
+  });
+
+  router.post('/presets', (req, res) => {
+    const result = createCropPreset(db, req.session.apiKey, req.body || {});
+    if (!result.ok) return res.status(400).json({ error: result.error });
+    res.status(201).json({ ok: true, preset: result.preset });
+  });
+
+  router.put('/presets/:id', (req, res) => {
+    const result = updateCropPreset(db, req.session.apiKey, req.params.id, req.body || {});
+    if (!result.ok) return res.status(result.status ?? 400).json({ error: result.error });
+    res.json({ ok: true, preset: result.preset });
+  });
+
+  router.delete('/presets/:id', (req, res) => {
+    const deleted = deleteCropPreset(db, req.session.apiKey, req.params.id);
+    if (!deleted) return res.status(404).json({ error: 'Preset not found' });
+    res.json({ ok: true });
+  });
+
+  router.post('/presets/:id/activate', async (req, res) => {
+    const apiKey = req.session.apiKey;
+    const preset = getCropPreset(db, apiKey, req.params.id);
+    if (!preset) return res.status(404).json({ error: 'Preset not found' });
+    if (!cropManager.isRunning(apiKey)) {
+      return res.status(409).json({ error: 'Crop renderer is not running' });
+    }
+    const transitionMs = Number(req.body?.transitionMs) >= 0
+      ? Number(req.body.transitionMs)
+      : getCropConfig(db, apiKey).transitionMs;
+    try {
+      const result = await cropManager.applyPosition(apiKey, {
+        xNorm: preset.xNorm,
+        yNorm: preset.yNorm,
+        transitionMs,
+        activePresetId: preset.id,
+      });
+      res.json({ ...result, presetId: preset.id });
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  // ── preset sets (banks) ───────────────────────────────────────────────────
+
+  router.get('/sets', (req, res) => {
+    const apiKey = req.session.apiKey;
+    res.json({ sets: listCropSets(db, apiKey), activeSetId: getCropConfig(db, apiKey).activeSetId });
+  });
+
+  router.post('/sets', (req, res) => {
+    const result = createCropSet(db, req.session.apiKey, req.body || {});
+    if (!result.ok) return res.status(400).json({ error: result.error });
+    res.status(201).json({ ok: true, set: result.set });
+  });
+
+  router.put('/sets/:id', (req, res) => {
+    const result = updateCropSet(db, req.session.apiKey, req.params.id, req.body || {});
+    if (!result.ok) return res.status(result.status ?? 400).json({ error: result.error });
+    res.json({ ok: true, set: result.set });
+  });
+
+  router.delete('/sets/:id', (req, res) => {
+    const deleted = deleteCropSet(db, req.session.apiKey, req.params.id);
+    if (!deleted) return res.status(404).json({ error: 'Set not found' });
+    res.json({ ok: true });
+  });
+
+  router.post('/sets/:id/activate', async (req, res) => {
+    const apiKey = req.session.apiKey;
+    const result = setCropConfig(db, apiKey, { activeSetId: req.params.id });
+    if (!result.ok) return res.status(404).json({ error: result.error });
+
+    // Re-apply: if the renderer is running and the previously-active preset has
+    // a same-named counterpart in the new set, shift to it live.
+    let applied = null;
+    const status = cropManager.getStatus(apiKey);
+    if (status.running && status.activePresetId) {
+      const oldPreset = getCropPreset(db, apiKey, status.activePresetId);
+      if (oldPreset) {
+        const counterpart = listCropPresets(db, apiKey, { setId: req.params.id })
+          .find(p => p.name === oldPreset.name);
+        if (counterpart) {
+          try {
+            applied = await cropManager.applyPosition(apiKey, {
+              xNorm: counterpart.xNorm,
+              yNorm: counterpart.yNorm,
+              transitionMs: result.config.transitionMs,
+              activePresetId: counterpart.id,
+            });
+          } catch (err) {
+            logger.warn(`[crop] set-activate re-apply failed for ${apiKey.slice(0, 8)}: ${err.message}`);
+          }
+        }
+      }
+    }
+    res.json({ ok: true, activeSetId: req.params.id, applied });
+  });
+
+  // ── source map ────────────────────────────────────────────────────────────
+
+  router.get('/source-map', (req, res) => {
+    res.json({ entries: listCropSourceMap(db, req.session.apiKey) });
+  });
+
+  router.post('/source-map', (req, res) => {
+    const result = createCropSourceMapEntry(db, req.session.apiKey, req.body || {});
+    if (!result.ok) return res.status(400).json({ error: result.error });
+    res.status(201).json({ ok: true, entry: result.entry });
+  });
+
+  router.delete('/source-map/:id', (req, res) => {
+    const deleted = deleteCropSourceMapEntry(db, req.session.apiKey, req.params.id);
+    if (!deleted) return res.status(404).json({ error: 'Mapping not found' });
+    res.json({ ok: true });
+  });
+
+  return router;
+}

--- a/packages/plugins/lcyt-rtmp/src/routes/rtmp.js
+++ b/packages/plugins/lcyt-rtmp/src/routes/rtmp.js
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import express from 'express';
-import { isRelayAllowed, isRelayActive, getRelays, getKey, resolveApiKeyFromIngestStreamKey } from '../db.js';
+import { isRelayAllowed, isRelayActive, getRelays, getKey, resolveApiKeyFromIngestStreamKey, getCropConfig } from '../db.js';
 import logger from 'lcyt/logger';
 
 /**
@@ -28,9 +28,10 @@ import logger from 'lcyt/logger';
  *
  * @param {import('better-sqlite3').Database} db
  * @param {import('../rtmp-manager.js').RtmpRelayManager} relayManager
+ * @param {import('../crop-manager.js').CropManager} [cropManager]  Vertical-crop renderer lifecycle
  * @returns {Router}
  */
-export function createRtmpRouter(db, relayManager) {
+export function createRtmpRouter(db, relayManager, cropManager = null) {
   const router = Router();
 
   // Parse application/x-www-form-urlencoded bodies (nginx-rtmp format)
@@ -85,6 +86,21 @@ export function createRtmpRouter(db, relayManager) {
         logger.info(`[rtmp] Relay not active for ${apiKey.slice(0, 8)}…; accepting stream but not fanning out`);
       }
 
+      // Vertical-crop renderer: start when the project has crop enabled
+      // (best-effort, parallel to the relay fan-out above).
+      if (cropManager) {
+        try {
+          const cropConfig = getCropConfig(db, apiKey);
+          if (cropConfig.enabled && !cropManager.isRunning(apiKey)) {
+            cropManager.start(apiKey, cropConfig).catch(err => {
+              logger.error(`[rtmp] Crop renderer start failed for ${apiKey.slice(0, 8)}…: ${err.message}`);
+            });
+          }
+        } catch (err) {
+          logger.error(`[rtmp] Crop config lookup failed for ${apiKey.slice(0, 8)}…: ${err.message}`);
+        }
+      }
+
       // Always 200 to allow the publish (relay fan-out is best-effort)
       return res.status(200).send('ok');
     }
@@ -96,6 +112,11 @@ export function createRtmpRouter(db, relayManager) {
         await relayManager.stopKey(apiKey);
       } catch (err) {
         logger.error(`[rtmp] Failed to stop relay for ${apiKey.slice(0, 8)}…: ${err.message}`);
+      }
+      if (cropManager?.isRunning(apiKey)) {
+        cropManager.stop(apiKey).catch(err => {
+          logger.error(`[rtmp] Crop renderer stop failed for ${apiKey.slice(0, 8)}…: ${err.message}`);
+        });
       }
       return res.status(200).send('ok');
     }

--- a/packages/plugins/lcyt-rtmp/src/routes/stream.js
+++ b/packages/plugins/lcyt-rtmp/src/routes/stream.js
@@ -52,13 +52,24 @@ export function createStreamRouter(db, auth, relayManager, allowedRtmpDomains) {
   }
 
   function validateBody(req, res) {
-    const { targetUrl, targetName, captionMode, scale, fps, videoBitrate, audioBitrate } = req.body || {};
+    const { targetUrl, targetName, captionMode, scale, fps, videoBitrate, audioBitrate, sourceView } = req.body || {};
     if (!targetUrl || typeof targetUrl !== 'string' || !targetUrl.startsWith('rtmp')) {
       res.status(400).json({ error: 'targetUrl must be a valid rtmp:// or rtmps:// URL' });
       return null;
     }
     const validModes = ['http', 'cea708'];
     const resolvedMode = validModes.includes(captionMode) ? captionMode : 'http';
+
+    // Which rendition this slot forwards (plan_vertical_crop.md): the raw
+    // program feed (default) or the {key}-crop vertical rendition.
+    let resolvedSourceView = 'program';
+    if (sourceView !== undefined && sourceView !== null && sourceView !== '') {
+      if (sourceView !== 'program' && sourceView !== 'crop') {
+        res.status(400).json({ error: "sourceView must be 'program' or 'crop'" });
+        return null;
+      }
+      resolvedSourceView = sourceView;
+    }
 
     // Validate optional per-slot transcode options
     let resolvedScale = null;
@@ -89,6 +100,7 @@ export function createStreamRouter(db, auth, relayManager, allowedRtmpDomains) {
       fps:          resolvedFps,
       videoBitrate: resolvedVideoBitrate,
       audioBitrate: resolvedAudioBitrate,
+      sourceView:   resolvedSourceView,
     };
   }
 
@@ -124,6 +136,7 @@ export function createStreamRouter(db, auth, relayManager, allowedRtmpDomains) {
         fps:          fields.fps,
         videoBitrate: fields.videoBitrate,
         audioBitrate: fields.audioBitrate,
+        sourceView:   fields.sourceView,
       });
       return res.status(201).json({ ok: true, relay });
     } catch (err) {
@@ -207,6 +220,7 @@ export function createStreamRouter(db, auth, relayManager, allowedRtmpDomains) {
         fps:          fields.fps,
         videoBitrate: fields.videoBitrate,
         audioBitrate: fields.audioBitrate,
+        sourceView:   fields.sourceView,
       });
       return res.status(200).json({ ok: true, relay });
     } catch (err) {

--- a/packages/plugins/lcyt-rtmp/src/rtmp-manager.js
+++ b/packages/plugins/lcyt-rtmp/src/rtmp-manager.js
@@ -211,6 +211,15 @@ export class RtmpRelayManager {
     this._mediamtxRelays = new Map();
 
     /**
+     * Crop-view relay fan-outs: slots forwarding the {key}-crop vertical
+     * rendition via a MediaMTX runOnPublish hook on that path
+     * (plan_vertical_crop.md). No local ffmpeg process here either — the
+     * crop renderer itself is owned by CropManager.
+     * @type {Map<string, { slots: Array, startedAt: Date }>}
+     */
+    this._cropRelays = new Map();
+
+    /**
      * Per-key metadata: { slots, startedAt, hasCea708, srtSeq }
      * @type {Map<string, { slots: Array, startedAt: Date, hasCea708: boolean, srtSeq: number, cea708DelayMs: number }>}
      */
@@ -279,9 +288,18 @@ export class RtmpRelayManager {
    * @returns {Promise<void>}
    */
   async start(apiKey, relays, { cea708DelayMs = 0 } = {}) {
-      if (!relays || relays.length === 0) {
+      // Crop-view slots (sourceView: 'crop') forward the {key}-crop vertical
+      // rendition instead of the raw ingest — they are fanned out by MediaMTX
+      // from that path and never participate in the CEA-708/transcode/DSK
+      // process modes below (the crop renderer already re-encodes).
+      const allSlots = relays ?? [];
+      const cropSlots = allSlots.filter(r => r.sourceView === 'crop');
+      relays = allSlots.filter(r => r.sourceView !== 'crop');
+
+      if (allSlots.length === 0) {
         await this._stopProc(apiKey);
         await this._stopMediamtxRelay(apiKey);
+        await this._stopCropRelay(apiKey);
         return;
       }
 
@@ -299,6 +317,12 @@ export class RtmpRelayManager {
       // Awaited so the path deletions land before we re-add path configs below.
       await this._stopProc(apiKey);
       await this._stopMediamtxRelay(apiKey);
+      await this._stopCropRelay(apiKey);
+
+      if (cropSlots.length > 0) {
+        await this._startCropRelay(apiKey, cropSlots);
+      }
+      if (relays.length === 0) return;
 
       // Determine operating mode.
       // CEA-708: any slot with captionMode='cea708' AND ffmpeg supports libx264+eia608+subrip.
@@ -679,6 +703,9 @@ export class RtmpRelayManager {
    */
   stop(apiKey) {
     return (async () => {
+      // Crop-view fan-out (may coexist with either mode below)
+      await this._stopCropRelay(apiKey);
+
       // MediaMTX-managed plain relay
       if (this._mediamtxRelays.has(apiKey)) {
         await this._stopMediamtxRelay(apiKey);
@@ -701,6 +728,75 @@ export class RtmpRelayManager {
         await this._stopProc(apiKey);
       }
     })();
+  }
+
+  /**
+   * Register the fan-out for crop-view slots: a runOnPublish hook on the
+   * {key}-crop path that tees the crop rendition to the slot targets. Fires
+   * when CropManager's renderer publishes. Requires a MediaMTX client — the
+   * crop rendition only exists inside MediaMTX.
+   * @param {string} apiKey
+   * @param {Array} cropSlots
+   * @returns {Promise<void>}
+   */
+  async _startCropRelay(apiKey, cropSlots) {
+    if (!this._mediamtx) {
+      logger.warn(`[rtmp] ${cropSlots.length} crop-view slot(s) configured for ${apiKey.slice(0, 8)} but no MediaMTX client — skipping (vertical crop requires MediaMTX)`);
+      return;
+    }
+    const cropPath = `${apiKey}-crop`;
+    if (!SAFE_NAME_RE.test(apiKey)) {
+      throw new Error('API key contains unsafe characters for MediaMTX runOnPublish');
+    }
+    const teeTargets = _buildTeeTargets(cropSlots);
+    const runOnPublish = `ffmpeg -re -i ${DEFAULT_MEDIAMTX_RTSP}/${cropPath} -c copy -f tee "${teeTargets}"`;
+    try {
+      await this._upsertPath(cropPath, { runOnPublish, runOnPublishRestart: true });
+      logger.info(`[rtmp] Crop relay for ${apiKey.slice(0, 8)} configured via MediaMTX (${cropSlots.length} slot(s))`);
+    } catch (err) {
+      logger.warn(`[rtmp] MediaMTX addPath (crop relay) failed for ${apiKey.slice(0, 8)}: ${err.message} — crop slots may not forward`);
+    }
+    // Kick any current publisher so the hook fires immediately for a
+    // renderer that is already mid-publish.
+    this._mediamtx.kickPath(cropPath).catch(() => {});
+
+    const startedAt = new Date();
+    this._cropRelays.set(apiKey, { slots: cropSlots.map(r => ({ ...r })), startedAt });
+    for (const r of cropSlots) {
+      this._onStreamStarted?.(apiKey, r.slot, {
+        targetUrl:   r.targetUrl,
+        targetName:  r.targetName ?? null,
+        captionMode: 'http',
+        startedAt,
+      });
+    }
+  }
+
+  /**
+   * Tear down the crop-view fan-out. No-op when none is registered.
+   * @param {string} apiKey
+   * @returns {Promise<void>}
+   */
+  async _stopCropRelay(apiKey) {
+    const meta = this._cropRelays.get(apiKey);
+    if (!meta) return;
+    this._cropRelays.delete(apiKey);
+    if (this._mediamtx) {
+      try { await this._mediamtx.deletePath(`${apiKey}-crop`); } catch {}
+    }
+    const endedAt = new Date();
+    const durationMs = endedAt.getTime() - meta.startedAt.getTime();
+    for (const r of meta.slots) {
+      this._onStreamEnded?.(apiKey, r.slot, {
+        targetUrl:   r.targetUrl,
+        targetName:  r.targetName ?? null,
+        captionMode: 'http',
+        startedAt:   meta.startedAt,
+        endedAt,
+        durationMs,
+        captionsSent: 0,
+      });
+    }
   }
 
   /**
@@ -763,7 +859,7 @@ export class RtmpRelayManager {
    * @returns {Promise<void>}
    */
   async stopAll() {
-    const keys = new Set([...this._procs.keys(), ...this._mediamtxRelays.keys()]);
+    const keys = new Set([...this._procs.keys(), ...this._mediamtxRelays.keys(), ...this._cropRelays.keys()]);
     await Promise.all([...keys].map(k => this.stop(k)));
   }
 
@@ -885,7 +981,7 @@ export class RtmpRelayManager {
    * @returns {boolean}
    */
   isRunning(apiKey) {
-    return this._procs.has(apiKey) || this._mediamtxRelays.has(apiKey);
+    return this._procs.has(apiKey) || this._mediamtxRelays.has(apiKey) || this._cropRelays.has(apiKey);
   }
 
   /**
@@ -896,7 +992,9 @@ export class RtmpRelayManager {
    */
   isSlotRunning(apiKey, slot) {
     const meta = this._meta.get(apiKey) ?? this._mediamtxRelays.get(apiKey);
-    return !!meta && meta.slots.some(s => s.slot === slot);
+    if (meta && meta.slots.some(s => s.slot === slot)) return true;
+    const crop = this._cropRelays.get(apiKey);
+    return !!crop && crop.slots.some(s => s.slot === slot);
   }
 
   /**
@@ -906,8 +1004,12 @@ export class RtmpRelayManager {
    */
   runningSlots(apiKey) {
     const meta = this._meta.get(apiKey) ?? this._mediamtxRelays.get(apiKey);
-    if (!meta) return [];
-    return meta.slots.map(s => s.slot).sort((a, b) => a - b);
+    const crop = this._cropRelays.get(apiKey);
+    const slots = [
+      ...(meta ? meta.slots.map(s => s.slot) : []),
+      ...(crop ? crop.slots.map(s => s.slot) : []),
+    ];
+    return slots.sort((a, b) => a - b);
   }
 
   /**
@@ -916,7 +1018,7 @@ export class RtmpRelayManager {
    * @returns {Date|null}
    */
   startedAt(apiKey) {
-    return (this._meta.get(apiKey) ?? this._mediamtxRelays.get(apiKey))?.startedAt ?? null;
+    return (this._meta.get(apiKey) ?? this._mediamtxRelays.get(apiKey) ?? this._cropRelays.get(apiKey))?.startedAt ?? null;
   }
 
   /**
@@ -1138,31 +1240,39 @@ export function probeFfmpeg() {
     } else {
       logger.warn('⚠ ffmpeg probe failed:', which.error.message);
     }
-    return { available: false, hasLibx264: false, hasEia608: false, hasSubrip: false };
+    return { available: false, hasLibx264: false, hasEia608: false, hasSubrip: false, hasZmq: false };
   }
 
   try {
     const enc = spawnSync('ffmpeg', ['-hide_banner', '-encoders'], { encoding: 'utf8', timeout: 3000 });
     const fmts = spawnSync('ffmpeg', ['-hide_banner', '-formats'], { encoding: 'utf8', timeout: 3000 });
     const demux = spawnSync('ffmpeg', ['-hide_banner', '-demuxers'], { encoding: 'utf8', timeout: 3000 });
+    const filters = spawnSync('ffmpeg', ['-hide_banner', '-filters'], { encoding: 'utf8', timeout: 3000 });
 
     const encOut = (enc.stdout || '') + (enc.stderr || '');
     const fmtsOut = (fmts.stdout || '') + (fmts.stderr || '');
     const demuxOut = (demux.stdout || '') + (demux.stderr || '');
+    const filtersOut = (filters.stdout || '') + (filters.stderr || '');
 
     const hasLibx264 = /libx264/i.test(encOut);
     const hasEia608 = /eia-?608|eia_?608|eia608/i.test(encOut);
     const hasSubrip = /subrip/i.test(fmtsOut) || /subrip/i.test(demuxOut);
+    // zmq filter (--enable-libzmq builds) — enables live crop repositioning
+    // via runtime filter commands (plan_vertical_crop.md).
+    const hasZmq = /\szmq\s/.test(filtersOut);
 
     logger.info('✓ ffmpeg found — RTMP relay is available.');
 
     if (!hasLibx264) {
       logger.info('  [i] ffmpeg: libx264 encoder not detected -- CEA-708 embedded captions unavailable (HTTP caption mode will be used).');
     }
+    if (!hasZmq) {
+      logger.info('  [i] ffmpeg: zmq filter not detected -- vertical-crop position changes will restart the renderer (build ffmpeg with --enable-libzmq for gapless repositioning).');
+    }
 
-    return { available: true, hasLibx264, hasEia608, hasSubrip };
+    return { available: true, hasLibx264, hasEia608, hasSubrip, hasZmq };
   } catch (err) {
     logger.warn('⚠ ffmpeg probe failed:', err.message);
-    return { available: false, hasLibx264: false, hasEia608: false, hasSubrip: false };
+    return { available: false, hasLibx264: false, hasEia608: false, hasSubrip: false, hasZmq: false };
   }
 }

--- a/packages/plugins/lcyt-rtmp/test/crop-db.test.js
+++ b/packages/plugins/lcyt-rtmp/test/crop-db.test.js
@@ -1,0 +1,210 @@
+/**
+ * DB-helper tests for src/db/crop.js — config, preset sets (incl. clone),
+ * presets, source map, and follow-resolution specificity.
+ */
+import { test, describe, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import Database from 'better-sqlite3';
+import {
+  runCropMigrations,
+  getCropConfig, setCropConfig,
+  listCropSets, createCropSet, updateCropSet, deleteCropSet,
+  listCropPresets, getCropPreset, createCropPreset, updateCropPreset, deleteCropPreset,
+  listCropSourceMap, createCropSourceMapEntry, deleteCropSourceMapEntry,
+  resolveCropPresetForSource,
+} from '../src/db/crop.js';
+
+const KEY = 'testkey1';
+let db;
+
+beforeEach(() => {
+  db = new Database(':memory:');
+  runCropMigrations(db);
+});
+
+describe('crop_config', () => {
+  test('defaults when no row exists', () => {
+    const cfg = getCropConfig(db, KEY);
+    assert.equal(cfg.enabled, false);
+    assert.equal(cfg.aspectW, 9);
+    assert.equal(cfg.aspectH, 16);
+    assert.equal(cfg.followProgram, true);
+    assert.equal(cfg.transitionMs, 0);
+    assert.equal(cfg.activeSetId, null);
+  });
+
+  test('partial updates preserve other fields', () => {
+    assert.equal(setCropConfig(db, KEY, { enabled: true, transitionMs: 300 }).ok, true);
+    const r2 = setCropConfig(db, KEY, { videoBitrate: '4500k' });
+    assert.equal(r2.ok, true);
+    assert.equal(r2.config.enabled, true);
+    assert.equal(r2.config.transitionMs, 300);
+    assert.equal(r2.config.videoBitrate, '4500k');
+  });
+
+  test('rejects invalid values', () => {
+    assert.equal(setCropConfig(db, KEY, { aspectW: 0 }).ok, false);
+    assert.equal(setCropConfig(db, KEY, { transitionMs: -5 }).ok, false);
+    assert.equal(setCropConfig(db, KEY, { videoBitrate: '; rm -rf /' }).ok, false);
+    assert.equal(setCropConfig(db, KEY, { activeSetId: 'nope' }).ok, false);
+  });
+});
+
+describe('preset sets', () => {
+  test('create, list, rename, unique names', () => {
+    const a = createCropSet(db, KEY, { name: 'Sermon' });
+    assert.equal(a.ok, true);
+    assert.equal(createCropSet(db, KEY, { name: 'Sermon' }).ok, false);
+    const b = createCropSet(db, KEY, { name: 'Concert', sortOrder: 1 });
+    assert.equal(b.ok, true);
+    assert.deepEqual(listCropSets(db, KEY).map(s => s.name), ['Sermon', 'Concert']);
+
+    const renamed = updateCropSet(db, KEY, a.set.id, { name: 'Sunday' });
+    assert.equal(renamed.ok, true);
+    assert.equal(renamed.set.name, 'Sunday');
+  });
+
+  test('clone copies presets and their source-map rows', () => {
+    const a = createCropSet(db, KEY, { name: 'A' });
+    const p = createCropPreset(db, KEY, { name: 'lectern', xNorm: 0.2, setId: a.set.id });
+    createCropSourceMapEntry(db, KEY, { mixerInput: 1, presetId: p.preset.id });
+
+    const b = createCropSet(db, KEY, { name: 'B', cloneFromSetId: a.set.id });
+    assert.equal(b.ok, true);
+    const clonedPresets = listCropPresets(db, KEY, { setId: b.set.id });
+    assert.equal(clonedPresets.length, 1);
+    assert.equal(clonedPresets[0].name, 'lectern');
+    assert.equal(clonedPresets[0].xNorm, 0.2);
+    assert.notEqual(clonedPresets[0].id, p.preset.id);
+
+    const maps = listCropSourceMap(db, KEY);
+    assert.equal(maps.length, 2);
+    assert.ok(maps.some(m => m.presetId === clonedPresets[0].id));
+  });
+
+  test('delete cascades presets, source-map rows, and clears active_set_id', () => {
+    const a = createCropSet(db, KEY, { name: 'A' });
+    const p = createCropPreset(db, KEY, { name: 'x', setId: a.set.id });
+    createCropSourceMapEntry(db, KEY, { mixerInput: 2, presetId: p.preset.id });
+    setCropConfig(db, KEY, { activeSetId: a.set.id });
+
+    assert.equal(deleteCropSet(db, KEY, a.set.id), true);
+    assert.equal(listCropSets(db, KEY).length, 0);
+    assert.equal(listCropPresets(db, KEY, { setId: a.set.id }).length, 0);
+    assert.equal(listCropSourceMap(db, KEY).length, 0);
+    assert.equal(getCropConfig(db, KEY).activeSetId, null);
+  });
+
+  test('sets are scoped per api_key', () => {
+    createCropSet(db, KEY, { name: 'Mine' });
+    assert.equal(listCropSets(db, 'otherkey').length, 0);
+    assert.equal(createCropSet(db, 'otherkey', { name: 'Mine' }).ok, true);
+  });
+});
+
+describe('presets', () => {
+  test('CRUD with clamped normalised positions', () => {
+    const created = createCropPreset(db, KEY, { name: 'wide', xNorm: 1.7, yNorm: -0.2 });
+    assert.equal(created.ok, true);
+    assert.equal(created.preset.xNorm, 1);
+    assert.equal(created.preset.yNorm, 0);
+    assert.equal(created.preset.setId, null);
+
+    const updated = updateCropPreset(db, KEY, created.preset.id, { xNorm: 0.25 });
+    assert.equal(updated.preset.xNorm, 0.25);
+    assert.equal(updated.preset.name, 'wide');
+
+    assert.equal(deleteCropPreset(db, KEY, created.preset.id), true);
+    assert.equal(getCropPreset(db, KEY, created.preset.id), null);
+  });
+
+  test('listCropPresets defaults to the ACTIVE set', () => {
+    const a = createCropSet(db, KEY, { name: 'A' });
+    createCropPreset(db, KEY, { name: 'default-set-preset' });          // set_id NULL
+    createCropPreset(db, KEY, { name: 'a-preset', setId: a.set.id });
+
+    // No active set → implicit default set (NULL)
+    assert.deepEqual(listCropPresets(db, KEY).map(p => p.name), ['default-set-preset']);
+
+    setCropConfig(db, KEY, { activeSetId: a.set.id });
+    assert.deepEqual(listCropPresets(db, KEY).map(p => p.name), ['a-preset']);
+  });
+
+  test('duplicate name in the same set rejected; same name across sets fine', () => {
+    const a = createCropSet(db, KEY, { name: 'A' });
+    assert.equal(createCropPreset(db, KEY, { name: 'p', setId: a.set.id }).ok, true);
+    assert.equal(createCropPreset(db, KEY, { name: 'p', setId: a.set.id }).ok, false);
+    assert.equal(createCropPreset(db, KEY, { name: 'p' }).ok, true); // default set
+  });
+
+  test('deleting a preset removes its source-map rows', () => {
+    const p = createCropPreset(db, KEY, { name: 'p' });
+    createCropSourceMapEntry(db, KEY, { mixerInput: 3, presetId: p.preset.id });
+    deleteCropPreset(db, KEY, p.preset.id);
+    assert.equal(listCropSourceMap(db, KEY).length, 0);
+  });
+});
+
+describe('source map + resolution', () => {
+  test('requires a preset and at least one source selector', () => {
+    assert.equal(createCropSourceMapEntry(db, KEY, { mixerInput: 1 }).ok, false);
+    const p = createCropPreset(db, KEY, { name: 'p' });
+    assert.equal(createCropSourceMapEntry(db, KEY, { presetId: p.preset.id }).ok, false);
+    assert.equal(createCropSourceMapEntry(db, KEY, { mixerInput: 1, presetId: p.preset.id }).ok, true);
+  });
+
+  test('camera 1/preset 1 → camera 2 → camera 1/preset 2 each resolve their own crop', () => {
+    const posA = createCropPreset(db, KEY, { name: 'lectern', xNorm: 0.1 }).preset;
+    const posB = createCropPreset(db, KEY, { name: 'centre',  xNorm: 0.5 }).preset;
+    const posC = createCropPreset(db, KEY, { name: 'piano',   xNorm: 0.9 }).preset;
+
+    createCropSourceMapEntry(db, KEY, { cameraId: 'cam1', cameraPreset: 1, presetId: posA.id });
+    createCropSourceMapEntry(db, KEY, { mixerInput: 2, presetId: posB.id });                    // camera 2's input
+    createCropSourceMapEntry(db, KEY, { cameraId: 'cam1', cameraPreset: 2, presetId: posC.id });
+
+    assert.equal(resolveCropPresetForSource(db, KEY, { cameraId: 'cam1', cameraPreset: 1 })?.id, posA.id);
+    assert.equal(resolveCropPresetForSource(db, KEY, { mixerInput: 2 })?.id, posB.id);
+    assert.equal(resolveCropPresetForSource(db, KEY, { cameraId: 'cam1', cameraPreset: 2 })?.id, posC.id);
+    assert.equal(resolveCropPresetForSource(db, KEY, { cameraId: 'cam9' }), null);
+  });
+
+  test('camera+preset beats camera-only beats mixer-input rows', () => {
+    const low  = createCropPreset(db, KEY, { name: 'low' }).preset;
+    const mid  = createCropPreset(db, KEY, { name: 'mid' }).preset;
+    const high = createCropPreset(db, KEY, { name: 'high' }).preset;
+
+    createCropSourceMapEntry(db, KEY, { mixerInput: 1, presetId: low.id });
+    createCropSourceMapEntry(db, KEY, { cameraId: 'cam1', presetId: mid.id });
+    createCropSourceMapEntry(db, KEY, { cameraId: 'cam1', cameraPreset: 4, presetId: high.id });
+
+    const resolved = resolveCropPresetForSource(db, KEY, { mixerInput: 1, cameraId: 'cam1', cameraPreset: 4 });
+    assert.equal(resolved?.id, high.id);
+
+    const noPtz = resolveCropPresetForSource(db, KEY, { mixerInput: 1, cameraId: 'cam1', cameraPreset: 9 });
+    assert.equal(noPtz?.id, mid.id);
+
+    const otherCam = resolveCropPresetForSource(db, KEY, { mixerInput: 1, cameraId: 'cam2' });
+    assert.equal(otherCam?.id, low.id);
+  });
+
+  test('resolution is scoped to the ACTIVE set', () => {
+    const setA = createCropSet(db, KEY, { name: 'A' }).set;
+    const inA   = createCropPreset(db, KEY, { name: 'p', setId: setA.id, xNorm: 0.3 }).preset;
+    const inDef = createCropPreset(db, KEY, { name: 'p', xNorm: 0.7 }).preset;
+    createCropSourceMapEntry(db, KEY, { mixerInput: 1, presetId: inA.id });
+    createCropSourceMapEntry(db, KEY, { mixerInput: 1, presetId: inDef.id });
+
+    // Default set active → only the default-set preset's row matches
+    assert.equal(resolveCropPresetForSource(db, KEY, { mixerInput: 1 })?.id, inDef.id);
+
+    setCropConfig(db, KEY, { activeSetId: setA.id });
+    assert.equal(resolveCropPresetForSource(db, KEY, { mixerInput: 1 })?.id, inA.id);
+  });
+
+  test('delete entry', () => {
+    const p = createCropPreset(db, KEY, { name: 'p' });
+    const e = createCropSourceMapEntry(db, KEY, { mixerInput: 1, presetId: p.preset.id });
+    assert.equal(deleteCropSourceMapEntry(db, KEY, e.entry.id), true);
+    assert.equal(deleteCropSourceMapEntry(db, KEY, e.entry.id), false);
+  });
+});

--- a/packages/plugins/lcyt-rtmp/test/crop-geometry.test.js
+++ b/packages/plugins/lcyt-rtmp/test/crop-geometry.test.js
@@ -1,0 +1,114 @@
+/**
+ * Pure geometry tests for crop-manager.js (plan_vertical_crop.md).
+ */
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { computeCropGeometry, normToPixels, clampNorm, buildEaseSteps } from '../src/crop-manager.js';
+
+describe('computeCropGeometry', () => {
+  test('16:9 1080p → 9:16 window is 608x1080 with horizontal travel only', () => {
+    const g = computeCropGeometry({ inW: 1920, inH: 1080, aspectW: 9, aspectH: 16 });
+    assert.equal(g.cropW, 608); // round_even(1080 * 9/16 = 607.5)
+    assert.equal(g.cropH, 1080);
+    assert.equal(g.maxX, 1920 - 608);
+    assert.equal(g.maxY, 0);
+  });
+
+  test('16:9 720p → 9:16 window scales with input height', () => {
+    const g = computeCropGeometry({ inW: 1280, inH: 720, aspectW: 9, aspectH: 16 });
+    assert.equal(g.cropW, 406); // round_even(720 * 9/16 = 405)
+    assert.equal(g.cropH, 720);
+  });
+
+  test('4:3 source → 9:16 window still uses full height', () => {
+    const g = computeCropGeometry({ inW: 1440, inH: 1080, aspectW: 9, aspectH: 16 });
+    assert.equal(g.cropW, 608);
+    assert.equal(g.cropH, 1080);
+    assert.equal(g.maxX, 1440 - 608);
+  });
+
+  test('1:1 source cropped to 9:16 still uses full height (horizontal travel)', () => {
+    const g = computeCropGeometry({ inW: 1080, inH: 1080, aspectW: 9, aspectH: 16 });
+    assert.equal(g.cropW, 608);
+    assert.equal(g.cropH, 1080);
+    assert.equal(g.maxX, 1080 - 608);
+  });
+
+  test('source narrower than target aspect pins width and shrinks height (vertical travel)', () => {
+    // 500-wide portrait-ish source cropped to 9:16 — full width, reduced height
+    const g = computeCropGeometry({ inW: 500, inH: 1080, aspectW: 9, aspectH: 16 });
+    assert.equal(g.cropW, 500);
+    assert.equal(g.cropH, 888); // round_even(500 * 16/9 = 888.9)
+    assert.equal(g.maxX, 0);
+    assert.equal(g.maxY, 1080 - 888);
+    // 16:9 source cropped to 16:9 (degenerate) — full frame, no travel
+    const g2 = computeCropGeometry({ inW: 1920, inH: 1080, aspectW: 16, aspectH: 9 });
+    assert.equal(g2.cropW, 1920);
+    assert.equal(g2.cropH, 1080);
+    assert.equal(g2.maxX, 0);
+    assert.equal(g2.maxY, 0);
+  });
+
+  test('crop window dimensions are always even (libx264 requirement)', () => {
+    for (const [inW, inH] of [[1919, 1079], [1280, 719], [854, 480]]) {
+      const g = computeCropGeometry({ inW, inH, aspectW: 9, aspectH: 16 });
+      assert.equal(g.cropW % 2, 0, `cropW even for ${inW}x${inH}`);
+    }
+  });
+});
+
+describe('normToPixels', () => {
+  const geom = { maxX: 1312, maxY: 0 };
+
+  test('0 / 0.5 / 1 map to left / centre / right of the travel range', () => {
+    assert.deepEqual(normToPixels({ xNorm: 0, yNorm: 0 }, geom), { x: 0, y: 0 });
+    assert.deepEqual(normToPixels({ xNorm: 1, yNorm: 0 }, geom), { x: 1312, y: 0 });
+    assert.equal(normToPixels({ xNorm: 0.5, yNorm: 0 }, geom).x, 656);
+  });
+
+  test('out-of-range and non-numeric values are clamped', () => {
+    assert.equal(normToPixels({ xNorm: 2, yNorm: 0 }, geom).x, 1312);
+    assert.equal(normToPixels({ xNorm: -1, yNorm: 0 }, geom).x, 0);
+    assert.equal(normToPixels({ xNorm: 'junk', yNorm: 0 }, geom).x, 0);
+  });
+
+  test('pixel offsets are even', () => {
+    const { x } = normToPixels({ xNorm: 0.333, yNorm: 0 }, geom);
+    assert.equal(x % 2, 0);
+  });
+});
+
+describe('clampNorm', () => {
+  test('clamps to 0..1 and defaults non-numeric to 0', () => {
+    assert.equal(clampNorm(0.5), 0.5);
+    assert.equal(clampNorm(-3), 0);
+    assert.equal(clampNorm(7), 1);
+    assert.equal(clampNorm('x'), 0);
+    assert.equal(clampNorm(undefined), 0);
+  });
+});
+
+describe('buildEaseSteps', () => {
+  test('ends exactly at the target and is monotonic for a forward move', () => {
+    const steps = buildEaseSteps({ xNorm: 0, yNorm: 0 }, { xNorm: 1, yNorm: 0 }, 300, 33);
+    assert.ok(steps.length >= 2);
+    const last = steps[steps.length - 1];
+    assert.equal(last.xNorm, 1);
+    for (let i = 1; i < steps.length; i++) {
+      assert.ok(steps[i].xNorm >= steps[i - 1].xNorm, 'monotonic');
+    }
+  });
+
+  test('very short transition produces a single step at the target', () => {
+    const steps = buildEaseSteps({ xNorm: 0.2, yNorm: 0 }, { xNorm: 0.8, yNorm: 0 }, 10, 33);
+    assert.equal(steps.length, 1);
+    assert.equal(steps[0].xNorm, 0.8);
+  });
+
+  test('ease is slower at the ends than the middle', () => {
+    const steps = buildEaseSteps({ xNorm: 0, yNorm: 0 }, { xNorm: 1, yNorm: 0 }, 990, 33); // 30 steps
+    const first = steps[0].xNorm;
+    const midDelta = steps[15].xNorm - steps[14].xNorm;
+    assert.ok(first < midDelta, `first step ${first} should be smaller than mid-step delta ${midDelta}`);
+  });
+});

--- a/packages/plugins/lcyt-rtmp/test/crop-manager.test.js
+++ b/packages/plugins/lcyt-rtmp/test/crop-manager.test.js
@@ -1,0 +1,205 @@
+/**
+ * CropManager lifecycle tests (no real ffmpeg): FFMPEG_RUNNER=worker against a
+ * mock daemon, injected resolution probe. Covers start/stop, status shape,
+ * restart-mode repositioning (position survives the swap, no state wipe from
+ * the old runner's close event), and crop-slot fan-out registration in
+ * RtmpRelayManager.
+ */
+import { test, describe, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { CropManager } from '../src/crop-manager.js';
+import { RtmpRelayManager } from '../src/rtmp-manager.js';
+
+let server;
+const savedEnv = {};
+const jobs = [];
+
+before(async () => {
+  await new Promise(resolve => {
+    server = createServer((req, res) => {
+      let body = '';
+      req.on('data', d => { body += d; });
+      req.on('end', () => {
+        if (req.method === 'POST') jobs.push(JSON.parse(body || '{}'));
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ jobId: `j-${Math.random()}`, ok: true }));
+      });
+    }).listen(0, '127.0.0.1', resolve);
+  });
+  for (const k of ['FFMPEG_RUNNER', 'WORKER_DAEMON_URL', 'COMPUTE_ORCHESTRATOR_URL', 'MEDIAMTX_API_URL']) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+  process.env.FFMPEG_RUNNER = 'worker';
+  process.env.WORKER_DAEMON_URL = `http://127.0.0.1:${server.address().port}`;
+});
+
+after(() => new Promise(resolve => {
+  for (const [k, v] of Object.entries(savedEnv)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  server.close(resolve);
+}));
+
+const CONFIG = {
+  enabled: true, aspectW: 9, aspectH: 16, outW: 1080, outH: 1920,
+  videoBitrate: null, followProgram: true, transitionMs: 0, activeSetId: null,
+};
+
+function makeManager() {
+  return new CropManager({
+    // No hasZmq → restart repositioning mode; no zmq socket involved.
+    ffmpegCaps: { available: true, hasZmq: false },
+    probeResolution: async () => ({ inW: 1920, inH: 1080 }),
+  });
+}
+
+describe('CropManager', () => {
+  test('start → status → stop lifecycle', async () => {
+    const mgr = makeManager();
+    await mgr.start('key1', CONFIG);
+
+    assert.ok(mgr.isRunning('key1'));
+    const st = mgr.getStatus('key1');
+    assert.equal(st.running, true);
+    assert.equal(st.repositionMode, 'restart');
+    assert.equal(st.cropW, 608);
+    assert.equal(st.cropH, 1080);
+    assert.equal(st.xNorm, 0.5);
+
+    await mgr.stop('key1');
+    await new Promise(r => setTimeout(r, 50));
+    assert.ok(!mgr.isRunning('key1'));
+    assert.equal(mgr.getStatus('key1').running, false);
+  });
+
+  test('ffmpeg args crop at incoming quality and push the bare {key}-crop path', async () => {
+    jobs.length = 0;
+    const mgr = makeManager();
+    await mgr.start('key2', CONFIG);
+
+    const plan = jobs[0];
+    const filter = plan.args[plan.args.indexOf('-filter_complex') + 1];
+    assert.match(filter, /crop@vcrop=608:1080:\d+:\d+/);
+    assert.match(filter, /scale=1080:1920/);
+    const out = plan.args[plan.args.length - 1];
+    assert.ok(out.endsWith('/key2-crop'), `push URL must be the bare path: ${out}`);
+    assert.ok(!out.includes('/stream/'), 'no RTMP app prefix');
+
+    await mgr.stop('key2');
+  });
+
+  test('restart-mode applyPosition swaps the renderer at the new position', async () => {
+    jobs.length = 0;
+    const mgr = makeManager();
+    await mgr.start('key3', CONFIG, { position: { xNorm: 0, yNorm: 0 } });
+    assert.equal(mgr.getStatus('key3').xNorm, 0);
+
+    const result = await mgr.applyPosition('key3', { xNorm: 1, yNorm: 0 });
+    assert.equal(result.mode, 'restart');
+    assert.equal(result.xNorm, 1);
+
+    // Old runner's async close event must not wipe the new session.
+    await new Promise(r => setTimeout(r, 150));
+    assert.ok(mgr.isRunning('key3'), 'restarted renderer stays registered');
+    assert.equal(mgr.getStatus('key3').xNorm, 1);
+
+    // Second spawn used the new x offset (maxX = 1920-608 = 1312)
+    const filters = jobs.map(j => j.args[j.args.indexOf('-filter_complex') + 1]);
+    assert.match(filters[0], /crop@vcrop=608:1080:0:0/);
+    assert.match(filters[1], /crop@vcrop=608:1080:1312:0/);
+
+    await mgr.stop('key3');
+  });
+
+  test('position carries across restarts when not overridden', async () => {
+    const mgr = makeManager();
+    await mgr.start('key4', CONFIG, { position: { xNorm: 0.25, yNorm: 0 } });
+    await mgr.start('key4', CONFIG); // restart without explicit position
+    assert.equal(mgr.getStatus('key4').xNorm, 0.25);
+    await mgr.stop('key4');
+  });
+
+  test('probe failure falls back to 1080p geometry', async () => {
+    const mgr = new CropManager({
+      ffmpegCaps: { available: true, hasZmq: false },
+      probeResolution: async () => null,
+    });
+    await mgr.start('key5', CONFIG);
+    const st = mgr.getStatus('key5');
+    assert.equal(st.inW, 1920);
+    assert.equal(st.inH, 1080);
+    await mgr.stop('key5');
+  });
+
+  test('applyPosition throws when not running', async () => {
+    const mgr = makeManager();
+    await assert.rejects(() => mgr.applyPosition('nope', { xNorm: 0.5, yNorm: 0 }), /not running/);
+  });
+});
+
+describe('RtmpRelayManager — crop-view slots', () => {
+  function makeFakeMtx() {
+    const calls = [];
+    return {
+      calls,
+      async addPath(name, cfg)   { calls.push(['add', name, cfg]); },
+      async patchPath(name, cfg) { calls.push(['patch', name, cfg]); },
+      async deletePath(name)     { calls.push(['delete', name]); },
+      async kickPath(name)       { calls.push(['kick', name]); },
+    };
+  }
+
+  test('crop slots register a fan-out on {key}-crop; program slots on the raw path', async () => {
+    const mtx = makeFakeMtx();
+    const mgr = new RtmpRelayManager({
+      mediamtxClient: mtx,
+      ffmpegCaps: { available: true, hasLibx264: false, hasEia608: false, hasSubrip: false },
+    });
+
+    await mgr.start('mixkey', [
+      { slot: 1, targetUrl: 'rtmp://a.example/live', targetName: 'main', sourceView: 'program' },
+      { slot: 2, targetUrl: 'rtmp://b.example/live', targetName: 'vertical', sourceView: 'crop' },
+    ]);
+
+    const adds = mtx.calls.filter(c => c[0] === 'add');
+    const cropAdd = adds.find(c => c[1] === 'mixkey-crop');
+    const rawAdd  = adds.find(c => c[1] === 'mixkey');
+    assert.ok(cropAdd, 'crop fan-out registered on mixkey-crop');
+    assert.ok(rawAdd, 'program fan-out registered on the raw path');
+    assert.match(cropAdd[2].runOnPublish, /mixkey-crop/);
+    assert.match(cropAdd[2].runOnPublish, /b\.example\/live\/vertical/);
+    assert.ok(!cropAdd[2].runOnPublish.includes('a.example'), 'program target not in crop fan-out');
+
+    assert.deepEqual(mgr.runningSlots('mixkey'), [1, 2]);
+    assert.ok(mgr.isSlotRunning('mixkey', 2));
+
+    await mgr.stop('mixkey');
+    assert.ok(!mgr.isRunning('mixkey'));
+    const deletes = mtx.calls.filter(c => c[0] === 'delete').map(c => c[1]);
+    assert.ok(deletes.includes('mixkey-crop'));
+    assert.ok(deletes.includes('mixkey'));
+  });
+
+  test('crop-only slot set works without any program slots', async () => {
+    const mtx = makeFakeMtx();
+    const ended = [];
+    const mgr = new RtmpRelayManager({
+      mediamtxClient: mtx,
+      ffmpegCaps: { available: true },
+      onStreamEnded: (apiKey, slot) => ended.push(slot),
+    });
+
+    await mgr.start('croponly', [
+      { slot: 1, targetUrl: 'rtmp://v.example/live', targetName: 'tiktok', sourceView: 'crop' },
+    ]);
+    assert.ok(mgr.isRunning('croponly'));
+    assert.deepEqual(mgr.runningSlots('croponly'), [1]);
+    assert.ok(!mtx.calls.some(c => c[0] === 'add' && c[1] === 'croponly'), 'no raw-path fan-out');
+
+    await mgr.stop('croponly');
+    assert.deepEqual(ended, [1], 'end stats fired for the crop slot');
+  });
+});

--- a/packages/plugins/lcyt-rtmp/test/crop-routes.test.js
+++ b/packages/plugins/lcyt-rtmp/test/crop-routes.test.js
@@ -1,0 +1,222 @@
+/**
+ * /crop router tests: config, presets, sets (incl. activate re-apply),
+ * position, source map, and the FEATURE_GATE_ENFORCE gate.
+ */
+import { test, describe, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import express from 'express';
+import Database from 'better-sqlite3';
+import { runCropMigrations } from '../src/db/crop.js';
+import { createCropRouter } from '../src/routes/crop.js';
+
+const KEY = 'routekey';
+let db, server, baseUrl, mockCrop, mockRelay;
+
+function makeMockCropManager() {
+  return {
+    running: new Set(),
+    applied: [],
+    status: {},
+    isRunning(k) { return this.running.has(k); },
+    getStatus(k) {
+      return this.running.has(k)
+        ? { running: true, repositionMode: 'live', xNorm: 0.5, yNorm: 0, activePresetId: this.status.activePresetId ?? null }
+        : { running: false, repositionMode: 'live' };
+    },
+    async start(k) { this.running.add(k); },
+    async stop(k) { this.running.delete(k); },
+    async applyPosition(k, opts) {
+      this.applied.push({ k, ...opts });
+      if (opts.activePresetId !== undefined) this.status.activePresetId = opts.activePresetId;
+      return { ok: true, mode: 'live', xNorm: opts.xNorm, yNorm: opts.yNorm };
+    },
+  };
+}
+
+before(async () => {
+  db = new Database(':memory:');
+  runCropMigrations(db);
+  db.exec(`CREATE TABLE project_features (api_key TEXT, feature_code TEXT, enabled INTEGER)`);
+
+  mockCrop = makeMockCropManager();
+  mockRelay = { isPublishing: () => true };
+
+  const auth = (req, res, next) => { req.session = { apiKey: KEY }; next(); };
+  const app = express();
+  app.use(express.json());
+  app.use('/crop', createCropRouter(db, auth, mockCrop, mockRelay));
+  await new Promise(resolve => {
+    server = createServer(app).listen(0, '127.0.0.1', () => {
+      baseUrl = `http://127.0.0.1:${server.address().port}`;
+      resolve();
+    });
+  });
+});
+
+after(() => new Promise(r => server.close(() => { db.close(); r(); })));
+
+beforeEach(() => {
+  mockCrop.running.clear();
+  mockCrop.applied.length = 0;
+  mockCrop.status = {};
+  db.exec('DELETE FROM crop_config; DELETE FROM crop_presets; DELETE FROM crop_preset_sets; DELETE FROM crop_source_map; DELETE FROM project_features;');
+});
+
+const j = (method, path, body) => fetch(`${baseUrl}${path}`, {
+  method,
+  headers: { 'Content-Type': 'application/json' },
+  ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+});
+
+describe('/crop/config', () => {
+  test('GET returns defaults + status', async () => {
+    const res = await j('GET', '/crop/config');
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.enabled, false);
+    assert.equal(body.aspectW, 9);
+    assert.equal(body.running, false);
+    assert.equal(body.repositionMode, 'live');
+  });
+
+  test('PUT updates config and starts the renderer when enabling mid-publish', async () => {
+    const res = await j('PUT', '/crop/config', { enabled: true, transitionMs: 250 });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.enabled, true);
+    assert.equal(body.transitionMs, 250);
+    assert.ok(mockCrop.isRunning(KEY), 'renderer started (isPublishing=true)');
+
+    const off = await j('PUT', '/crop/config', { enabled: false });
+    assert.equal((await off.json()).enabled, false);
+    assert.ok(!mockCrop.isRunning(KEY), 'renderer stopped on disable');
+  });
+
+  test('PUT rejects invalid values', async () => {
+    assert.equal((await j('PUT', '/crop/config', { aspectW: -1 })).status, 400);
+  });
+});
+
+describe('/crop/position', () => {
+  test('applies a clamped free position when running', async () => {
+    mockCrop.running.add(KEY);
+    const res = await j('POST', '/crop/position', { xNorm: 0.8, yNorm: 0, transitionMs: 100 });
+    assert.equal(res.status, 200);
+    assert.equal((await res.json()).mode, 'live');
+    assert.equal(mockCrop.applied[0].xNorm, 0.8);
+    assert.equal(mockCrop.applied[0].activePresetId, null, 'free move clears the active preset');
+  });
+
+  test('409 when the renderer is not running; 400 on bad input', async () => {
+    assert.equal((await j('POST', '/crop/position', { xNorm: 0.5, yNorm: 0 })).status, 409);
+    mockCrop.running.add(KEY);
+    assert.equal((await j('POST', '/crop/position', { xNorm: 'junk' })).status, 400);
+  });
+});
+
+describe('/crop/presets', () => {
+  test('CRUD + activate', async () => {
+    const created = await j('POST', '/crop/presets', { name: 'lectern', xNorm: 0.2, yNorm: 0 });
+    assert.equal(created.status, 201);
+    const { preset } = await created.json();
+
+    const listed = await (await j('GET', '/crop/presets')).json();
+    assert.equal(listed.presets.length, 1);
+
+    const updated = await j('PUT', `/crop/presets/${preset.id}`, { xNorm: 0.3 });
+    assert.equal((await updated.json()).preset.xNorm, 0.3);
+
+    mockCrop.running.add(KEY);
+    const activated = await j('POST', `/crop/presets/${preset.id}/activate`, {});
+    assert.equal(activated.status, 200);
+    assert.equal((await activated.json()).presetId, preset.id);
+    assert.equal(mockCrop.applied[0].xNorm, 0.3);
+    assert.equal(mockCrop.applied[0].activePresetId, preset.id);
+
+    assert.equal((await j('DELETE', `/crop/presets/${preset.id}`)).status, 200);
+    assert.equal((await j('DELETE', `/crop/presets/${preset.id}`)).status, 404);
+  });
+
+  test('activate 409s when the renderer is not running', async () => {
+    const { preset } = await (await j('POST', '/crop/presets', { name: 'x' })).json();
+    assert.equal((await j('POST', `/crop/presets/${preset.id}/activate`, {})).status, 409);
+  });
+
+  test('activate uses the configured default transition when none is given', async () => {
+    await j('PUT', '/crop/config', { transitionMs: 400 });
+    const { preset } = await (await j('POST', '/crop/presets', { name: 'x' })).json();
+    mockCrop.running.add(KEY);
+    await j('POST', `/crop/presets/${preset.id}/activate`, {});
+    assert.equal(mockCrop.applied.at(-1).transitionMs, 400);
+  });
+});
+
+describe('/crop/sets', () => {
+  test('CRUD + clone + activate re-applies the same-named preset from the new set', async () => {
+    const setA = (await (await j('POST', '/crop/sets', { name: 'A' })).json()).set;
+    const pA = (await (await j('POST', '/crop/presets', { name: 'stage', xNorm: 0.2, setId: setA.id })).json()).preset;
+
+    // Clone A → B, then move B's "stage" position
+    const setB = (await (await j('POST', '/crop/sets', { name: 'B', cloneFromSetId: setA.id })).json()).set;
+    const bPresets = (await (await j('GET', `/crop/presets?setId=${setB.id}`)).json()).presets;
+    assert.equal(bPresets.length, 1);
+    await j('PUT', `/crop/presets/${bPresets[0].id}`, { xNorm: 0.9 });
+
+    // Activate set A and its "stage" preset
+    await j('POST', `/crop/sets/${setA.id}/activate`, {});
+    mockCrop.running.add(KEY);
+    await j('POST', `/crop/presets/${pA.id}/activate`, {});
+
+    // Switching to set B re-applies "stage" from B — live, at B's position
+    const res = await j('POST', `/crop/sets/${setB.id}/activate`, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.activeSetId, setB.id);
+    assert.equal(body.applied?.xNorm, 0.9);
+
+    assert.equal((await j('DELETE', `/crop/sets/${setB.id}`)).status, 200);
+  });
+
+  test('GET lists sets with the active id', async () => {
+    const setA = (await (await j('POST', '/crop/sets', { name: 'A' })).json()).set;
+    await j('POST', `/crop/sets/${setA.id}/activate`, {});
+    const body = await (await j('GET', '/crop/sets')).json();
+    assert.equal(body.sets.length, 1);
+    assert.equal(body.activeSetId, setA.id);
+  });
+});
+
+describe('/crop/source-map', () => {
+  test('CRUD with validation', async () => {
+    const { preset } = await (await j('POST', '/crop/presets', { name: 'p' })).json();
+    assert.equal((await j('POST', '/crop/source-map', { mixerInput: 1 })).status, 400);
+    const created = await j('POST', '/crop/source-map', { mixerInput: 1, presetId: preset.id });
+    assert.equal(created.status, 201);
+    const { entry } = await created.json();
+
+    const listed = await (await j('GET', '/crop/source-map')).json();
+    assert.equal(listed.entries.length, 1);
+
+    assert.equal((await j('DELETE', `/crop/source-map/${entry.id}`)).status, 200);
+    assert.equal((await j('DELETE', `/crop/source-map/${entry.id}`)).status, 404);
+  });
+});
+
+describe('feature gate', () => {
+  test("403 when FEATURE_GATE_ENFORCE=1 and 'crop' is not enabled; passes when granted", async () => {
+    const orig = process.env.FEATURE_GATE_ENFORCE;
+    process.env.FEATURE_GATE_ENFORCE = '1';
+    try {
+      const denied = await j('GET', '/crop/config');
+      assert.equal(denied.status, 403);
+      assert.equal((await denied.json()).feature, 'crop');
+
+      db.prepare("INSERT INTO project_features (api_key, feature_code, enabled) VALUES (?, 'crop', 1)").run(KEY);
+      assert.equal((await j('GET', '/crop/config')).status, 200);
+    } finally {
+      if (orig === undefined) delete process.env.FEATURE_GATE_ENFORCE;
+      else process.env.FEATURE_GATE_ENFORCE = orig;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Implements Phases 1–2 of [`plan_vertical_crop.md`](docs/plans/plan_vertical_crop.md): a per-project **vertical (9:16) crop rendition** of the landscape RTMP ingest, cut at incoming resolution, with **live-repositionable** crop presets organised into switchable sets.

### What's in

**Data model** (`packages/plugins/lcyt-rtmp/src/db/crop.js`)
- `crop_config` — aspect, delivery size, bitrate, default transition, follow-program flag, active set
- `crop_preset_sets` — named banks of positions; creating a set can clone another (presets + their source-map rows)
- `crop_presets` — normalised 0..1 positions (resolution-independent), unique per set
- `crop_source_map` + `resolveCropPresetForSource()` — most-specific-wins (camera+PTZ preset > camera > mixer input), scoped to the **active** set; covers the "camera 1/preset 1 → camera 2 → camera 1/preset 2" scenario from the plan
- Manual delete cascades (FK enforcement is off repo-wide)

**Renderer** (`src/crop-manager.js`)
- One long-running ffmpeg per key: RTSP read of the raw ingest → `crop@vcrop` window at full incoming quality (608×1080 out of 1080p for 9:16, even-rounded) → scale to delivery size (default 1080×1920) → publish to the bare `{key}-crop` MediaMTX path
- **Live repositioning**: when the ffmpeg build has the `zmq` filter (new `hasZmq` capability in `probeFfmpeg()`) *and* the optional `zeromq` npm package imports, position changes go over runtime filter commands — next-frame, no restart, no black gap — with instant or cubic-eased transitions
- **Restart fallback** otherwise: the renderer is swapped at the new position (position carried across, identity-guarded close handlers so the old process's close event can't wipe the new session)
- ffprobe input-resolution probe with 1080p fallback, reused across restarts

**Relay integration** (`src/rtmp-manager.js`, `src/db/relay.js`, `src/routes/stream.js`)
- Relay slots gain `sourceView: 'program' | 'crop'` — crop-view slots register a MediaMTX runOnPublish fan-out on `{key}-crop` instead of the raw path (never part of CEA-708/transcode/DSK modes), fully integrated with start/stop/stats/`runningSlots`

**API** (`src/routes/crop.js`, mounted at `/crop` by lcyt-backend when `RTMP_RELAY_ACTIVE=1`)
- config (PUT starts/stops the renderer mid-publish), status (`repositionMode: live|restart`), free `POST /position` (drag UI backend), preset CRUD + activate, set CRUD + activate (re-applies the same-named preset from the new set, live), source-map CRUD
- Feature-gated on the new `crop` feature code (dep: `ingest`) when `FEATURE_GATE_ENFORCE=1`

**Lifecycle**: renderer starts from the `/rtmp` on_publish callback when `crop_config.enabled`, stops on publish_done, and is included in the plugin's graceful shutdown.

### What's NOT in (later phases)

- Phase 3: web UI (set selector, sources×sets overview grid, draggable preset editor, vertical monitor tile)
- Phase 4: production-follow wiring (mixer/camera registry callbacks → `resolveCropPresetForSource`) + `crop_preset` named action
- Phase 5: ffmpeg image `--enable-libzmq`, `overridePublisher` pre-config for a cleaner restart-mode splice, PORTS.md

## Test plan

- [x] New suites: `crop-geometry` (window derivation, even rounding, clamping, easing), `crop-db` (config/sets incl. clone/presets/source-map resolution specificity), `crop-manager` (lifecycle + restart-mode repositioning via mock worker daemon, ffmpeg args/path assertions, crop-slot fan-out in RtmpRelayManager), `crop-routes` (CRUD, activate flows, feature gate) — lcyt-rtmp suite now 178 tests
- [x] Full workspace suite green (all packages)
- [ ] Manual verification against a live MediaMTX deployment: publish a test stream, enable crop, activate presets while watching `{key}-crop` HLS — confirm gapless shifts in live mode / splice-only in restart mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EanGbgWtGM2Gvqib2McGnm

---
_Generated by [Claude Code](https://claude.ai/code/session_01EanGbgWtGM2Gvqib2McGnm)_