### PR TITLE
fix(crop): address PR #263 Copilot review — zmq gating, libx264 fail-fast, source-map type coercion

### DIFF
--- a/packages/plugins/lcyt-rtmp/src/crop-manager.js
+++ b/packages/plugins/lcyt-rtmp/src/crop-manager.js
@@ -145,6 +145,27 @@ export class CropManager {
      */
     this._sessions = new Map();
     this._nextZmqOffset = 0;
+
+    /** null = not checked yet; boolean once the lazy import has settled. */
+    this._zmqModuleAvailable = null;
+    this._zmqLoad = undefined;
+  }
+
+  /**
+   * Lazily import the optional `zeromq` package (memoized). Resolves the
+   * module or null when it is not installed.
+   */
+  _loadZmqModule() {
+    if (this._zmqLoad === undefined) {
+      this._zmqLoad = import('zeromq')
+        .then(m => { this._zmqModuleAvailable = true; return m; })
+        .catch(() => {
+          this._zmqModuleAvailable = false;
+          logger.warn('[crop] optional dependency "zeromq" not installed — position changes will restart the renderer');
+          return null;
+        });
+    }
+    return this._zmqLoad;
   }
 
   /** MediaMTX path name of the crop rendition. */
@@ -154,10 +175,11 @@ export class CropManager {
 
   /**
    * `'live'` when position changes go over runtime filter commands,
-   * `'restart'` when they need a process swap.
+   * `'restart'` when they need a process swap. Optimistically 'live' until
+   * the lazy `zeromq` import has settled (first start() resolves it).
    */
   repositionMode() {
-    return this._ffmpegCaps?.hasZmq ? 'live' : 'restart';
+    return this._ffmpegCaps?.hasZmq && this._zmqModuleAvailable !== false ? 'live' : 'restart';
   }
 
   getStatus(apiKey) {
@@ -187,6 +209,11 @@ export class CropManager {
   async start(apiKey, config, { position, activePresetId = null } = {}) {
     if (this._ffmpegCaps?.available === false) {
       throw new Error('ffmpeg is not installed or not available in PATH. Vertical crop requires ffmpeg.');
+    }
+    // The renderer always re-encodes with libx264 — fail fast with a clear
+    // error instead of spawning an ffmpeg that exits immediately.
+    if (this._ffmpegCaps?.hasLibx264 === false) {
+      throw new Error('ffmpeg lacks the libx264 encoder. Vertical crop requires an ffmpeg build with libx264.');
     }
     const previous = this._sessions.get(apiKey);
     // Carry the last position across restarts unless explicitly overridden.
@@ -219,8 +246,11 @@ export class CropManager {
     const outH = config.outH ?? Number((process.env.CROP_OUTPUT_DEFAULT || '1080x1920').split('x')[1]);
 
     // zmq lands in the graph only when both the ffmpeg build and the node
-    // client side are available — a bind without a client is dead weight.
-    const zmqPort = this._ffmpegCaps?.hasZmq ? ZMQ_PORT_BASE + (this._nextZmqOffset++ % 1000) : null;
+    // client side are available — a bind without a client would be dead
+    // weight (and a pointless port allocation), so resolve the optional
+    // `zeromq` import BEFORE deciding whether to insert the filter.
+    const zmqMod = this._ffmpegCaps?.hasZmq ? await this._loadZmqModule() : null;
+    const zmqPort = zmqMod ? ZMQ_PORT_BASE + (this._nextZmqOffset++ % 1000) : null;
     let filter = `[0:v]crop@vcrop=${geometry.cropW}:${geometry.cropH}:${x}:${y},scale=${outW}:${outH}`;
     // Args go through spawn (no shell); only the filtergraph parser needs the
     // ':' inside the bind address escaped, so a single literal backslash.
@@ -262,7 +292,7 @@ export class CropManager {
     this._sessions.set(apiKey, session);
 
     if (zmqPort) {
-      session.zmq = await this._openZmq(apiKey, zmqPort);
+      session.zmq = this._openZmq(apiKey, zmqMod, zmqPort);
     }
 
     if (handle?.stderr) handle.stderr.on('data', d => process.stderr.write(`${tag} ${d}`));
@@ -360,17 +390,10 @@ export class CropManager {
 
   /**
    * Open a ZeroMQ REQ socket to the process's zmq filter. Returns null (and
-   * downgrades the session to restart mode) when the optional `zeromq`
-   * package is not installed.
+   * downgrades the session to restart mode) when socket setup fails.
+   * The module itself was already resolved by start() via _loadZmqModule().
    */
-  async _openZmq(apiKey, port) {
-    let zmqMod;
-    try {
-      zmqMod = await import('zeromq');
-    } catch {
-      logger.warn(`[crop:${apiKey.slice(0, 8)}] optional dependency "zeromq" not installed — falling back to restart-based repositioning`);
-      return null;
-    }
+  _openZmq(apiKey, zmqMod, port) {
     try {
       const socket = new zmqMod.Request({ sendTimeout: 500, receiveTimeout: 500 });
       socket.connect(`tcp://127.0.0.1:${port}`);

--- a/packages/plugins/lcyt-rtmp/src/db/crop.js
+++ b/packages/plugins/lcyt-rtmp/src/db/crop.js
@@ -78,6 +78,19 @@ export function runCropMigrations(db) {
 
 const clamp01 = v => Math.max(0, Math.min(1, Number(v)));
 
+/**
+ * Coerce a mixer-input / camera-preset value to an integer or null.
+ * JSON bodies and env-derived values often carry these as strings; the
+ * source-map resolver compares with strict equality, so both the stored and
+ * the queried values must be normalised to the same type.
+ * Returns NaN for values that are set but not integer-coercible.
+ */
+function toIntOrNull(v) {
+  if (v === null || v === undefined || v === '') return null;
+  const n = Number(v);
+  return Number.isInteger(n) ? n : NaN;
+}
+
 function formatConfig(row) {
   return {
     enabled:       row.enabled === 1,
@@ -339,14 +352,22 @@ export function createCropSourceMapEntry(db, apiKey, { mixerId = null, mixerInpu
   if (!presetId) return { ok: false, error: 'presetId is required' };
   const preset = db.prepare('SELECT id FROM crop_presets WHERE api_key = ? AND id = ?').get(apiKey, presetId);
   if (!preset) return { ok: false, error: 'presetId does not reference one of this project\'s presets' };
-  const hasMixer = mixerId !== null || mixerInput !== null;
-  const hasCamera = cameraId !== null;
+
+  const normMixerInput   = toIntOrNull(mixerInput);
+  const normCameraPreset = toIntOrNull(cameraPreset);
+  if (Number.isNaN(normMixerInput))   return { ok: false, error: 'mixerInput must be an integer' };
+  if (Number.isNaN(normCameraPreset)) return { ok: false, error: 'cameraPreset must be an integer' };
+  const normMixerId  = mixerId  != null && mixerId  !== '' ? String(mixerId)  : null;
+  const normCameraId = cameraId != null && cameraId !== '' ? String(cameraId) : null;
+
+  const hasMixer = normMixerId !== null || normMixerInput !== null;
+  const hasCamera = normCameraId !== null;
   if (!hasMixer && !hasCamera) {
     return { ok: false, error: 'At least one of mixerId/mixerInput or cameraId must be set' };
   }
   const id = randomUUID();
   db.prepare('INSERT INTO crop_source_map (id, api_key, mixer_id, mixer_input, camera_id, camera_preset, preset_id) VALUES (?, ?, ?, ?, ?, ?, ?)')
-    .run(id, apiKey, mixerId, mixerInput, cameraId, cameraPreset, presetId);
+    .run(id, apiKey, normMixerId, normMixerInput, normCameraId, normCameraPreset, presetId);
   return { ok: true, entry: formatMapRow(db.prepare('SELECT * FROM crop_source_map WHERE id = ?').get(id)) };
 }
 
@@ -365,6 +386,15 @@ export function deleteCropSourceMapEntry(db, apiKey, id) {
  * @returns {object|null} the winning preset (formatPreset shape) or null
  */
 export function resolveCropPresetForSource(db, apiKey, { mixerId = null, mixerInput = null, cameraId = null, cameraPreset = null } = {}) {
+  // Normalise caller-provided values (JSON bodies often carry numbers as
+  // strings) so the strict comparisons below match the normalised DB values.
+  mixerInput   = toIntOrNull(mixerInput);
+  cameraPreset = toIntOrNull(cameraPreset);
+  if (Number.isNaN(mixerInput))   mixerInput = null;
+  if (Number.isNaN(cameraPreset)) cameraPreset = null;
+  mixerId  = mixerId  != null && mixerId  !== '' ? String(mixerId)  : null;
+  cameraId = cameraId != null && cameraId !== '' ? String(cameraId) : null;
+
   const activeSetId = getCropConfig(db, apiKey).activeSetId;
   const rows = db.prepare('SELECT * FROM crop_source_map WHERE api_key = ?').all(apiKey);
 

--- a/packages/plugins/lcyt-rtmp/test/crop-db.test.js
+++ b/packages/plugins/lcyt-rtmp/test/crop-db.test.js
@@ -207,4 +207,25 @@ describe('source map + resolution', () => {
     assert.equal(deleteCropSourceMapEntry(db, KEY, e.entry.id), true);
     assert.equal(deleteCropSourceMapEntry(db, KEY, e.entry.id), false);
   });
+
+  test('string-typed numeric values (JSON bodies) are coerced on insert and resolve', () => {
+    const p = createCropPreset(db, KEY, { name: 'p' });
+
+    // Stored as strings → normalised to integers
+    const e = createCropSourceMapEntry(db, KEY, { mixerInput: '2', cameraId: 'cam1', cameraPreset: '3', presetId: p.preset.id });
+    assert.equal(e.ok, true);
+    assert.equal(e.entry.mixerInput, 2);
+    assert.equal(e.entry.cameraPreset, 3);
+
+    // Queried as strings → still resolves
+    assert.equal(resolveCropPresetForSource(db, KEY, { mixerInput: '2', cameraId: 'cam1', cameraPreset: '3' })?.id, p.preset.id);
+    // Queried as numbers against string-inserted rows → still resolves
+    assert.equal(resolveCropPresetForSource(db, KEY, { mixerInput: 2, cameraId: 'cam1', cameraPreset: 3 })?.id, p.preset.id);
+  });
+
+  test('non-integer mixerInput/cameraPreset are rejected on insert', () => {
+    const p = createCropPreset(db, KEY, { name: 'p' });
+    assert.equal(createCropSourceMapEntry(db, KEY, { mixerInput: 'abc', presetId: p.preset.id }).ok, false);
+    assert.equal(createCropSourceMapEntry(db, KEY, { cameraId: 'cam1', cameraPreset: 1.5, presetId: p.preset.id }).ok, false);
+  });
 });

--- a/packages/plugins/lcyt-rtmp/test/crop-manager.test.js
+++ b/packages/plugins/lcyt-rtmp/test/crop-manager.test.js
@@ -138,6 +138,33 @@ describe('CropManager', () => {
     const mgr = makeManager();
     await assert.rejects(() => mgr.applyPosition('nope', { xNorm: 0.5, yNorm: 0 }), /not running/);
   });
+
+  test('fails fast when ffmpeg lacks libx264', async () => {
+    const mgr = new CropManager({
+      ffmpegCaps: { available: true, hasLibx264: false, hasZmq: false },
+      probeResolution: async () => ({ inW: 1920, inH: 1080 }),
+    });
+    await assert.rejects(() => mgr.start('nox264', CONFIG), /libx264/);
+    assert.ok(!mgr.isRunning('nox264'));
+  });
+
+  test('hasZmq without the zeromq module: no zmq filter in the graph, restart mode reported', async () => {
+    // The optional `zeromq` package is not installed in this repo, so the
+    // lazy import fails — the filter must NOT bind a dead port.
+    jobs.length = 0;
+    const mgr = new CropManager({
+      ffmpegCaps: { available: true, hasZmq: true },
+      probeResolution: async () => ({ inW: 1920, inH: 1080 }),
+    });
+    await mgr.start('zmqless', CONFIG);
+
+    const filter = jobs[0].args[jobs[0].args.indexOf('-filter_complex') + 1];
+    assert.ok(!filter.includes('zmq'), `no zmq filter without the client module: ${filter}`);
+    assert.equal(mgr.getStatus('zmqless').repositionMode, 'restart');
+    assert.equal(mgr.repositionMode(), 'restart', 'manager-level mode downgrades once the import has settled');
+
+    await mgr.stop('zmqless');
+  });
 });
 
 describe('RtmpRelayManager — crop-view slots', () => {


### PR DESCRIPTION
- CropManager: resolve the optional zeromq import BEFORE building the filter
  graph, so ffmpeg never binds a zmq port that has no client (the module was
  previously only checked after spawn); repositionMode() now reports
  'restart' once the import has settled unavailable
- CropManager: fail fast with a clear error when ffmpegCaps.hasLibx264 ===
  false instead of spawning an ffmpeg that exits immediately
- db/crop.js: normalise mixerInput/cameraPreset to integers (and
  mixerId/cameraId to strings) on both source-map insert and resolution —
  strict-equality matching silently failed when JSON bodies carried numbers
  as strings; non-integer values are now rejected on insert

Regression tests for all three behaviours (string-typed insert+resolve
round-trips, libx264 rejection, zmq-module-absent graph without the filter).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EanGbgWtGM2Gvqib2McGnm