### PR TITLE
Add broadcasts entity with lifecycle, assets, and session binding

### DIFF
--- a/packages/lcyt-backend/CLAUDE.md
+++ b/packages/lcyt-backend/CLAUDE.md
@@ -230,6 +230,16 @@ PUT    /targets/:id       — update a target (Bearer token)
 DELETE /targets/:id       — delete a target (Bearer token)
 PUT    /targets/reorder   — persist a new sort order in one call, body { order: string[] } (Bearer token)
 
+GET    /broadcasts              — list broadcasts (?status=, ?from=, ?to= calendar range, ?includeArchived=1) (plan/broadcasts; Bearer token)
+POST   /broadcasts              — create a broadcast (draft) (Bearer token)
+GET    /broadcasts/:id          — one broadcast + linked reusable assets (Bearer token)
+PUT    /broadcasts/:id          — edit title/description/schedule/status (Bearer token)
+DELETE /broadcasts/:id          — first call archives (202); a second call on an already-archived broadcast hard-deletes it, but 409s until archived ≥ BROADCAST_ARCHIVE_MIN_AGE_DAYS (default 30). Hard delete nulls broadcast_id on produced rows (Bearer token)
+POST   /broadcasts/:id/restore  — un-archive (Bearer token)
+POST   /broadcasts/:id/duplicate — clone (title + reusable-asset links, never produced content); cross-project targetApiKey is 501 (deep-copy TODO) (Bearer token)
+POST   /broadcasts/:id/assets            — link a reusable asset { assetType, assetRef, sortOrder? } (Bearer token)
+DELETE /broadcasts/:id/assets/:rowId     — unlink a reusable asset (Bearer token)
+
 GET    /translation/config              — combined read: { vendor, targets } (Bearer token)
 PUT    /translation/config/vendor       — update vendor + credentials (Bearer token)
 POST   /translation/config/targets      — create a language/destination translation target (Bearer token)
@@ -380,6 +390,7 @@ PUT    /admin/orgs/:id/feature-overrides/:code     — set an org-level override
 - `src/routes/targets.js` — Server-persisted caption delivery target CRUD (`caption_targets` table; `/targets/*`).
 - `src/routes/translation.js` — Server-persisted translation vendor + language config CRUD (`translation_vendor_config`/`translation_targets` tables; `/translation/config*`).
 - `src/db/caption-targets.js` — Caption target DB helpers (`caption_targets` table).
+- `src/db/broadcasts.js` — Broadcast entity DB helpers (`broadcasts` + `broadcast_assets` tables; plan/broadcasts): CRUD, calendar/status list, archive/restore, cooling-off hard-delete (`BROADCAST_ARCHIVE_MIN_AGE_DAYS`, default 30), same-project `duplicateBroadcast`, and session-lifecycle binding (`autoCreateForSession`/`bindSessionStart`/`completeBroadcast`). Produced-content tables (`sessions`/`session_stats`/`caption_files`) carry a nullable `broadcast_id`; `POST /live`'s optional `broadcastId` binds a session (1:1 per run) or auto-creates a `live` broadcast, and the session-end paths write `session_stats.broadcast_id` + call `completeBroadcast`. `src/routes/broadcasts.js` mounts the routes (in `content.js` under `scoped('broadcast')`).
 - `src/db/translation-config.js` — Translation vendor + target DB helpers (`translation_vendor_config`/`translation_targets` tables).
 - `src/routes/stream-hls.js` — Video+audio HLS streaming (public, rate-limited).
 - `src/routes/preview.js` — RTMP → JPEG thumbnail serving (public).

--- a/packages/lcyt-backend/src/db/broadcasts.js
+++ b/packages/lcyt-backend/src/db/broadcasts.js
@@ -1,0 +1,383 @@
+/**
+ * Broadcast DB helpers — first-class intra-project casting occasion.
+ * (plan/broadcasts) A project (`api_key`) has many broadcasts; each has a
+ * lifecycle (draft → scheduled → live → completed → archived), optional
+ * schedule, and linked reusable assets. Produced content (sessions,
+ * session_stats, caption_files) attaches back via a nullable `broadcast_id`.
+ *
+ * Route handlers stay thin and delegate all SQL here (backend DB convention).
+ */
+
+import { randomUUID } from 'node:crypto';
+
+export const BROADCAST_STATUSES = new Set([
+  'draft', 'scheduled', 'live', 'completed', 'archived',
+]);
+
+export const BROADCAST_ASSET_TYPES = new Set([
+  'graphic', 'cue', 'action', 'icon', 'target', 'rundown',
+]);
+
+/** Minimum days a broadcast must be archived before it can be hard-deleted. */
+export function archiveMinAgeDays() {
+  const v = Number(process.env.BROADCAST_ARCHIVE_MIN_AGE_DAYS);
+  return Number.isFinite(v) && v >= 0 ? v : 30;
+}
+
+/**
+ * Shape a DB row to the API representation (camelCase, parsed JSON).
+ * @param {object} row
+ * @returns {object}
+ */
+function formatRow(row) {
+  return {
+    id:                 row.id,
+    title:              row.title,
+    description:        row.description ?? null,
+    status:             row.status,
+    scheduledStart:     row.scheduled_start ?? null,
+    scheduledEnd:       row.scheduled_end ?? null,
+    actualStart:        row.actual_start ?? null,
+    actualEnd:          row.actual_end ?? null,
+    youtubeVideoIds:    row.youtube_video_ids ? JSON.parse(row.youtube_video_ids) : [],
+    youtubeBroadcastId: row.youtube_broadcast_id ?? null,
+    rundownFileId:      row.rundown_file_id ?? null,
+    archivedAt:         row.archived_at ?? null,
+    createdAt:          row.created_at,
+    updatedAt:          row.updated_at,
+  };
+}
+
+function formatAsset(row) {
+  return {
+    id:         row.id,
+    assetType:  row.asset_type,
+    assetRef:   row.asset_ref,
+    sortOrder:  row.sort_order,
+    createdAt:  row.created_at,
+  };
+}
+
+/**
+ * List broadcasts for a project.
+ * @param {import('better-sqlite3').Database} db
+ * @param {string} apiKey
+ * @param {{ status?: string, includeArchived?: boolean, from?: string, to?: string }} [opts]
+ * @returns {object[]}
+ */
+export function listBroadcasts(db, apiKey, { status, includeArchived = false, from, to } = {}) {
+  const clauses = ['api_key = ?'];
+  const params = [apiKey];
+  if (status) {
+    clauses.push('status = ?');
+    params.push(status);
+  } else if (!includeArchived) {
+    clauses.push("status != 'archived'");
+  }
+  // Calendar range filter on the scheduled window (overlap semantics).
+  if (from) { clauses.push('(scheduled_start IS NULL OR scheduled_start >= ?)'); params.push(from); }
+  if (to)   { clauses.push('(scheduled_start IS NULL OR scheduled_start <= ?)'); params.push(to); }
+
+  const rows = db.prepare(
+    `SELECT * FROM broadcasts WHERE ${clauses.join(' AND ')}
+     ORDER BY COALESCE(scheduled_start, created_at) DESC`
+  ).all(...params);
+  return rows.map(formatRow);
+}
+
+/**
+ * Get the raw row for a broadcast, scoped to a project (internal use).
+ * @returns {object|null}
+ */
+function getRow(db, apiKey, id) {
+  return db.prepare('SELECT * FROM broadcasts WHERE api_key = ? AND id = ?').get(apiKey, id) ?? null;
+}
+
+/**
+ * Get one broadcast + its linked assets.
+ * @returns {object|null}
+ */
+export function getBroadcast(db, apiKey, id) {
+  const row = getRow(db, apiKey, id);
+  if (!row) return null;
+  const assets = db.prepare(
+    'SELECT * FROM broadcast_assets WHERE broadcast_id = ? ORDER BY sort_order, id'
+  ).all(id).map(formatAsset);
+  return { ...formatRow(row), assets };
+}
+
+/**
+ * Create a broadcast.
+ * @param {{ title?, description?, status?, scheduledStart?, scheduledEnd?, id?, actualStart?, youtubeBroadcastId?, rundownFileId? }} fields
+ * @returns {{ ok: true, broadcast: object }|{ ok: false, error: string }}
+ */
+export function createBroadcast(db, apiKey, fields = {}) {
+  const {
+    id = randomUUID(),
+    title = '', description = null,
+    status = 'draft',
+    scheduledStart = null, scheduledEnd = null, actualStart = null,
+    youtubeBroadcastId = null, rundownFileId = null,
+  } = fields;
+
+  if (!BROADCAST_STATUSES.has(status)) {
+    return { ok: false, error: `Invalid status: ${status}` };
+  }
+
+  db.prepare(`
+    INSERT INTO broadcasts
+      (id, api_key, title, description, status, scheduled_start, scheduled_end, actual_start, youtube_broadcast_id, rundown_file_id)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    id, apiKey, title, description, status,
+    scheduledStart, scheduledEnd, actualStart,
+    youtubeBroadcastId, rundownFileId,
+  );
+  return { ok: true, broadcast: getBroadcast(db, apiKey, id) };
+}
+
+const UPDATABLE = {
+  title:              'title',
+  description:        'description',
+  status:             'status',
+  scheduledStart:     'scheduled_start',
+  scheduledEnd:       'scheduled_end',
+  youtubeBroadcastId: 'youtube_broadcast_id',
+  rundownFileId:      'rundown_file_id',
+};
+
+/**
+ * Update editable fields on a broadcast. Only provided keys change.
+ * @returns {{ ok: true, broadcast: object }|{ ok: false, error: string, status?: number }}
+ */
+export function updateBroadcast(db, apiKey, id, patch = {}) {
+  const existing = getRow(db, apiKey, id);
+  if (!existing) return { ok: false, error: 'Broadcast not found', status: 404 };
+
+  if (patch.status !== undefined && !BROADCAST_STATUSES.has(patch.status)) {
+    return { ok: false, error: `Invalid status: ${patch.status}` };
+  }
+
+  const sets = [];
+  const params = [];
+  for (const [key, col] of Object.entries(UPDATABLE)) {
+    if (patch[key] !== undefined) {
+      sets.push(`${col} = ?`);
+      params.push(patch[key]);
+    }
+  }
+  if (sets.length === 0) return { ok: true, broadcast: getBroadcast(db, apiKey, id) };
+
+  sets.push("updated_at = datetime('now')");
+  params.push(apiKey, id);
+  db.prepare(`UPDATE broadcasts SET ${sets.join(', ')} WHERE api_key = ? AND id = ?`).run(...params);
+  return { ok: true, broadcast: getBroadcast(db, apiKey, id) };
+}
+
+/**
+ * Archive (soft-delete) a broadcast.
+ * @returns {{ ok: true, broadcast: object }|{ ok: false, error: string, status?: number }}
+ */
+export function archiveBroadcast(db, apiKey, id) {
+  const existing = getRow(db, apiKey, id);
+  if (!existing) return { ok: false, error: 'Broadcast not found', status: 404 };
+  if (existing.status === 'live') {
+    return { ok: false, error: 'Cannot archive a live broadcast', status: 409 };
+  }
+  db.prepare(
+    "UPDATE broadcasts SET status = 'archived', archived_at = datetime('now'), updated_at = datetime('now') WHERE api_key = ? AND id = ?"
+  ).run(apiKey, id);
+  return { ok: true, broadcast: getBroadcast(db, apiKey, id) };
+}
+
+/**
+ * Restore an archived broadcast back to draft.
+ * @returns {{ ok: true, broadcast: object }|{ ok: false, error: string, status?: number }}
+ */
+export function restoreBroadcast(db, apiKey, id) {
+  const existing = getRow(db, apiKey, id);
+  if (!existing) return { ok: false, error: 'Broadcast not found', status: 404 };
+  if (existing.status !== 'archived') {
+    return { ok: false, error: 'Broadcast is not archived', status: 409 };
+  }
+  db.prepare(
+    "UPDATE broadcasts SET status = 'draft', archived_at = NULL, updated_at = datetime('now') WHERE api_key = ? AND id = ?"
+  ).run(apiKey, id);
+  return { ok: true, broadcast: getBroadcast(db, apiKey, id) };
+}
+
+/**
+ * Permanently delete a broadcast. Only permitted once it has been archived for
+ * at least archiveMinAgeDays(); otherwise blocked. Produced content survives —
+ * broadcast_id is nulled on sessions / session_stats / caption_files, and
+ * broadcast_assets cascade-drop via FK.
+ * @returns {{ ok: true }|{ ok: false, error: string, status?: number, archive?: object }}
+ */
+export function deleteBroadcast(db, apiKey, id) {
+  const existing = getRow(db, apiKey, id);
+  if (!existing) return { ok: false, error: 'Broadcast not found', status: 404 };
+
+  if (existing.status !== 'archived') {
+    // First delete archives instead of hard-deleting.
+    const archived = archiveBroadcast(db, apiKey, id);
+    return archived.ok
+      ? { ok: false, error: 'Broadcast archived; delete again after the cooling-off window to remove permanently', status: 202, archive: archived.broadcast }
+      : archived;
+  }
+
+  // Already archived — enforce cooling-off window before permanent delete.
+  const minDays = archiveMinAgeDays();
+  const eligible = db.prepare(
+    "SELECT (archived_at IS NOT NULL AND archived_at <= datetime('now', ?)) AS ok FROM broadcasts WHERE api_key = ? AND id = ?"
+  ).get(`-${minDays} days`, apiKey, id);
+  if (!eligible || eligible.ok !== 1) {
+    return { ok: false, error: `Archived broadcast cannot be permanently deleted until ${minDays} days after archiving`, status: 409 };
+  }
+
+  const tx = db.transaction(() => {
+    db.prepare('UPDATE sessions       SET broadcast_id = NULL WHERE broadcast_id = ?').run(id);
+    db.prepare('UPDATE session_stats  SET broadcast_id = NULL WHERE broadcast_id = ?').run(id);
+    db.prepare('UPDATE caption_files  SET broadcast_id = NULL WHERE broadcast_id = ?').run(id);
+    db.prepare('DELETE FROM broadcasts WHERE api_key = ? AND id = ?').run(apiKey, id);
+  });
+  tx();
+  return { ok: true };
+}
+
+// ── Asset linkage ──────────────────────────────────────────────────────────
+
+/**
+ * Link a reusable asset to a broadcast.
+ * @returns {{ ok: true, asset: object }|{ ok: false, error: string, status?: number }}
+ */
+export function linkAsset(db, apiKey, id, { assetType, assetRef, sortOrder } = {}) {
+  const existing = getRow(db, apiKey, id);
+  if (!existing) return { ok: false, error: 'Broadcast not found', status: 404 };
+  if (!BROADCAST_ASSET_TYPES.has(assetType)) {
+    return { ok: false, error: `Invalid asset type: ${assetType}` };
+  }
+  if (assetRef === undefined || assetRef === null || assetRef === '') {
+    return { ok: false, error: 'assetRef is required' };
+  }
+  const ref = String(assetRef);
+  const order = Number.isFinite(Number(sortOrder))
+    ? Number(sortOrder)
+    : (db.prepare('SELECT COALESCE(MAX(sort_order), -1) AS m FROM broadcast_assets WHERE broadcast_id = ?').get(id).m + 1);
+  try {
+    const info = db.prepare(
+      'INSERT INTO broadcast_assets (broadcast_id, asset_type, asset_ref, sort_order) VALUES (?, ?, ?, ?)'
+    ).run(id, assetType, ref, order);
+    const asset = db.prepare('SELECT * FROM broadcast_assets WHERE id = ?').get(info.lastInsertRowid);
+    return { ok: true, asset: formatAsset(asset) };
+  } catch (e) {
+    if (String(e.message).includes('UNIQUE')) {
+      return { ok: false, error: 'Asset already linked to this broadcast', status: 409 };
+    }
+    throw e;
+  }
+}
+
+/**
+ * Unlink an asset from a broadcast.
+ * @returns {{ ok: true }|{ ok: false, error: string, status?: number }}
+ */
+export function unlinkAsset(db, apiKey, id, assetRowId) {
+  const existing = getRow(db, apiKey, id);
+  if (!existing) return { ok: false, error: 'Broadcast not found', status: 404 };
+  const result = db.prepare('DELETE FROM broadcast_assets WHERE broadcast_id = ? AND id = ?').run(id, assetRowId);
+  if (result.changes === 0) return { ok: false, error: 'Linked asset not found', status: 404 };
+  return { ok: true };
+}
+
+// ── Duplication ──────────────────────────────────────────────────────────
+
+/**
+ * Duplicate a broadcast within the same project. Copies title (suffixed
+ * "(copy)"), description, and the reusable-asset links. Never copies produced
+ * content (youtube ids, actual_start/end, session records, caption files). The
+ * clone starts as a fresh draft. Cross-project deep-copy (targetApiKey) is a
+ * follow-up — see plan_broadcasts.md.
+ * @returns {{ ok: true, broadcast: object }|{ ok: false, error: string, status?: number }}
+ */
+export function duplicateBroadcast(db, apiKey, id) {
+  const source = getRow(db, apiKey, id);
+  if (!source) return { ok: false, error: 'Broadcast not found', status: 404 };
+
+  const newId = randomUUID();
+  const tx = db.transaction(() => {
+    db.prepare(`
+      INSERT INTO broadcasts (id, api_key, title, description, status)
+      VALUES (?, ?, ?, ?, 'draft')
+    `).run(newId, apiKey, `${source.title || 'Broadcast'} (copy)`, source.description ?? null);
+
+    const links = db.prepare('SELECT asset_type, asset_ref, sort_order FROM broadcast_assets WHERE broadcast_id = ?').all(id);
+    const ins = db.prepare('INSERT INTO broadcast_assets (broadcast_id, asset_type, asset_ref, sort_order) VALUES (?, ?, ?, ?)');
+    for (const l of links) ins.run(newId, l.asset_type, l.asset_ref, l.sort_order);
+  });
+  tx();
+  return { ok: true, broadcast: getBroadcast(db, apiKey, newId) };
+}
+
+// ── Session-lifecycle binding ────────────────────────────────────────────
+
+/**
+ * Auto-create a `live` broadcast for an ad-hoc session (POST /live without a
+ * broadcastId). Title is a timestamp (editable later).
+ * @returns {object} the created broadcast (formatted)
+ */
+export function autoCreateForSession(db, apiKey, { startedAt } = {}) {
+  const id = randomUUID();
+  const when = startedAt ? new Date(startedAt) : new Date();
+  const title = `Broadcast ${when.toISOString().slice(0, 16).replace('T', ' ')}`;
+  db.prepare(`
+    INSERT INTO broadcasts (id, api_key, title, status, actual_start)
+    VALUES (?, ?, ?, 'live', ?)
+  `).run(id, apiKey, title, when.toISOString());
+  return getBroadcast(db, apiKey, id);
+}
+
+/**
+ * Bind a starting session to an existing broadcast: transition to `live` and
+ * stamp actual_start. Rejects if the broadcast is already live (1:1 per run).
+ * @returns {{ ok: true, broadcast: object }|{ ok: false, error: string, status?: number }}
+ */
+export function bindSessionStart(db, apiKey, id, { startedAt } = {}) {
+  const existing = getRow(db, apiKey, id);
+  if (!existing) return { ok: false, error: 'Broadcast not found', status: 404 };
+  if (existing.status === 'live') {
+    return { ok: false, error: 'Broadcast already has a live session', status: 409 };
+  }
+  if (existing.status === 'archived') {
+    return { ok: false, error: 'Cannot bind a session to an archived broadcast', status: 409 };
+  }
+  db.prepare(`
+    UPDATE broadcasts
+    SET status = 'live', actual_start = COALESCE(actual_start, ?), updated_at = datetime('now')
+    WHERE api_key = ? AND id = ?
+  `).run((startedAt ? new Date(startedAt) : new Date()).toISOString(), apiKey, id);
+  return { ok: true, broadcast: getBroadcast(db, apiKey, id) };
+}
+
+/**
+ * Complete a broadcast when its session ends: transition to `completed`, stamp
+ * actual_end, and record the YouTube video id(s) the cast produced. Best-effort
+ * and id-only (no apiKey scope) since the session end path already trusts its
+ * own session record.
+ * @param {string[]} [youtubeVideoIds]
+ */
+export function completeBroadcast(db, id, { youtubeVideoIds, endedAt } = {}) {
+  if (!id) return;
+  const row = db.prepare("SELECT status FROM broadcasts WHERE id = ?").get(id);
+  if (!row) return;
+  const ids = Array.isArray(youtubeVideoIds) && youtubeVideoIds.length
+    ? JSON.stringify(youtubeVideoIds)
+    : null;
+  db.prepare(`
+    UPDATE broadcasts
+    SET status = CASE WHEN status = 'archived' THEN status ELSE 'completed' END,
+        actual_end = ?,
+        youtube_video_ids = COALESCE(?, youtube_video_ids),
+        updated_at = datetime('now')
+    WHERE id = ?
+  `).run((endedAt ? new Date(endedAt) : new Date()).toISOString(), ids, id);
+}

--- a/packages/lcyt-backend/src/db/broadcasts.js
+++ b/packages/lcyt-backend/src/db/broadcasts.js
@@ -75,8 +75,8 @@ export function listBroadcasts(db, apiKey, { status, includeArchived = false, fr
     clauses.push("status != 'archived'");
   }
   // Calendar range filter on the scheduled window (overlap semantics).
-  if (from) { clauses.push('(scheduled_start IS NULL OR scheduled_start >= ?)'); params.push(from); }
-  if (to)   { clauses.push('(scheduled_start IS NULL OR scheduled_start <= ?)'); params.push(to); }
+  if (from) { clauses.push('(scheduled_start IS NOT NULL AND COALESCE(scheduled_end, scheduled_start) >= ?)'); params.push(from); }
+  if (to)   { clauses.push('(scheduled_start IS NOT NULL AND scheduled_start <= ?)'); params.push(to); }
 
   const rows = db.prepare(
     `SELECT * FROM broadcasts WHERE ${clauses.join(' AND ')}

--- a/packages/lcyt-backend/src/db/broadcasts.js
+++ b/packages/lcyt-backend/src/db/broadcasts.js
@@ -347,8 +347,8 @@ export function bindSessionStart(db, apiKey, id, { startedAt } = {}) {
   if (existing.status === 'live') {
     return { ok: false, error: 'Broadcast already has a live session', status: 409 };
   }
-  if (existing.status === 'archived') {
-    return { ok: false, error: 'Cannot bind a session to an archived broadcast', status: 409 };
+  if (existing.status !== 'draft' && existing.status !== 'scheduled') {
+    return { ok: false, error: `Cannot bind a session to a ${existing.status} broadcast`, status: 409 };
   }
   db.prepare(`
     UPDATE broadcasts

--- a/packages/lcyt-backend/src/db/index.js
+++ b/packages/lcyt-backend/src/db/index.js
@@ -19,6 +19,7 @@ export * from './project-features.js';
 export * from './project-members.js';
 export * from './device-roles.js';
 export * from './caption-targets.js';
+export * from './broadcasts.js';
 export * from './translation-config.js';
 export * from './mcp-tokens.js';
 

--- a/packages/lcyt-backend/src/db/schema.js
+++ b/packages/lcyt-backend/src/db/schema.js
@@ -307,6 +307,55 @@ export function initDb(dbPath) {
     )
   `);
 
+  // ── Broadcasts: first-class intra-project casting occasion ───────────────
+  // (plan/broadcasts — a project casts many times; groups scheduling + linked
+  // reusable assets, and produced content attaches back via broadcast_id.)
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS broadcasts (
+      id                   TEXT    PRIMARY KEY,
+      api_key              TEXT    NOT NULL REFERENCES api_keys(key) ON DELETE CASCADE,
+      title                TEXT    NOT NULL DEFAULT '',
+      description          TEXT,
+      status               TEXT    NOT NULL DEFAULT 'draft',
+      scheduled_start      TEXT,
+      scheduled_end        TEXT,
+      actual_start         TEXT,
+      actual_end           TEXT,
+      youtube_video_ids    TEXT,
+      youtube_broadcast_id TEXT,
+      rundown_file_id      INTEGER,
+      archived_at          TEXT,
+      created_at           TEXT    NOT NULL DEFAULT (datetime('now')),
+      updated_at           TEXT    NOT NULL DEFAULT (datetime('now'))
+    )
+  `);
+  db.exec('CREATE INDEX IF NOT EXISTS idx_broadcasts_api_key ON broadcasts(api_key)');
+  db.exec('CREATE INDEX IF NOT EXISTS idx_broadcasts_status  ON broadcasts(api_key, status)');
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS broadcast_assets (
+      id            INTEGER PRIMARY KEY AUTOINCREMENT,
+      broadcast_id  TEXT    NOT NULL REFERENCES broadcasts(id) ON DELETE CASCADE,
+      asset_type    TEXT    NOT NULL,
+      asset_ref     TEXT    NOT NULL,
+      sort_order    INTEGER NOT NULL DEFAULT 0,
+      created_at    TEXT    NOT NULL DEFAULT (datetime('now')),
+      UNIQUE(broadcast_id, asset_type, asset_ref)
+    )
+  `);
+  db.exec('CREATE INDEX IF NOT EXISTS idx_broadcast_assets_bid ON broadcast_assets(broadcast_id)');
+
+  // Additive: nullable broadcast_id on produced-content tables so a session,
+  // its stats, and its caption files attach to the broadcast that made them.
+  // (No FK — SQLite ALTER TABLE ADD COLUMN cannot add one; the delete helper
+  // nulls these manually to keep produced content when a broadcast is removed.)
+  const sessionsCols = new Set(db.prepare('PRAGMA table_info(sessions)').all().map(c => c.name));
+  if (!sessionsCols.has('broadcast_id')) db.exec('ALTER TABLE sessions ADD COLUMN broadcast_id TEXT');
+  const sessionStatsCols = new Set(db.prepare('PRAGMA table_info(session_stats)').all().map(c => c.name));
+  if (!sessionStatsCols.has('broadcast_id')) db.exec('ALTER TABLE session_stats ADD COLUMN broadcast_id TEXT');
+  const captionFilesCols = new Set(db.prepare('PRAGMA table_info(caption_files)').all().map(c => c.name));
+  if (!captionFilesCols.has('broadcast_id')) db.exec('ALTER TABLE caption_files ADD COLUMN broadcast_id TEXT');
+
   db.exec(`
     CREATE TABLE IF NOT EXISTS viewer_key_daily_stats (
       date        TEXT    NOT NULL,

--- a/packages/lcyt-backend/src/db/stats.js
+++ b/packages/lcyt-backend/src/db/stats.js
@@ -1,12 +1,12 @@
 /**
  * Write a completed session summary to session_stats.
  * @param {import('better-sqlite3').Database} db
- * @param {{ sessionId: string, apiKey: string, domain: string, startedAt: string, endedAt: string, durationMs: number, captionsSent: number, captionsFailed: number, finalSequence: number, endedBy: string }} data
+ * @param {{ sessionId: string, apiKey: string, domain: string, startedAt: string, endedAt: string, durationMs: number, captionsSent: number, captionsFailed: number, finalSequence: number, endedBy: string, broadcastId?: string|null }} data
  */
-export function writeSessionStat(db, { sessionId, apiKey, domain, startedAt, endedAt, durationMs, captionsSent, captionsFailed, finalSequence, endedBy }) {
+export function writeSessionStat(db, { sessionId, apiKey, domain, startedAt, endedAt, durationMs, captionsSent, captionsFailed, finalSequence, endedBy, broadcastId }) {
   db.prepare(
-    'INSERT INTO session_stats (session_id, api_key, domain, started_at, ended_at, duration_ms, captions_sent, captions_failed, final_sequence, ended_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
-  ).run(sessionId, apiKey, domain ?? null, startedAt, endedAt, durationMs, captionsSent ?? 0, captionsFailed ?? 0, finalSequence ?? 0, endedBy ?? 'client');
+    'INSERT INTO session_stats (session_id, api_key, domain, started_at, ended_at, duration_ms, captions_sent, captions_failed, final_sequence, ended_by, broadcast_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+  ).run(sessionId, apiKey, domain ?? null, startedAt, endedAt, durationMs, captionsSent ?? 0, captionsFailed ?? 0, finalSequence ?? 0, endedBy ?? 'client', broadcastId ?? null);
 }
 
 /**
@@ -39,7 +39,7 @@ export function writeAuthEvent(db, { apiKey, eventType, domain }) {
  */
 export function getKeyStats(db, apiKey) {
   const sessions = db.prepare(
-    'SELECT session_id AS sessionId, domain, started_at AS startedAt, ended_at AS endedAt, duration_ms AS durationMs, captions_sent AS captionsSent, captions_failed AS captionsFailed, final_sequence AS finalSequence, ended_by AS endedBy FROM session_stats WHERE api_key = ? ORDER BY id DESC LIMIT 100'
+    'SELECT session_id AS sessionId, domain, started_at AS startedAt, ended_at AS endedAt, duration_ms AS durationMs, captions_sent AS captionsSent, captions_failed AS captionsFailed, final_sequence AS finalSequence, ended_by AS endedBy, broadcast_id AS broadcastId FROM session_stats WHERE api_key = ? ORDER BY id DESC LIMIT 100'
   ).all(apiKey);
 
   const captionErrors = db.prepare(

--- a/packages/lcyt-backend/src/routes/broadcasts.js
+++ b/packages/lcyt-backend/src/routes/broadcasts.js
@@ -18,7 +18,7 @@
 import { Router } from 'express';
 import {
   listBroadcasts, getBroadcast, createBroadcast, updateBroadcast,
-  archiveBroadcast, restoreBroadcast, deleteBroadcast,
+  restoreBroadcast, deleteBroadcast,
   duplicateBroadcast, linkAsset, unlinkAsset,
 } from '../db/broadcasts.js';
 

--- a/packages/lcyt-backend/src/routes/broadcasts.js
+++ b/packages/lcyt-backend/src/routes/broadcasts.js
@@ -1,0 +1,109 @@
+/**
+ * /broadcasts routes — first-class intra-project broadcast entity (plan/broadcasts).
+ *
+ * Session/project Bearer auth (per-connected-project), same as /targets.
+ *
+ * Routes:
+ *   GET    /broadcasts                    — list (?status=, ?from=, ?to=, ?includeArchived=1)
+ *   POST   /broadcasts                    — create (draft)
+ *   GET    /broadcasts/:id                — one broadcast + linked assets
+ *   PUT    /broadcasts/:id                — edit title/desc/schedule/status
+ *   DELETE /broadcasts/:id                — archive, or hard-delete if already archived past cooling-off
+ *   POST   /broadcasts/:id/restore        — un-archive
+ *   POST   /broadcasts/:id/duplicate      — clone (config + asset links, no produced content)
+ *   POST   /broadcasts/:id/assets         — link a reusable asset
+ *   DELETE /broadcasts/:id/assets/:rowId  — unlink
+ */
+
+import { Router } from 'express';
+import {
+  listBroadcasts, getBroadcast, createBroadcast, updateBroadcast,
+  archiveBroadcast, restoreBroadcast, deleteBroadcast,
+  duplicateBroadcast, linkAsset, unlinkAsset,
+} from '../db/broadcasts.js';
+
+/**
+ * @param {import('express').RequestHandler} auth  project-access / session Bearer middleware
+ * @param {import('better-sqlite3').Database} db
+ * @returns {import('express').Router}
+ */
+export function createBroadcastsRouter(auth, db) {
+  const router = Router();
+
+  router.get('/', auth, (req, res) => {
+    const { status, from, to, includeArchived } = req.query || {};
+    const broadcasts = listBroadcasts(db, req.session.apiKey, {
+      status: status || undefined,
+      from: from || undefined,
+      to: to || undefined,
+      includeArchived: includeArchived === '1' || includeArchived === 'true',
+    });
+    res.json({ broadcasts });
+  });
+
+  router.post('/', auth, (req, res) => {
+    const { title, description, status, scheduledStart, scheduledEnd, youtubeBroadcastId, rundownFileId } = req.body || {};
+    const result = createBroadcast(db, req.session.apiKey, {
+      title, description, status, scheduledStart, scheduledEnd, youtubeBroadcastId, rundownFileId,
+    });
+    if (!result.ok) return res.status(result.status || 400).json({ error: result.error });
+    res.status(201).json({ ok: true, broadcast: result.broadcast });
+  });
+
+  router.get('/:id', auth, (req, res) => {
+    const broadcast = getBroadcast(db, req.session.apiKey, req.params.id);
+    if (!broadcast) return res.status(404).json({ error: 'Broadcast not found' });
+    res.json({ broadcast });
+  });
+
+  router.put('/:id', auth, (req, res) => {
+    const { title, description, status, scheduledStart, scheduledEnd, youtubeBroadcastId, rundownFileId } = req.body || {};
+    const result = updateBroadcast(db, req.session.apiKey, req.params.id, {
+      title, description, status, scheduledStart, scheduledEnd, youtubeBroadcastId, rundownFileId,
+    });
+    if (!result.ok) return res.status(result.status || 400).json({ error: result.error });
+    res.json({ ok: true, broadcast: result.broadcast });
+  });
+
+  // DELETE — first call archives; a second call on an archived broadcast
+  // permanently deletes it, but only once past the cooling-off window.
+  router.delete('/:id', auth, (req, res) => {
+    const result = deleteBroadcast(db, req.session.apiKey, req.params.id);
+    if (result.ok) return res.json({ ok: true });
+    // 202: archived on this call, not yet permanently deleted.
+    if (result.status === 202) return res.status(202).json({ ok: true, archived: true, broadcast: result.archive });
+    return res.status(result.status || 400).json({ error: result.error });
+  });
+
+  router.post('/:id/restore', auth, (req, res) => {
+    const result = restoreBroadcast(db, req.session.apiKey, req.params.id);
+    if (!result.ok) return res.status(result.status || 400).json({ error: result.error });
+    res.json({ ok: true, broadcast: result.broadcast });
+  });
+
+  router.post('/:id/duplicate', auth, (req, res) => {
+    const { targetApiKey } = req.body || {};
+    if (targetApiKey && targetApiKey !== req.session.apiKey) {
+      // Cross-project deep-copy is a follow-up (per-asset-type copy routines).
+      return res.status(501).json({ error: 'Cross-project duplicate not yet implemented' });
+    }
+    const result = duplicateBroadcast(db, req.session.apiKey, req.params.id);
+    if (!result.ok) return res.status(result.status || 400).json({ error: result.error });
+    res.status(201).json({ ok: true, broadcast: result.broadcast });
+  });
+
+  router.post('/:id/assets', auth, (req, res) => {
+    const { assetType, assetRef, sortOrder } = req.body || {};
+    const result = linkAsset(db, req.session.apiKey, req.params.id, { assetType, assetRef, sortOrder });
+    if (!result.ok) return res.status(result.status || 400).json({ error: result.error });
+    res.status(201).json({ ok: true, asset: result.asset });
+  });
+
+  router.delete('/:id/assets/:rowId', auth, (req, res) => {
+    const result = unlinkAsset(db, req.session.apiKey, req.params.id, req.params.rowId);
+    if (!result.ok) return res.status(result.status || 400).json({ error: result.error });
+    res.json({ ok: true });
+  });
+
+  return router;
+}

--- a/packages/lcyt-backend/src/routes/content.js
+++ b/packages/lcyt-backend/src/routes/content.js
@@ -12,6 +12,7 @@ import { createVideoRouter } from './video.js';
 import { createYouTubeRouter } from './youtube.js';
 import { createSttRouter } from './stt.js';
 import { createTargetsRouter } from './targets.js';
+import { createBroadcastsRouter } from './broadcasts.js';
 import { createTranslationRouter } from './translation.js';
 import { createBridgeDownloadRouter } from './bridge-download.js';
 import { createFilesRouter } from 'lcyt-files';
@@ -38,6 +39,7 @@ export function createContentRouters(db, auth, store, jwtSecret, { hlsManager = 
   router.use('/youtube',         createYouTubeRouter(auth));
   router.use('/stt',             createSttRouter(scoped('stt'), sttManager, db, jwtSecret));
   router.use('/targets',         createTargetsRouter(scoped('target'), db));
+  router.use('/broadcasts',      createBroadcastsRouter(scoped('broadcast'), db));
   router.use('/translation',     createTranslationRouter(scoped('translation'), db));
   router.use('/bridge-download', createBridgeDownloadRouter());
   return router;

--- a/packages/lcyt-backend/src/routes/live.js
+++ b/packages/lcyt-backend/src/routes/live.js
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import jwt from 'jsonwebtoken';
 import { YoutubeLiveCaptionSender } from 'lcyt';
-import { validateApiKey, writeSessionStat, writeAuthEvent, incrementDomainHourlySessionStart, incrementDomainHourlySessionEnd, saveSession, getKeySequence, updateKeySequence, resetKeySequence, isGraphicsEnabled, getCaptionTargets } from '../db.js';
+import { validateApiKey, writeSessionStat, writeAuthEvent, incrementDomainHourlySessionStart, incrementDomainHourlySessionEnd, saveSession, getKeySequence, updateKeySequence, resetKeySequence, isGraphicsEnabled, getCaptionTargets, bindSessionStart, autoCreateForSession, completeBroadcast } from '../db.js';
 import { makeSessionId } from '../store.js';
 import { createAuthMiddleware } from '../middleware/auth.js';
 import { isAllowedDomain } from '../lib/allowed-domains.js';
@@ -97,7 +97,7 @@ export function createLiveRouter(db, store, jwtSecret) {
 
   // POST /live — Register session
   router.post('/', async (req, res) => {
-    const { apiKey, streamKey, domain, sequence: startSeqRaw, targets } = req.body || {};
+    const { apiKey, streamKey, domain, sequence: startSeqRaw, targets, broadcastId } = req.body || {};
 
     // Validate required fields (streamKey is optional — targets array supersedes it)
     if (!apiKey || !domain) {
@@ -223,6 +223,19 @@ export function createLiveRouter(db, store, jwtSecret) {
       }
     }
 
+    // Bind this session to a broadcast (plan/broadcasts). An explicit broadcastId
+    // binds an existing broadcast (rejected if it already has a live session);
+    // omitting it auto-creates a fresh `live` broadcast so every session always
+    // has exactly one and produced content attaches back to it.
+    let boundBroadcastId = null;
+    if (broadcastId) {
+      const bind = bindSessionStart(db, apiKey, broadcastId);
+      if (!bind.ok) return res.status(bind.status || 400).json({ error: bind.error });
+      boundBroadcastId = broadcastId;
+    } else {
+      boundBroadcastId = autoCreateForSession(db, apiKey, {}).id;
+    }
+
     // Sign JWT — omit streamKey and domain from payload (sensitive; not needed by route handlers)
     const sessionTtlMs = Number(process.env.SESSION_TTL) || 2 * 60 * 60 * 1000;
     const token = jwt.sign({ sessionId, apiKey }, jwtSecret, { expiresIn: Math.floor(sessionTtlMs / 1000) });
@@ -238,6 +251,7 @@ export function createLiveRouter(db, store, jwtSecret) {
       sender,
       extraTargets,
     });
+    session.broadcastId = boundBroadcastId;
 
     incrementDomainHourlySessionStart(db, domain, store.size());
 
@@ -248,6 +262,7 @@ export function createLiveRouter(db, store, jwtSecret) {
       sequence: session.sequence,
       syncOffset: session.syncOffset,
       startedAt: session.startedAt,
+      broadcastId: boundBroadcastId,
       graphicsEnabled: isGraphicsEnabled(db, apiKey),
     });
   });
@@ -356,18 +371,29 @@ export function createLiveRouter(db, store, jwtSecret) {
     const removed = store.remove(sessionId);
     if (removed) {
       const durationMs = Date.now() - removed.startedAt;
+      const endedAt = new Date().toISOString();
       writeSessionStat(db, {
         sessionId: removed.sessionId,
         apiKey: removed.apiKey,
         domain: removed.domain,
         startedAt: new Date(removed.startedAt).toISOString(),
-        endedAt: new Date().toISOString(),
+        endedAt,
         durationMs,
         captionsSent: removed.captionsSent,
         captionsFailed: removed.captionsFailed,
         finalSequence: removed.sequence,
         endedBy: 'client',
+        broadcastId: removed.broadcastId ?? null,
       });
+      // Transition the bound broadcast to completed (plan/broadcasts).
+      if (removed.broadcastId) {
+        try {
+          completeBroadcast(db, removed.broadcastId, {
+            youtubeVideoIds: removed.youtubeVideoIds,
+            endedAt,
+          });
+        } catch { /* non-fatal */ }
+      }
       incrementDomainHourlySessionEnd(db, removed.domain, durationMs);
     }
     return res.status(200).json({ removed: true, sessionId });

--- a/packages/lcyt-backend/src/routes/live.js
+++ b/packages/lcyt-backend/src/routes/live.js
@@ -392,7 +392,9 @@ export function createLiveRouter(db, store, jwtSecret) {
             youtubeVideoIds: removed.youtubeVideoIds,
             endedAt,
           });
-        } catch { /* non-fatal */ }
+        } catch (err) {
+          console.warn(`[broadcasts] completeBroadcast failed (broadcastId=${removed.broadcastId})`, err);
+        }
       }
       incrementDomainHourlySessionEnd(db, removed.domain, durationMs);
     }

--- a/packages/lcyt-backend/src/server.js
+++ b/packages/lcyt-backend/src/server.js
@@ -5,6 +5,7 @@ import { DskBus } from './dsk-bus.js';
 import {
   initDb, writeSessionStat, incrementDomainHourlySessionEnd,
   getCaptionTargets, createCaptionTarget, updateCaptionTarget, deleteCaptionTarget,
+  completeBroadcast,
 } from './db.js';
 import { SessionStore } from './store.js';
 import { createCorsMiddleware } from './middleware/cors.js';
@@ -345,18 +346,29 @@ store.onSessionEnd = async (session) => {
   // Some persisted sessions may lack an apiKey (nullable in older DBs);
   // avoid writing a session_stats row when apiKey is missing to prevent NOT NULL errors.
   if (session.apiKey) {
+    const endedAt = new Date().toISOString();
     writeSessionStat(db, {
       sessionId: session.sessionId,
       apiKey: session.apiKey,
       domain: session.domain,
       startedAt: new Date(session.startedAt).toISOString(),
-      endedAt: new Date().toISOString(),
+      endedAt,
       durationMs,
       captionsSent: session.captionsSent,
       captionsFailed: session.captionsFailed,
       finalSequence: session.sequence,
       endedBy: 'ttl',
+      broadcastId: session.broadcastId ?? null,
     });
+    // Transition the bound broadcast to completed (plan/broadcasts).
+    if (session.broadcastId) {
+      try {
+        completeBroadcast(db, session.broadcastId, {
+          youtubeVideoIds: session.youtubeVideoIds,
+          endedAt,
+        });
+      } catch { /* non-fatal */ }
+    }
   } else {
     console.warn(`[store] session ended without apiKey (sessionId=${session.sessionId}) — skipping session_stats write`);
   }

--- a/packages/lcyt-backend/src/server.js
+++ b/packages/lcyt-backend/src/server.js
@@ -367,7 +367,9 @@ store.onSessionEnd = async (session) => {
           youtubeVideoIds: session.youtubeVideoIds,
           endedAt,
         });
-      } catch { /* non-fatal */ }
+      } catch (err) {
+        console.warn(`[broadcasts] completeBroadcast failed (broadcastId=${session.broadcastId})`, err);
+      }
     }
   } else {
     console.warn(`[store] session ended without apiKey (sessionId=${session.sessionId}) — skipping session_stats write`);

--- a/packages/lcyt-backend/test/broadcasts-db.test.js
+++ b/packages/lcyt-backend/test/broadcasts-db.test.js
@@ -1,0 +1,218 @@
+/**
+ * Tests for src/db/broadcasts.js — the Broadcast entity DB helpers.
+ * In-memory SQLite; a seeded api_keys row satisfies the FK.
+ */
+
+import { describe, it, before, beforeEach, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { initDb } from '../src/db.js';
+import {
+  listBroadcasts, getBroadcast, createBroadcast, updateBroadcast,
+  archiveBroadcast, restoreBroadcast, deleteBroadcast,
+  duplicateBroadcast, linkAsset, unlinkAsset,
+  autoCreateForSession, bindSessionStart, completeBroadcast,
+} from '../src/db/broadcasts.js';
+
+const KEY = 'bcast-test-key';
+
+let db;
+before(() => {
+  db = initDb(':memory:');
+  db.prepare("INSERT INTO api_keys (key, owner, active) VALUES (?, 'Owner', 1)").run(KEY);
+});
+after(() => db.close());
+
+beforeEach(() => {
+  db.prepare('DELETE FROM broadcasts WHERE api_key = ?').run(KEY);
+});
+
+describe('createBroadcast / getBroadcast', () => {
+  it('creates a draft with defaults and returns it', () => {
+    const r = createBroadcast(db, KEY, { title: 'Sunday Service' });
+    assert.equal(r.ok, true);
+    assert.equal(r.broadcast.title, 'Sunday Service');
+    assert.equal(r.broadcast.status, 'draft');
+    assert.deepEqual(r.broadcast.youtubeVideoIds, []);
+    assert.deepEqual(r.broadcast.assets, []);
+  });
+
+  it('rejects an invalid status', () => {
+    const r = createBroadcast(db, KEY, { title: 'x', status: 'bogus' });
+    assert.equal(r.ok, false);
+  });
+
+  it('getBroadcast returns null for unknown id', () => {
+    assert.equal(getBroadcast(db, KEY, 'nope'), null);
+  });
+});
+
+describe('listBroadcasts', () => {
+  it('excludes archived by default, includes with flag', () => {
+    const a = createBroadcast(db, KEY, { title: 'A' }).broadcast;
+    createBroadcast(db, KEY, { title: 'B' });
+    archiveBroadcast(db, KEY, a.id);
+
+    const visible = listBroadcasts(db, KEY);
+    assert.equal(visible.length, 1);
+    assert.equal(visible[0].title, 'B');
+
+    const all = listBroadcasts(db, KEY, { includeArchived: true });
+    assert.equal(all.length, 2);
+  });
+
+  it('filters by status', () => {
+    createBroadcast(db, KEY, { title: 'sched', status: 'scheduled' });
+    createBroadcast(db, KEY, { title: 'draft' });
+    const sched = listBroadcasts(db, KEY, { status: 'scheduled' });
+    assert.equal(sched.length, 1);
+    assert.equal(sched[0].title, 'sched');
+  });
+});
+
+describe('updateBroadcast', () => {
+  it('patches only provided fields', () => {
+    const b = createBroadcast(db, KEY, { title: 'orig' }).broadcast;
+    const r = updateBroadcast(db, KEY, b.id, { title: 'new', scheduledStart: '2026-08-01T10:00:00' });
+    assert.equal(r.ok, true);
+    assert.equal(r.broadcast.title, 'new');
+    assert.equal(r.broadcast.scheduledStart, '2026-08-01T10:00:00');
+  });
+
+  it('404s for unknown id', () => {
+    const r = updateBroadcast(db, KEY, 'nope', { title: 'x' });
+    assert.equal(r.ok, false);
+    assert.equal(r.status, 404);
+  });
+});
+
+describe('archive / restore / delete lifecycle', () => {
+  it('archive sets status+archived_at; restore clears it', () => {
+    const b = createBroadcast(db, KEY, { title: 'x' }).broadcast;
+    const arch = archiveBroadcast(db, KEY, b.id);
+    assert.equal(arch.broadcast.status, 'archived');
+    assert.ok(arch.broadcast.archivedAt);
+
+    const rest = restoreBroadcast(db, KEY, b.id);
+    assert.equal(rest.broadcast.status, 'draft');
+    assert.equal(rest.broadcast.archivedAt, null);
+  });
+
+  it('cannot archive a live broadcast', () => {
+    const b = autoCreateForSession(db, KEY, {});
+    const r = archiveBroadcast(db, KEY, b.id);
+    assert.equal(r.ok, false);
+    assert.equal(r.status, 409);
+  });
+
+  it('first delete archives (202); second is blocked until cooling-off; then succeeds and nulls produced links', () => {
+    const b = createBroadcast(db, KEY, { title: 'x' }).broadcast;
+
+    // First delete → archive
+    const first = deleteBroadcast(db, KEY, b.id);
+    assert.equal(first.ok, false);
+    assert.equal(first.status, 202);
+    assert.equal(getBroadcast(db, KEY, b.id).status, 'archived');
+
+    // Attach a produced session_stats row to this broadcast
+    db.prepare(
+      "INSERT INTO session_stats (session_id, api_key, started_at, ended_at, duration_ms, broadcast_id) VALUES ('s1', ?, 'a', 'b', 1, ?)"
+    ).run(KEY, b.id);
+
+    // Second delete → still within cooling-off window → blocked
+    const blocked = deleteBroadcast(db, KEY, b.id);
+    assert.equal(blocked.ok, false);
+    assert.equal(blocked.status, 409);
+
+    // Backdate archived_at beyond the window
+    db.prepare("UPDATE broadcasts SET archived_at = datetime('now', '-40 days') WHERE id = ?").run(b.id);
+
+    const done = deleteBroadcast(db, KEY, b.id);
+    assert.equal(done.ok, true);
+    assert.equal(getBroadcast(db, KEY, b.id), null);
+
+    // Produced content survives with broadcast_id nulled
+    const stat = db.prepare("SELECT broadcast_id FROM session_stats WHERE session_id = 's1'").get();
+    assert.equal(stat.broadcast_id, null);
+  });
+});
+
+describe('asset linkage', () => {
+  it('links, lists, rejects dup, and unlinks', () => {
+    const b = createBroadcast(db, KEY, { title: 'x' }).broadcast;
+    const link = linkAsset(db, KEY, b.id, { assetType: 'graphic', assetRef: '42' });
+    assert.equal(link.ok, true);
+
+    const withAssets = getBroadcast(db, KEY, b.id);
+    assert.equal(withAssets.assets.length, 1);
+    assert.equal(withAssets.assets[0].assetType, 'graphic');
+    assert.equal(withAssets.assets[0].assetRef, '42');
+
+    const dup = linkAsset(db, KEY, b.id, { assetType: 'graphic', assetRef: '42' });
+    assert.equal(dup.ok, false);
+    assert.equal(dup.status, 409);
+
+    const un = unlinkAsset(db, KEY, b.id, link.asset.id);
+    assert.equal(un.ok, true);
+    assert.equal(getBroadcast(db, KEY, b.id).assets.length, 0);
+  });
+
+  it('rejects an invalid asset type', () => {
+    const b = createBroadcast(db, KEY, { title: 'x' }).broadcast;
+    const r = linkAsset(db, KEY, b.id, { assetType: 'nonsense', assetRef: '1' });
+    assert.equal(r.ok, false);
+  });
+});
+
+describe('duplicateBroadcast (same project)', () => {
+  it('copies title+links, not produced content, and starts as fresh draft', () => {
+    const b = createBroadcast(db, KEY, { title: 'Original', status: 'scheduled', scheduledStart: '2026-08-01T10:00:00' }).broadcast;
+    linkAsset(db, KEY, b.id, { assetType: 'cue', assetRef: 'c1' });
+    // Simulate produced content on the source
+    completeBroadcast(db, b.id, { youtubeVideoIds: ['vid123'] });
+
+    const dup = duplicateBroadcast(db, KEY, b.id);
+    assert.equal(dup.ok, true);
+    assert.equal(dup.broadcast.title, 'Original (copy)');
+    assert.equal(dup.broadcast.status, 'draft');
+    assert.deepEqual(dup.broadcast.youtubeVideoIds, []);
+    assert.equal(dup.broadcast.scheduledStart, null);
+    assert.equal(dup.broadcast.assets.length, 1);
+    assert.equal(dup.broadcast.assets[0].assetRef, 'c1');
+  });
+});
+
+describe('session-lifecycle binding', () => {
+  it('autoCreateForSession creates a live broadcast with a timestamp title', () => {
+    const b = autoCreateForSession(db, KEY, {});
+    assert.equal(b.status, 'live');
+    assert.match(b.title, /^Broadcast \d{4}-\d{2}-\d{2}/);
+  });
+
+  it('bindSessionStart moves draft→live and rejects a second bind', () => {
+    const b = createBroadcast(db, KEY, { title: 'x', status: 'scheduled' }).broadcast;
+    const bind = bindSessionStart(db, KEY, b.id);
+    assert.equal(bind.ok, true);
+    assert.equal(bind.broadcast.status, 'live');
+    assert.ok(bind.broadcast.actualStart);
+
+    const second = bindSessionStart(db, KEY, b.id);
+    assert.equal(second.ok, false);
+    assert.equal(second.status, 409);
+  });
+
+  it('completeBroadcast sets completed + actual_end + youtube ids', () => {
+    const b = autoCreateForSession(db, KEY, {});
+    completeBroadcast(db, b.id, { youtubeVideoIds: ['abc', 'def'] });
+    const done = getBroadcast(db, KEY, b.id);
+    assert.equal(done.status, 'completed');
+    assert.ok(done.actualEnd);
+    assert.deepEqual(done.youtubeVideoIds, ['abc', 'def']);
+  });
+
+  it('completeBroadcast does not revive an archived broadcast', () => {
+    const b = createBroadcast(db, KEY, { title: 'x' }).broadcast;
+    archiveBroadcast(db, KEY, b.id);
+    completeBroadcast(db, b.id, {});
+    assert.equal(getBroadcast(db, KEY, b.id).status, 'archived');
+  });
+});

--- a/packages/lcyt-backend/test/broadcasts-route.test.js
+++ b/packages/lcyt-backend/test/broadcasts-route.test.js
@@ -1,0 +1,125 @@
+/**
+ * Tests for the /broadcasts router. In-memory SQLite + session JWT auth,
+ * following the harness in stream.test.js.
+ */
+
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import express from 'express';
+import jwt from 'jsonwebtoken';
+import { initDb } from '../src/db.js';
+import { createAuthMiddleware } from '../src/middleware/auth.js';
+import { createBroadcastsRouter } from '../src/routes/broadcasts.js';
+
+const JWT_SECRET = 'test-broadcasts-secret';
+const KEY = 'bcast-route-key';
+
+let server, baseUrl, db, token;
+
+before(() => new Promise((resolve) => {
+  db = initDb(':memory:');
+  db.prepare("INSERT INTO api_keys (key, owner, active) VALUES (?, 'Owner', 1)").run(KEY);
+
+  const auth = createAuthMiddleware(JWT_SECRET);
+  const app = express();
+  app.use(express.json());
+  app.use('/broadcasts', createBroadcastsRouter(auth, db));
+
+  server = createServer(app);
+  server.listen(0, () => {
+    baseUrl = `http://localhost:${server.address().port}`;
+    resolve();
+  });
+
+  token = jwt.sign({ sessionId: 'sess-b-1', apiKey: KEY }, JWT_SECRET);
+}));
+
+after(() => new Promise((resolve) => {
+  db.close();
+  server.close(resolve);
+}));
+
+beforeEach(() => {
+  db.prepare('DELETE FROM broadcasts WHERE api_key = ?').run(KEY);
+});
+
+async function api(path, opts = {}) {
+  const res = await fetch(`${baseUrl}/broadcasts${path}`, {
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', ...(opts.headers || {}) },
+    ...opts,
+  });
+  const body = await res.json().catch(() => ({}));
+  return { status: res.status, body };
+}
+
+describe('/broadcasts CRUD', () => {
+  it('requires auth', async () => {
+    const res = await fetch(`${baseUrl}/broadcasts`);
+    assert.equal(res.status, 401);
+  });
+
+  it('creates, lists, gets, and updates', async () => {
+    const created = await api('/', { method: 'POST', body: JSON.stringify({ title: 'Cast 1' }) });
+    assert.equal(created.status, 201);
+    const id = created.body.broadcast.id;
+
+    const list = await api('/');
+    assert.equal(list.status, 200);
+    assert.equal(list.body.broadcasts.length, 1);
+
+    const got = await api(`/${id}`);
+    assert.equal(got.status, 200);
+    assert.equal(got.body.broadcast.title, 'Cast 1');
+
+    const upd = await api(`/${id}`, { method: 'PUT', body: JSON.stringify({ status: 'scheduled', scheduledStart: '2026-08-01T10:00:00' }) });
+    assert.equal(upd.status, 200);
+    assert.equal(upd.body.broadcast.status, 'scheduled');
+  });
+
+  it('404s for unknown id', async () => {
+    const got = await api('/does-not-exist');
+    assert.equal(got.status, 404);
+  });
+});
+
+describe('/broadcasts delete = archive then cooling-off', () => {
+  it('first DELETE archives (202), second is blocked (409)', async () => {
+    const created = await api('/', { method: 'POST', body: JSON.stringify({ title: 'x' }) });
+    const id = created.body.broadcast.id;
+
+    const first = await api(`/${id}`, { method: 'DELETE' });
+    assert.equal(first.status, 202);
+    assert.equal(first.body.archived, true);
+
+    const second = await api(`/${id}`, { method: 'DELETE' });
+    assert.equal(second.status, 409);
+
+    // restore brings it back
+    const restored = await api(`/${id}/restore`, { method: 'POST' });
+    assert.equal(restored.status, 200);
+    assert.equal(restored.body.broadcast.status, 'draft');
+  });
+});
+
+describe('/broadcasts assets + duplicate', () => {
+  it('links an asset and duplicates without produced content', async () => {
+    const created = await api('/', { method: 'POST', body: JSON.stringify({ title: 'Orig' }) });
+    const id = created.body.broadcast.id;
+
+    const link = await api(`/${id}/assets`, { method: 'POST', body: JSON.stringify({ assetType: 'graphic', assetRef: '7' }) });
+    assert.equal(link.status, 201);
+
+    const dup = await api(`/${id}/duplicate`, { method: 'POST', body: JSON.stringify({}) });
+    assert.equal(dup.status, 201);
+    assert.equal(dup.body.broadcast.title, 'Orig (copy)');
+    assert.equal(dup.body.broadcast.assets.length, 1);
+  });
+
+  it('cross-project duplicate is 501 (not yet implemented)', async () => {
+    const created = await api('/', { method: 'POST', body: JSON.stringify({ title: 'Orig' }) });
+    const id = created.body.broadcast.id;
+    const dup = await api(`/${id}/duplicate`, { method: 'POST', body: JSON.stringify({ targetApiKey: 'other-key' }) });
+    assert.equal(dup.status, 501);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the first-class **broadcasts** entity (plan/broadcasts) — a project-scoped casting occasion with lifecycle management (draft → scheduled → live → completed → archived), optional scheduling, linked reusable assets, and integration with session start/end events.

## Key Changes

- **New DB module** (`src/db/broadcasts.js`): 383 lines of SQL helpers for broadcast CRUD, lifecycle transitions, asset linkage, duplication, and session binding
  - Broadcast statuses: `draft`, `scheduled`, `live`, `completed`, `archived`
  - Asset types: `graphic`, `cue`, `action`, `icon`, `target`, `rundown`
  - Soft-delete (archive) with configurable cooling-off window before hard-delete (default 30 days)
  - Produced content (sessions, session_stats, caption_files) survives deletion with `broadcast_id` nulled
  - Duplication copies config + asset links, not produced content

- **New Express router** (`src/routes/broadcasts.js`): 109 lines implementing REST endpoints
  - `GET /broadcasts` — list with optional status/date-range filters
  - `POST /broadcasts` — create draft
  - `GET/PUT /broadcasts/:id` — retrieve and edit
  - `DELETE /broadcasts/:id` — archive (202) or hard-delete if past cooling-off (200)
  - `POST /broadcasts/:id/restore` — un-archive
  - `POST /broadcasts/:id/duplicate` — clone within project (cross-project marked 501)
  - `POST/DELETE /broadcasts/:id/assets` — link/unlink reusable assets

- **Session lifecycle binding** (`src/db/broadcasts.js` + `src/routes/live.js`)
  - `autoCreateForSession()` — auto-create a live broadcast for ad-hoc sessions (POST /live without broadcastId)
  - `bindSessionStart()` — transition existing broadcast draft→live when session starts
  - `completeBroadcast()` — mark broadcast completed, stamp actual_end, record YouTube video IDs when session ends
  - Prevents binding a second session to an already-live broadcast (1:1 per run)

- **Schema updates** (`src/db/schema.js`)
  - New tables: `broadcasts`, `broadcast_assets`
  - Additive columns on `sessions`, `session_stats`, `caption_files`: nullable `broadcast_id` for produced-content linkage
  - Indexes on api_key and status for efficient filtering

- **Integration points**
  - `src/routes/live.js`: Accept optional `broadcastId` in POST /live; bind session start/end to broadcast lifecycle
  - `src/server.js`: Call `completeBroadcast()` when session ends
  - `src/db/index.js`: Export broadcasts module
  - `src/routes/content.js`: Mount broadcasts router

- **Comprehensive test coverage** (218 lines in `test/broadcasts-db.test.js`, 125 lines in `test/broadcasts-route.test.js`)
  - CRUD, lifecycle transitions, archive cooling-off, asset linkage, duplication
  - Session binding (auto-create, bind-start, complete)
  - HTTP route auth, error cases, status codes

## Notable Implementation Details

- **Soft-delete with cooling-off**: First DELETE archives (202 response); second DELETE on archived broadcast is blocked until `BROADCAST_ARCHIVE_MIN_AGE_DAYS` (env var, default 30) has elapsed, then hard-deletes and nulls produced-content links
- **Asset uniqueness**: Broadcast + asset_type + asset_ref is unique; prevents duplicate links
- **Produced content survival**: Sessions, session_stats, caption_files are never deleted when a broadcast is removed — only `broadcast_id` is nulled
- **Session 1:1 binding**: A broadcast can only have one active session at a time; attempting to bind a second session to a live broadcast returns 409
- **Cross-project duplicate**: Marked 501 (not yet implemented); same-project duplication is fully functional
- **Timestamp formatting**: All dates use ISO 8601 strings; camelCase in API responses,

https://claude.ai/code/session_014uYbCqerw43NTswPfkHEup