### PR TITLE
Add camera thumbnail capture to production control

### DIFF
--- a/packages/lcyt-backend/CLAUDE.md
+++ b/packages/lcyt-backend/CLAUDE.md
@@ -168,6 +168,8 @@ GET  /production/cameras  — list cameras (admin key)
 POST /production/cameras  — create camera
 PUT/DELETE /production/cameras/:id — update/delete camera
 POST /production/cameras/:id/preset/:preset — trigger camera PTZ preset
+POST /production/cameras/:id/thumbnail/capture — capture a still frame as this camera's thumbnail (webcam/mobile: from its own feed; amx/visca-ip: from the mixer program feed while this camera is live, body { apiKey, mixerId? })
+GET  /production/cameras/:id/thumbnail[.jpg] — serve the saved thumbnail JPEG
 GET  /production/mixers   — list mixers with connection status
 POST /production/mixers   — create mixer
 PUT/DELETE /production/mixers/:id — update/delete mixer

--- a/packages/plugins/lcyt-production/CLAUDE.md
+++ b/packages/plugins/lcyt-production/CLAUDE.md
@@ -16,9 +16,10 @@ app.use('/production', createProductionRouter(db, registry, bridgeManager, { pub
 - `crud.js` — Plain, directly-callable camera/mixer CRUD (`listCameras`/`createCamera`/`updateCamera`/`deleteCamera` + mixer equivalents) — the in-process counterpart to `routes/cameras.js`/`routes/mixers.js`'s HTTP handlers, for callers with no Express `req`/`res` (`packages/lcyt-tools`'s `camera.*`/`mixer.*` tools, `plan/mcp`). Also owns `buildSwitchCommand(mixer, inputNumber)`, extracted here so both `routes/mixers.js` and the shared tool registry dispatch bridge-relayed mixer switches through one implementation rather than two.
 - `bridge-manager.js` — `BridgeManager`: manages SSE connections from `lcyt-bridge` agents. `sendCommand(instanceId, command, { timeoutMs })` — per-call timeout override; defaults to 120s for `type: 'model_call'` (local AI inference is slow, `plan_ai_model_registry.md`) and 10s otherwise. Resolved command results now pass response payload fields (e.g. `status`/`body` from `http_request`/`model_call`) through to the caller instead of dropping them. Sends SSE heartbeats every 20s.
 - `db.js` — SQLite migrations for `prod_cameras`, `prod_mixers`, `prod_bridge_instances`, `prod_encoders` tables.
+- `camera-thumbnail.js` — `captureCameraThumbnail(db, camera, registry, opts)` + `deleteCameraThumbnailFile(cameraId, thumbnailsDir)` + `thumbnailPath(cameraId, thumbnailsDir)`: still-frame thumbnail capture for a camera's "picture", persisted to disk (`CAMERA_THUMBNAILS_DIR`) + a `thumbnail_captured_at` DB timestamp. Two capture paths depending on the camera's control type — see "Camera Thumbnail Capture" below.
 - `obs-client.js` — `OBSClient`: shared OBS WebSocket v5 abstraction (connection lifecycle, auto-reconnect, RPC helpers) used by both the OBS mixer adapter (direct connections) and `lcyt-bridge`'s `ObsPool` (bridged connections). Owns all OBS protocol details.
 - `mediamtx-client.js` — `MediaMtxClient` copy for production-control use (path liveness checks, WHIP publisher kick, path pre-registration). Copied from `lcyt-rtmp`'s client to avoid a cross-plugin dependency — keep in sync. Reads `MEDIAMTX_API_URL` / `MEDIAMTX_WEBRTC_BASE_URL` / `MEDIAMTX_API_USER` / `MEDIAMTX_API_PASSWORD`.
-- `routes/cameras.js` — CRUD + PTZ preset trigger.
+- `routes/cameras.js` — CRUD + PTZ preset trigger + thumbnail capture/serve (`POST /:id/thumbnail/capture`, `GET /:id/thumbnail[.jpg]`). `GET /` and `GET /:id` include a computed `thumbnailUrl` (`null` until first capture).
 - `routes/mixers.js` — CRUD + source switching (dispatch logic now delegates to `crud.js`'s `buildSwitchCommand`).
 - `routes/encoders.js` — Hardware encoder CRUD + control (`GET/POST /production/encoders`, `GET/PUT/DELETE /production/encoders/:id`, `POST /production/encoders/:id/start|stop|test`). Encoder types: `monarch_hd`, `monarch_hdx`. Connection sources: `backend` (server calls the encoder's HTTP API), `frontend` (browser calls it directly; backend only stores config), `bridge` (relayed via a bridge agent `http_request` command).
 - `routes/bridge.js` — Bridge instance CRUD + SSE command stream + status callback.
@@ -33,11 +34,26 @@ app.use('/production', createProductionRouter(db, registry, bridgeManager, { pub
 - `adapters/mixer/lcyt.js` — LCYT software mixer adapter.
 - `adapters/mixer/monarch_hdx.js` — Matrox Monarch HDX encoder/mixer adapter.
 
-**Camera control types:** `amx`, `visca-ip`, `browser`, `none`
+**Camera control types:** `none`, `amx`, `visca-ip`, `webcam`, `mobile` (`webcam`/`mobile` route through the browser/WebRTC adapter — only these two ever get a `camera_key`)
 **Mixer types:** `roland`, `amx`, `atem`, `obs`, `lcyt`, `monarch_hdx`
 **Encoder types:** `monarch_hd`, `monarch_hdx` (connection sources: `backend`, `frontend`, `bridge`)
 
-**Tests:** `packages/plugins/lcyt-production/test/*.test.js` — uses `node:test`. `test/crud.test.js` covers the plain CRUD helpers; `test/bridge-manager.test.js` covers the per-call `timeoutMs` override and result-payload passthrough.
+## Camera Thumbnail Capture
+
+`POST /production/cameras/:id/thumbnail/capture` grabs a still frame from a camera's live feed and persists it as that camera's "picture" (`thumbnail_captured_at` on `prod_cameras` + a JPEG file under `CAMERA_THUMBNAILS_DIR`), so an operator can see what a camera is framing without a live preview open. `GET /production/cameras/:id/thumbnail[.jpg]` serves the saved file; `DELETE /production/cameras/:id` removes it too. Manually triggered only — no background/periodic capture.
+
+Both paths fetch from the backend's own public preview-JPEG endpoint (`GET /preview/:key/incoming`, `lcyt-rtmp`'s `PreviewManager`) over plain HTTP, the same "deliberately HTTP, not an in-process import" pattern `lcyt-agent`'s `VisionFrameFetcher` already uses against that endpoint — **this requires `RTMP_RELAY_ACTIVE=1`** on this backend (that's what mounts `/preview` at all); without it every capture attempt fails with the same error a genuinely-offline camera would produce.
+
+- **Path A — independent feed** (`webcam`/`mobile`, `camera.cameraKey` set): fetches `/preview/:cameraKey/incoming` directly. 409 if the camera isn't currently publishing.
+- **Path B — program-feed capture** (`amx`/`visca-ip`, no `cameraKey`): these control types are pure PTZ protocols with no video path of their own — the only feed ever available for them is the mixer's program output, and only while this camera is the mixer's active source. The request body must supply `apiKey` (the project's RTMP ingest key; this plugin has no project/apiKey concept of its own, so the caller provides it) and, if more than one mixer row exists, `mixerId` to disambiguate. Liveness is checked via `registry.getActiveSource(mixerId) === camera.mixerInput` before saving — 409 if this camera isn't currently cut to program. Not supported for `none`-type cameras (no `mixerInput` relationship implied) unless `mixerInput` is set.
+
+**Environment variables:**
+| Variable | Purpose | Default |
+|---|---|---|
+| `CAMERA_THUMBNAILS_DIR` | Local directory for captured camera thumbnail JPEGs | `/data/camera-thumbnails` |
+| `CAMERA_PREVIEW_BASE_URL` | Base URL this plugin fetches `/preview/:key/incoming` from (same underlying backend process in every real deployment — same convention as `lcyt-agent`'s `VISION_PREVIEW_BASE_URL`/`lcyt-dsk`'s `DSK_LOCAL_SERVER`, each plugin owns its own copy rather than sharing one) | `http://localhost:$PORT` |
+
+**Tests:** `packages/plugins/lcyt-production/test/*.test.js` — uses `node:test`. `test/crud.test.js` covers the plain CRUD helpers; `test/bridge-manager.test.js` covers the per-call `timeoutMs` override and result-payload passthrough; `test/camera-thumbnail.test.js` covers `captureCameraThumbnail`'s two capture paths (mocked `fetch`); `test/cameras-routes.test.js` is the first route-level test for `routes/cameras.js`, covering the thumbnail capture/serve/delete endpoints end-to-end against a real Express app.
 
 ---
 

--- a/packages/plugins/lcyt-production/src/api.js
+++ b/packages/plugins/lcyt-production/src/api.js
@@ -53,13 +53,14 @@ export async function initProductionControl(db) {
  * @param {object} [opts]
  * @param {string} [opts.publicUrl]      Server's public URL for .env generation
  * @param {MediaMtxClient} [opts.mediamtxClient]  MediaMTX REST client (optional)
+ * @param {object} [opts.cameraThumbnail]  Overrides for camera-thumbnail.js's defaults (thumbnailsDir/previewBaseUrl) — tests only, env vars suffice in production
  * @returns {import('express').Router}
  */
 export function createProductionRouter(db, registry, bridgeManager, opts = {}) {
   const router = Router();
   const mediamtxClient = opts.mediamtxClient ?? null;
 
-  router.use('/cameras',  createCamerasRouter(db, registry, bridgeManager, { mediamtxClient }));
+  router.use('/cameras',  createCamerasRouter(db, registry, bridgeManager, { mediamtxClient, cameraThumbnail: opts.cameraThumbnail }));
   router.use('/mixers',   createMixersRouter(db, registry, bridgeManager, { mediamtxClient }));
   router.use('/bridge',   createBridgeRouter(db, bridgeManager, opts.publicUrl));
   router.use('/encoders', createEncodersRouter(db, bridgeManager));

--- a/packages/plugins/lcyt-production/src/camera-thumbnail.js
+++ b/packages/plugins/lcyt-production/src/camera-thumbnail.js
@@ -1,0 +1,184 @@
+/**
+ * Camera thumbnail capture — grabs a still-frame JPEG for a camera's "picture"
+ * and persists it to disk + a DB timestamp, so an operator can see what a
+ * camera is pointed at without a live feed open.
+ *
+ * Two capture paths, depending on the camera's control type:
+ *
+ *   Path A — independent feed (webcam/mobile, camera.cameraKey set):
+ *     fetches the camera's own MediaMTX preview directly.
+ *
+ *   Path B — program-feed capture (amx/visca-ip, no cameraKey):
+ *     these cameras have no video path of their own — AMX/VISCA-IP are pure
+ *     PTZ control protocols. The only feed ever available for them is the
+ *     mixer's program output, and only while this camera is the mixer's
+ *     currently active source. Caller must supply apiKey (the project's RTMP
+ *     ingest key); liveness is checked via the DeviceRegistry before saving.
+ *
+ * Both paths fetch from the backend's already-public preview-JPEG endpoint
+ * (`GET /preview/:key/incoming`, PreviewManager in lcyt-rtmp) over plain HTTP
+ * — deliberately, not an in-process import of PreviewManager/MediaMtxClient,
+ * same reasoning as lcyt-agent's VisionFrameFetcher (avoids new cross-plugin
+ * coupling; this plugin's own MediaMtxClient copy has no getThumbnail method
+ * at all). Requires RTMP_RELAY_ACTIVE=1 on this backend (that's what mounts
+ * /preview) — without it every capture attempt fails with the same 409 a
+ * genuinely-offline camera would produce.
+ */
+
+import * as fs from 'node:fs';
+import { join, resolve } from 'node:path';
+import { randomBytes } from 'node:crypto';
+
+export const DEFAULT_THUMBNAILS_DIR = resolve(process.env.CAMERA_THUMBNAILS_DIR || '/data/camera-thumbnails');
+export const DEFAULT_PREVIEW_BASE_URL = process.env.CAMERA_PREVIEW_BASE_URL
+  || `http://localhost:${process.env.PORT || 3000}`;
+
+/**
+ * @param {string} cameraId
+ * @param {string} [thumbnailsDir]
+ * @returns {string} absolute path to the camera's stored thumbnail file
+ */
+export function thumbnailPath(cameraId, thumbnailsDir = DEFAULT_THUMBNAILS_DIR) {
+  return join(thumbnailsDir, `${cameraId}.jpg`);
+}
+
+/**
+ * Fetch a JPEG from the backend's public preview endpoint for the given key
+ * (a camera_key or a project apiKey — the endpoint doesn't distinguish).
+ *
+ * @param {string} previewBaseUrl
+ * @param {string} key
+ * @returns {Promise<{ ok: true, buffer: Buffer } | { ok: false, error: string, status: number }>}
+ */
+async function fetchPreviewJpeg(previewBaseUrl, key) {
+  const url = `${previewBaseUrl.replace(/\/$/, '')}/preview/${encodeURIComponent(key)}/incoming`;
+  let res;
+  try {
+    res = await fetch(url);
+  } catch (err) {
+    return { ok: false, error: `Preview fetch failed: ${err.message}`, status: 502 };
+  }
+  if (res.status === 404) {
+    return {
+      ok: false,
+      status: 409,
+      error: 'No live preview available (not currently publishing, or RTMP_RELAY_ACTIVE is not set on this backend)',
+    };
+  }
+  if (!res.ok) {
+    return { ok: false, error: `Preview fetch failed: HTTP ${res.status}`, status: 502 };
+  }
+  return { ok: true, buffer: Buffer.from(await res.arrayBuffer()) };
+}
+
+/**
+ * Atomically write a thumbnail buffer to disk for a camera.
+ * @param {string} cameraId
+ * @param {Buffer} buffer
+ * @param {string} thumbnailsDir
+ * @returns {{ ok: true } | { ok: false, error: string, status: number }}
+ */
+function writeThumbnailFile(cameraId, buffer, thumbnailsDir) {
+  try {
+    fs.mkdirSync(thumbnailsDir, { recursive: true });
+  } catch (err) {
+    return { ok: false, error: `Could not create thumbnails directory: ${err.message}`, status: 500 };
+  }
+
+  const finalPath = thumbnailPath(cameraId, thumbnailsDir);
+  const tmpPath = join(thumbnailsDir, `.${cameraId}-${randomBytes(6).toString('hex')}.tmp`);
+  try {
+    fs.writeFileSync(tmpPath, buffer);
+    fs.renameSync(tmpPath, finalPath);
+  } catch (err) {
+    try { fs.unlinkSync(tmpPath); } catch { /* ignore */ }
+    return { ok: false, error: `Could not write thumbnail file: ${err.message}`, status: 500 };
+  }
+  return { ok: true };
+}
+
+/**
+ * Capture a still-frame thumbnail for a camera and persist it.
+ *
+ * @param {import('better-sqlite3').Database} db
+ * @param {{ id: string, cameraKey: string|null, mixerInput: number|null }} camera  parsed camera row
+ * @param {import('./registry.js').DeviceRegistry} registry
+ * @param {{ apiKey?: string, mixerId?: string, thumbnailsDir?: string, previewBaseUrl?: string }} [opts]
+ * @returns {Promise<{ ok: true, thumbnailCapturedAt: string, sizeBytes: number }
+ *                  | { ok: false, error: string, status: number }>}
+ */
+export async function captureCameraThumbnail(db, camera, registry, opts = {}) {
+  const thumbnailsDir = opts.thumbnailsDir ?? DEFAULT_THUMBNAILS_DIR;
+  const previewBaseUrl = opts.previewBaseUrl ?? DEFAULT_PREVIEW_BASE_URL;
+
+  let fetchResult;
+
+  if (camera.cameraKey) {
+    // Path A — independent feed (webcam/mobile)
+    fetchResult = await fetchPreviewJpeg(previewBaseUrl, camera.cameraKey);
+  } else {
+    // Path B — program-feed capture (amx/visca-ip, no independent feed)
+    if (!opts.apiKey) {
+      return {
+        ok: false,
+        status: 400,
+        error: 'Camera has no camera_key; pass apiKey to capture from the current program feed instead',
+      };
+    }
+    if (camera.mixerInput == null) {
+      return {
+        ok: false,
+        status: 400,
+        error: 'Camera has no mixer_input assigned — cannot determine when it is live on program',
+      };
+    }
+
+    let mixerId = opts.mixerId ?? null;
+    if (!mixerId) {
+      const mixers = db.prepare('SELECT id FROM prod_mixers').all();
+      if (mixers.length !== 1) {
+        return {
+          ok: false,
+          status: 400,
+          error: mixers.length === 0
+            ? 'No mixer is configured — cannot determine program-feed liveness'
+            : 'Multiple mixers are configured — pass mixerId to disambiguate',
+        };
+      }
+      mixerId = mixers[0].id;
+    }
+
+    const activeSource = registry.getActiveSource(mixerId);
+    if (activeSource !== camera.mixerInput) {
+      return {
+        ok: false,
+        status: 409,
+        error: 'Camera is not currently the active mixer source — switch to it before capturing',
+      };
+    }
+
+    fetchResult = await fetchPreviewJpeg(previewBaseUrl, opts.apiKey);
+  }
+
+  if (!fetchResult.ok) return fetchResult;
+
+  const writeResult = writeThumbnailFile(camera.id, fetchResult.buffer, thumbnailsDir);
+  if (!writeResult.ok) return writeResult;
+
+  const thumbnailCapturedAt = new Date().toISOString();
+  db.prepare('UPDATE prod_cameras SET thumbnail_captured_at = ? WHERE id = ?').run(thumbnailCapturedAt, camera.id);
+
+  return { ok: true, thumbnailCapturedAt, sizeBytes: fetchResult.buffer.length };
+}
+
+/**
+ * Best-effort delete of a camera's thumbnail file. Never throws.
+ * @param {string} cameraId
+ * @param {string} [thumbnailsDir]
+ */
+export function deleteCameraThumbnailFile(cameraId, thumbnailsDir = DEFAULT_THUMBNAILS_DIR) {
+  try {
+    const p = thumbnailPath(cameraId, thumbnailsDir);
+    if (fs.existsSync(p)) fs.unlinkSync(p);
+  } catch { /* ignore, matches lcyt-dsk images.js's delete-route precedent */ }
+}

--- a/packages/plugins/lcyt-production/src/db.js
+++ b/packages/plugins/lcyt-production/src/db.js
@@ -78,6 +78,12 @@ export function runMigrations(db) {
   if (!mixerCols2.includes('output_key')) {
     db.exec('ALTER TABLE prod_mixers ADD COLUMN output_key TEXT');
   }
+
+  // thumbnail_captured_at: ISO timestamp of the last successful still-frame capture
+  const cameraCols3 = db.prepare("PRAGMA table_info(prod_cameras)").all().map(c => c.name);
+  if (!cameraCols3.includes('thumbnail_captured_at')) {
+    db.exec('ALTER TABLE prod_cameras ADD COLUMN thumbnail_captured_at TEXT');
+  }
 }
 
 /**

--- a/packages/plugins/lcyt-production/src/registry.js
+++ b/packages/plugins/lcyt-production/src/registry.js
@@ -267,6 +267,7 @@ export function parseCamera(row) {
     bridgeInstanceId: row.bridge_instance_id,
     sortOrder:        row.sort_order,
     cameraKey:        row.camera_key ?? null,
+    thumbnailCapturedAt: row.thumbnail_captured_at ?? null,
     createdAt:        row.created_at,
   };
 }

--- a/packages/plugins/lcyt-production/src/routes/cameras.js
+++ b/packages/plugins/lcyt-production/src/routes/cameras.js
@@ -1,13 +1,29 @@
 import { Router } from 'express';
 import { randomUUID } from 'node:crypto';
+import * as fs from 'node:fs';
 import { parseCamera } from '../registry.js';
+import { captureCameraThumbnail, deleteCameraThumbnailFile, thumbnailPath } from '../camera-thumbnail.js';
 
 const CAMERA_CONTROL_TYPES = ['none', 'amx', 'visca-ip', 'webcam', 'mobile'];
 const BROWSER_CAMERA_TYPES = new Set(['webcam', 'mobile']);
 
 export function createCamerasRouter(db, registry, bridgeManager = null, opts = {}) {
   const mediamtxClient = opts.mediamtxClient ?? null;
+  const cameraThumbnailOpts = opts.cameraThumbnail ?? {};
   const router = Router();
+
+  /**
+   * Build the computed thumbnailUrl field for a parsed camera row.
+   * @param {object} camera  parseCamera() output
+   * @param {import('express').Request} req
+   */
+  function withThumbnailUrl(camera, req) {
+    const origin = `${req.protocol}://${req.get('host')}`;
+    return {
+      ...camera,
+      thumbnailUrl: camera.thumbnailCapturedAt ? `${origin}/production/cameras/${camera.id}/thumbnail` : null,
+    };
+  }
 
   // -------------------------------------------------------------------------
   // Text body parser for WHIP SDP routes (must come before route definitions)
@@ -29,11 +45,11 @@ export function createCamerasRouter(db, registry, bridgeManager = null, opts = {
   );
 
   // GET /production/cameras — list all cameras
-  router.get('/', (_req, res) => {
+  router.get('/', (req, res) => {
     const rows = db
       .prepare('SELECT * FROM prod_cameras ORDER BY sort_order, created_at')
       .all()
-      .map(parseCamera);
+      .map(row => withThumbnailUrl(parseCamera(row), req));
     res.json(rows);
   });
 
@@ -41,7 +57,7 @@ export function createCamerasRouter(db, registry, bridgeManager = null, opts = {
   router.get('/:id', (req, res) => {
     const row = db.prepare('SELECT * FROM prod_cameras WHERE id = ?').get(req.params.id);
     if (!row) return res.status(404).json({ error: 'Camera not found' });
-    res.json(parseCamera(row));
+    res.json(withThumbnailUrl(parseCamera(row), req));
   });
 
   // POST /production/cameras — create camera
@@ -114,8 +130,41 @@ export function createCamerasRouter(db, registry, bridgeManager = null, opts = {
 
     db.prepare('DELETE FROM prod_cameras WHERE id = ?').run(id);
     registry.removeCamera(id).catch(() => {});
+    deleteCameraThumbnailFile(id, cameraThumbnailOpts.thumbnailsDir);
     res.status(204).end();
   });
+
+  // POST /production/cameras/:id/thumbnail/capture — capture a still frame as this camera's thumbnail
+  router.post('/:id/thumbnail/capture', async (req, res) => {
+    const row = db.prepare('SELECT * FROM prod_cameras WHERE id = ?').get(req.params.id);
+    if (!row) return res.status(404).json({ error: 'Camera not found' });
+
+    const camera = parseCamera(row);
+    const { apiKey, mixerId } = req.body ?? {};
+    const result = await captureCameraThumbnail(db, camera, registry, {
+      apiKey, mixerId, ...cameraThumbnailOpts,
+    });
+    if (!result.ok) return res.status(result.status).json({ error: result.error });
+    res.json({ ok: true, thumbnailCapturedAt: result.thumbnailCapturedAt, sizeBytes: result.sizeBytes });
+  });
+
+  // GET /production/cameras/:id/thumbnail(.jpg) — serve the saved thumbnail
+  function serveThumbnail(req, res) {
+    const row = db.prepare('SELECT thumbnail_captured_at FROM prod_cameras WHERE id = ?').get(req.params.id);
+    if (!row || !row.thumbnail_captured_at) {
+      return res.status(404).json({ error: 'No thumbnail captured for this camera' });
+    }
+
+    const filepath = thumbnailPath(req.params.id, cameraThumbnailOpts.thumbnailsDir);
+    if (!fs.existsSync(filepath)) return res.status(404).json({ error: 'Thumbnail file not found on disk' });
+
+    res.setHeader('Content-Type', 'image/jpeg');
+    res.setHeader('Cache-Control', 'private, max-age=60');
+    try { res.setHeader('Content-Length', fs.statSync(filepath).size); } catch { /* ignore */ }
+    fs.createReadStream(filepath).pipe(res);
+  }
+  router.get('/:id/thumbnail', serveThumbnail);
+  router.get('/:id/thumbnail.jpg', serveThumbnail);
 
   // POST /production/cameras/:id/preset/:presetId — trigger preset
   router.post('/:id/preset/:presetId', async (req, res) => {

--- a/packages/plugins/lcyt-production/test/camera-thumbnail.test.js
+++ b/packages/plugins/lcyt-production/test/camera-thumbnail.test.js
@@ -1,0 +1,234 @@
+/**
+ * Unit tests for camera-thumbnail.js: capture (both paths), disk write, and
+ * best-effort delete. Mocks global.fetch the same way
+ * packages/plugins/lcyt-agent/test/vision-frame-fetcher.test.js does.
+ */
+
+import { test, describe, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import Database from 'better-sqlite3';
+import * as fs from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { runMigrations } from '../src/db.js';
+import { parseCamera } from '../src/registry.js';
+import {
+  captureCameraThumbnail,
+  deleteCameraThumbnailFile,
+  thumbnailPath,
+} from '../src/camera-thumbnail.js';
+
+const realFetch = global.fetch;
+afterEach(() => { global.fetch = realFetch; });
+
+function makeDb() {
+  const db = new Database(':memory:');
+  runMigrations(db);
+  return db;
+}
+
+function insertCamera(db, overrides = {}) {
+  const id = overrides.id ?? randomUUID();
+  db.prepare(`
+    INSERT INTO prod_cameras (id, name, mixer_input, control_type, control_config, sort_order, camera_key)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    id,
+    overrides.name ?? 'Cam 1',
+    overrides.mixer_input ?? null,
+    overrides.control_type ?? 'webcam',
+    JSON.stringify(overrides.control_config ?? {}),
+    overrides.sort_order ?? 0,
+    overrides.camera_key ?? null,
+  );
+  return parseCamera(db.prepare('SELECT * FROM prod_cameras WHERE id = ?').get(id));
+}
+
+function insertMixer(db, overrides = {}) {
+  const id = overrides.id ?? randomUUID();
+  db.prepare(`
+    INSERT INTO prod_mixers (id, name, type, connection_config)
+    VALUES (?, ?, ?, ?)
+  `).run(id, overrides.name ?? 'Mixer 1', overrides.type ?? 'lcyt', JSON.stringify(overrides.connection_config ?? {}));
+  return id;
+}
+
+function makeRegistryStub(activeSourceByMixer = {}) {
+  return { getActiveSource: (mixerId) => activeSourceByMixer[mixerId] ?? null };
+}
+
+function makeTmpDir() {
+  return fs.mkdtempSync(join(tmpdir(), 'lcyt-cam-thumb-'));
+}
+
+describe('captureCameraThumbnail — Path A (independent feed, camera_key)', () => {
+  test('no camera_key and no apiKey -> 400', async () => {
+    const db = makeDb();
+    const camera = insertCamera(db, { control_type: 'amx', camera_key: null });
+    const registry = makeRegistryStub();
+    const result = await captureCameraThumbnail(db, camera, registry, { thumbnailsDir: makeTmpDir() });
+    assert.equal(result.ok, false);
+    assert.equal(result.status, 400);
+  });
+
+  test('preview 404 -> 409 (not live)', async () => {
+    global.fetch = async () => ({ ok: false, status: 404 });
+    const db = makeDb();
+    const camera = insertCamera(db, { camera_key: 'cam-key-1' });
+    const registry = makeRegistryStub();
+    const result = await captureCameraThumbnail(db, camera, registry, {
+      thumbnailsDir: makeTmpDir(), previewBaseUrl: 'http://x',
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.status, 409);
+  });
+
+  test('preview non-ok non-404 -> 502', async () => {
+    global.fetch = async () => ({ ok: false, status: 500 });
+    const db = makeDb();
+    const camera = insertCamera(db, { camera_key: 'cam-key-1' });
+    const registry = makeRegistryStub();
+    const result = await captureCameraThumbnail(db, camera, registry, {
+      thumbnailsDir: makeTmpDir(), previewBaseUrl: 'http://x',
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.status, 502);
+  });
+
+  test('fetch throw -> 502', async () => {
+    global.fetch = async () => { throw new Error('network down'); };
+    const db = makeDb();
+    const camera = insertCamera(db, { camera_key: 'cam-key-1' });
+    const registry = makeRegistryStub();
+    const result = await captureCameraThumbnail(db, camera, registry, {
+      thumbnailsDir: makeTmpDir(), previewBaseUrl: 'http://x',
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.status, 502);
+    assert.match(result.error, /network down/);
+  });
+
+  test('success: writes file, updates DB, returns sizeBytes', async () => {
+    global.fetch = async () => ({ ok: true, status: 200, arrayBuffer: async () => Buffer.from('jpeg-bytes') });
+    const db = makeDb();
+    const camera = insertCamera(db, { camera_key: 'cam-key-1' });
+    const registry = makeRegistryStub();
+    const thumbnailsDir = makeTmpDir();
+
+    const result = await captureCameraThumbnail(db, camera, registry, {
+      thumbnailsDir, previewBaseUrl: 'http://x',
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.sizeBytes, Buffer.from('jpeg-bytes').length);
+    assert.ok(result.thumbnailCapturedAt);
+
+    const filepath = thumbnailPath(camera.id, thumbnailsDir);
+    assert.equal(fs.readFileSync(filepath, 'utf8'), 'jpeg-bytes');
+
+    const row = db.prepare('SELECT thumbnail_captured_at FROM prod_cameras WHERE id = ?').get(camera.id);
+    assert.equal(row.thumbnail_captured_at, result.thumbnailCapturedAt);
+  });
+});
+
+describe('captureCameraThumbnail — Path B (program-feed capture, no camera_key)', () => {
+  test('no mixer_input -> 400', async () => {
+    const db = makeDb();
+    const camera = insertCamera(db, { control_type: 'amx', camera_key: null, mixer_input: null });
+    const registry = makeRegistryStub();
+    const result = await captureCameraThumbnail(db, camera, registry, {
+      apiKey: 'proj-key', thumbnailsDir: makeTmpDir(),
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.status, 400);
+  });
+
+  test('no mixer configured -> 400', async () => {
+    const db = makeDb();
+    const camera = insertCamera(db, { control_type: 'amx', camera_key: null, mixer_input: 1 });
+    const registry = makeRegistryStub();
+    const result = await captureCameraThumbnail(db, camera, registry, {
+      apiKey: 'proj-key', thumbnailsDir: makeTmpDir(),
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.status, 400);
+  });
+
+  test('multiple mixers with no mixerId given -> 400 asking to disambiguate', async () => {
+    const db = makeDb();
+    insertMixer(db);
+    insertMixer(db);
+    const camera = insertCamera(db, { control_type: 'amx', camera_key: null, mixer_input: 1 });
+    const registry = makeRegistryStub();
+    const result = await captureCameraThumbnail(db, camera, registry, {
+      apiKey: 'proj-key', thumbnailsDir: makeTmpDir(),
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.status, 400);
+    assert.match(result.error, /mixerId/);
+  });
+
+  test('camera not currently the active mixer source -> 409', async () => {
+    const db = makeDb();
+    const mixerId = insertMixer(db);
+    const camera = insertCamera(db, { control_type: 'amx', camera_key: null, mixer_input: 2 });
+    const registry = makeRegistryStub({ [mixerId]: 1 }); // active source is input 1, camera is input 2
+    const result = await captureCameraThumbnail(db, camera, registry, {
+      apiKey: 'proj-key', thumbnailsDir: makeTmpDir(),
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.status, 409);
+  });
+
+  test('success: auto-resolves the single mixer, fetches by apiKey, writes + updates DB', async () => {
+    let requestedUrl = null;
+    global.fetch = async (url) => {
+      requestedUrl = url;
+      return { ok: true, status: 200, arrayBuffer: async () => Buffer.from('program-frame') };
+    };
+    const db = makeDb();
+    const mixerId = insertMixer(db);
+    const camera = insertCamera(db, { control_type: 'amx', camera_key: null, mixer_input: 2 });
+    const registry = makeRegistryStub({ [mixerId]: 2 }); // camera 2 is live
+    const thumbnailsDir = makeTmpDir();
+
+    const result = await captureCameraThumbnail(db, camera, registry, {
+      apiKey: 'proj-key', thumbnailsDir, previewBaseUrl: 'http://x',
+    });
+    assert.equal(result.ok, true);
+    assert.equal(requestedUrl, 'http://x/preview/proj-key/incoming');
+
+    const filepath = thumbnailPath(camera.id, thumbnailsDir);
+    assert.equal(fs.readFileSync(filepath, 'utf8'), 'program-frame');
+  });
+
+  test('explicit mixerId is honored over auto-resolution', async () => {
+    global.fetch = async () => ({ ok: true, status: 200, arrayBuffer: async () => Buffer.from('x') });
+    const db = makeDb();
+    const mixerA = insertMixer(db);
+    const mixerB = insertMixer(db);
+    const camera = insertCamera(db, { control_type: 'amx', camera_key: null, mixer_input: 3 });
+    const registry = makeRegistryStub({ [mixerA]: 999, [mixerB]: 3 });
+
+    const result = await captureCameraThumbnail(db, camera, registry, {
+      apiKey: 'proj-key', mixerId: mixerB, thumbnailsDir: makeTmpDir(),
+    });
+    assert.equal(result.ok, true);
+  });
+});
+
+describe('deleteCameraThumbnailFile', () => {
+  test('removes an existing file and is a no-op when absent', () => {
+    const thumbnailsDir = makeTmpDir();
+    const cameraId = randomUUID();
+    const filepath = thumbnailPath(cameraId, thumbnailsDir);
+    fs.writeFileSync(filepath, 'bytes');
+    assert.ok(fs.existsSync(filepath));
+
+    deleteCameraThumbnailFile(cameraId, thumbnailsDir);
+    assert.equal(fs.existsSync(filepath), false);
+
+    // Second call (already deleted) must not throw
+    assert.doesNotThrow(() => deleteCameraThumbnailFile(cameraId, thumbnailsDir));
+  });
+});

--- a/packages/plugins/lcyt-production/test/cameras-routes.test.js
+++ b/packages/plugins/lcyt-production/test/cameras-routes.test.js
@@ -1,0 +1,183 @@
+/**
+ * Route-level tests for the camera thumbnail capture/serve endpoints added to
+ * routes/cameras.js: POST /:id/thumbnail/capture, GET /:id/thumbnail(.jpg),
+ * DELETE /:id (thumbnail-file cleanup), and the thumbnailUrl field on
+ * GET / and GET /:id. First route-level test file for this router.
+ */
+
+import { describe, it, before, after, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import * as fs from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import Database from 'better-sqlite3';
+import express from 'express';
+
+import { runMigrations } from '../src/db.js';
+import { createCamerasRouter } from '../src/routes/cameras.js';
+
+const realFetch = global.fetch;
+
+let server, baseUrl, db, thumbnailsDir;
+
+function makeRegistryStub(activeSourceByMixer = {}) {
+  return {
+    reloadCamera: async () => {},
+    removeCamera: async () => {},
+    getActiveSource: (mixerId) => activeSourceByMixer[mixerId] ?? null,
+  };
+}
+
+function insertCamera(overrides = {}) {
+  const id = overrides.id ?? randomUUID();
+  db.prepare(`
+    INSERT INTO prod_cameras (id, name, mixer_input, control_type, control_config, sort_order, camera_key)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    id,
+    overrides.name ?? 'Cam 1',
+    overrides.mixer_input ?? null,
+    overrides.control_type ?? 'webcam',
+    JSON.stringify(overrides.control_config ?? {}),
+    overrides.sort_order ?? 0,
+    overrides.camera_key ?? null,
+  );
+  return id;
+}
+
+function insertMixer(overrides = {}) {
+  const id = overrides.id ?? randomUUID();
+  db.prepare(`
+    INSERT INTO prod_mixers (id, name, type, connection_config)
+    VALUES (?, ?, ?, ?)
+  `).run(id, overrides.name ?? 'Mixer 1', overrides.type ?? 'lcyt', JSON.stringify({}));
+  return id;
+}
+
+// global.fetch is shared with the test's own calls to the local test server —
+// only intercept the capture module's internal preview fetch, pass everything else through.
+function mockPreview(jpegBytes = 'jpeg-bytes') {
+  global.fetch = async (url, init) => {
+    if (typeof url === 'string' && url.includes('/production/cameras')) return realFetch(url, init);
+    return { ok: true, status: 200, arrayBuffer: async () => Buffer.from(jpegBytes) };
+  };
+}
+
+function startApp(registry) {
+  const app = express();
+  app.use(express.json());
+  app.use('/production/cameras', createCamerasRouter(db, registry, null, { cameraThumbnail: { thumbnailsDir } }));
+  return new Promise((resolve) => {
+    server = createServer(app);
+    server.listen(0, () => { baseUrl = `http://localhost:${server.address().port}`; resolve(); });
+  });
+}
+
+before(() => {
+  db = new Database(':memory:');
+  runMigrations(db);
+});
+
+after(() => db.close());
+
+afterEach(() => {
+  global.fetch = realFetch;
+  if (server) { server.close(); server = null; }
+});
+
+describe('camera thumbnail routes', () => {
+  it('capture on unknown camera id -> 404', async () => {
+    thumbnailsDir = fs.mkdtempSync(join(tmpdir(), 'lcyt-cam-thumb-'));
+    await startApp(makeRegistryStub());
+    const res = await fetch(`${baseUrl}/production/cameras/does-not-exist/thumbnail/capture`, { method: 'POST' });
+    assert.equal(res.status, 404);
+  });
+
+  it('capture with no camera_key and no apiKey -> 400', async () => {
+    thumbnailsDir = fs.mkdtempSync(join(tmpdir(), 'lcyt-cam-thumb-'));
+    await startApp(makeRegistryStub());
+    const id = insertCamera({ control_type: 'amx', camera_key: null });
+    const res = await fetch(`${baseUrl}/production/cameras/${id}/thumbnail/capture`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}',
+    });
+    assert.equal(res.status, 400);
+  });
+
+  it('GET .../thumbnail before any capture -> 404', async () => {
+    thumbnailsDir = fs.mkdtempSync(join(tmpdir(), 'lcyt-cam-thumb-'));
+    await startApp(makeRegistryStub());
+    const id = insertCamera();
+    const res = await fetch(`${baseUrl}/production/cameras/${id}/thumbnail`);
+    assert.equal(res.status, 404);
+  });
+
+  it('capture happy path (webcam camera_key) then GET .../thumbnail serves the JPEG', async () => {
+    thumbnailsDir = fs.mkdtempSync(join(tmpdir(), 'lcyt-cam-thumb-'));
+    await startApp(makeRegistryStub());
+    const id = insertCamera({ camera_key: 'cam-key-1' });
+
+    mockPreview();
+
+    const captureRes = await fetch(`${baseUrl}/production/cameras/${id}/thumbnail/capture`, { method: 'POST' });
+    assert.equal(captureRes.status, 200);
+    const captureBody = await captureRes.json();
+    assert.equal(captureBody.ok, true);
+    assert.ok(captureBody.thumbnailCapturedAt);
+
+    const getRes = await fetch(`${baseUrl}/production/cameras/${id}/thumbnail`);
+    assert.equal(getRes.status, 200);
+    assert.equal(getRes.headers.get('content-type'), 'image/jpeg');
+    const bytes = Buffer.from(await getRes.arrayBuffer());
+    assert.equal(bytes.toString(), 'jpeg-bytes');
+  });
+
+  it('program-feed capture (amx camera) requires the camera to be the active mixer source', async () => {
+    thumbnailsDir = fs.mkdtempSync(join(tmpdir(), 'lcyt-cam-thumb-'));
+    const mixerId = insertMixer();
+    const id = insertCamera({ control_type: 'amx', camera_key: null, mixer_input: 2 });
+    await startApp(makeRegistryStub({ [mixerId]: 1 })); // input 1 is live, camera is input 2
+
+    const res = await fetch(`${baseUrl}/production/cameras/${id}/thumbnail/capture`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ apiKey: 'proj-key' }),
+    });
+    assert.equal(res.status, 409);
+  });
+
+  it('DELETE /:id removes the thumbnail file from disk', async () => {
+    thumbnailsDir = fs.mkdtempSync(join(tmpdir(), 'lcyt-cam-thumb-'));
+    await startApp(makeRegistryStub());
+    const id = insertCamera({ camera_key: 'cam-key-1' });
+
+    mockPreview();
+    const captureRes = await fetch(`${baseUrl}/production/cameras/${id}/thumbnail/capture`, { method: 'POST' });
+    assert.equal(captureRes.status, 200);
+
+    const filepath = join(thumbnailsDir, `${id}.jpg`);
+    assert.ok(fs.existsSync(filepath));
+
+    const delRes = await fetch(`${baseUrl}/production/cameras/${id}`, { method: 'DELETE' });
+    assert.equal(delRes.status, 204);
+    assert.equal(fs.existsSync(filepath), false);
+  });
+
+  it('GET / shows thumbnailUrl: null before capture and a URL after', async () => {
+    thumbnailsDir = fs.mkdtempSync(join(tmpdir(), 'lcyt-cam-thumb-'));
+    await startApp(makeRegistryStub());
+    const id = insertCamera({ camera_key: 'cam-key-1' });
+
+    const beforeRes = await fetch(`${baseUrl}/production/cameras`);
+    const beforeList = await beforeRes.json();
+    const beforeCam = beforeList.find(c => c.id === id);
+    assert.equal(beforeCam.thumbnailUrl, null);
+
+    mockPreview();
+    await fetch(`${baseUrl}/production/cameras/${id}/thumbnail/capture`, { method: 'POST' });
+
+    const afterRes = await fetch(`${baseUrl}/production/cameras`);
+    const afterList = await afterRes.json();
+    const afterCam = afterList.find(c => c.id === id);
+    assert.equal(afterCam.thumbnailUrl, `${baseUrl}/production/cameras/${id}/thumbnail`);
+  });
+});


### PR DESCRIPTION
Lets an operator persist a still-frame "picture" per camera so they can
see what a camera is framing without a live preview open. Two capture
paths depending on control type: webcam/mobile cameras capture from
their own MediaMTX preview (camera_key); amx/visca-ip cameras have no
video path of their own, so capture instead pulls from the mixer's
program feed while that camera is the active source. Both reuse the
existing public /preview/:key/incoming endpoint over plain HTTP, the
same pattern lcyt-agent's VisionFrameFetcher already uses.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JPogmMvvjcJGfGnKYBVyD8