### PR TITLE
Fix project routing: show summary on enter, require project for scoped pages

### DIFF
--- a/packages/lcyt-web/src/components/AiSettingsPage.jsx
+++ b/packages/lcyt-web/src/components/AiSettingsPage.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useSessionContext } from '../contexts/SessionContext';
 import { useLang } from '../contexts/LangContext';
+import { useProjectRequired } from '../hooks/useProjectRequired';
 
 const PROVIDERS = [
   { value: 'none',   label: 'Disabled' },
@@ -10,6 +11,7 @@ const PROVIDERS = [
 ];
 
 export function AiSettingsPage() {
+  useProjectRequired();
   const { t } = useLang();
   const session = useSessionContext();
   const [config, setConfig] = useState(null);

--- a/packages/lcyt-web/src/components/AssetsPage.jsx
+++ b/packages/lcyt-web/src/components/AssetsPage.jsx
@@ -6,6 +6,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Link } from 'wouter';
 import { useSessionContext } from '../contexts/SessionContext';
+import { useProjectRequired } from '../hooks/useProjectRequired';
 import { SetupCard, SetupItemRow } from './setup-hub/SetupCard.jsx';
 
 const FILTERS = [
@@ -40,6 +41,7 @@ function formatBytes(bytes) {
 }
 
 export function AssetsPage() {
+  useProjectRequired();
   const session = useSessionContext();
   const connected = session?.connected;
   const backendUrl = session?.backendUrl;

--- a/packages/lcyt-web/src/components/AudioPage.jsx
+++ b/packages/lcyt-web/src/components/AudioPage.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useAudioContext } from '../contexts/AudioContext';
 import { useSentLogContext } from '../contexts/SentLogContext';
+import { useProjectRequired } from '../hooks/useProjectRequired';
 import { LanguagePicker } from './LanguagePicker';
 import { readInputLang, writeInputLang, INPUT_LANG_EVENT } from '../lib/inputLang';
 import { formatTime } from '../lib/formatting';
@@ -36,6 +37,7 @@ function MiniSentLog() {
 }
 
 export function AudioPage() {
+  useProjectRequired();
   const audio = useAudioContext();
   const [lang, setLang] = useState(readInputLang);
   const [utteranceEnd, setUtteranceEnd] = useState(

--- a/packages/lcyt-web/src/components/BroadcastPage.jsx
+++ b/packages/lcyt-web/src/components/BroadcastPage.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useProjectRequired } from '../hooks/useProjectRequired';
 import { LiveTab } from './broadcast/LiveTab.jsx';
 import { SettingsTab } from './broadcast/SettingsTab.jsx';
 
@@ -15,6 +16,7 @@ const TABS = [
  * config (formerly `BroadcastModal`).
  */
 export function BroadcastPage() {
+  useProjectRequired();
   const [activeTab, setActiveTab] = useState('live');
 
   return (

--- a/packages/lcyt-web/src/components/DskControlPage.jsx
+++ b/packages/lcyt-web/src/components/DskControlPage.jsx
@@ -1,5 +1,6 @@
 import { useCallback, useContext, useEffect, useState } from 'react';
 import { SessionContext } from '../contexts/SessionContext';
+import { useProjectRequired } from '../hooks/useProjectRequired';
 import { templateSlug } from '../lib/formatting.js';
 
 /**
@@ -76,6 +77,10 @@ const inputStyle = {
 };
 
 export function DskControlPage() {
+  // Only require project when in sidebar mode (/graphics/control), not in standalone mode (/dsk-control/:key)
+  const isStandalone = window.location.pathname.startsWith('/dsk-control/');
+  if (!isStandalone) useProjectRequired();
+
   const session = useContext(SessionContext);
   const pathParts = window.location.pathname.split('/');
   // /dsk-control/:apikey (standalone) or /graphics/control (sidebar) — context takes priority

--- a/packages/lcyt-web/src/components/DskEditorPage.jsx
+++ b/packages/lcyt-web/src/components/DskEditorPage.jsx
@@ -2,6 +2,7 @@ import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { SessionContext } from '../contexts/SessionContext';
 import { useToastContext } from '../contexts/ToastContext';
 import { usePageThemeOverride } from '../hooks/usePageThemeOverride.js';
+import { useProjectRequired } from '../hooks/useProjectRequired.js';
 import { useResizableColumn } from '../hooks/useResizableColumn.js';
 import { KEYS } from '../lib/storageKeys.js';
 import { templateSlug } from '../lib/formatting.js';
@@ -166,6 +167,7 @@ function newGroupId()     { _groupCounter += 1; return `grp-${_groupCounter}`; }
 // ── Main component ────────────────────────────────────────────────────────────
 
 export function DskEditorPage() {
+  useProjectRequired();
   usePageThemeOverride(KEYS.ui.editorTheme);
   const session   = useContext(SessionContext);
   const params    = new URLSearchParams(window.location.search);

--- a/packages/lcyt-web/src/components/DskViewportsPage.jsx
+++ b/packages/lcyt-web/src/components/DskViewportsPage.jsx
@@ -1,5 +1,6 @@
 import { useContext, useEffect, useState, useCallback, useId } from 'react';
 import { SessionContext } from '../contexts/SessionContext';
+import { useProjectRequired } from '../hooks/useProjectRequired';
 import { dark, btnPrimary, btnDanger, btnSmall, inputStyle, labelStyle } from './dsk-viewports/styles.js';
 import { TextLayersEditor } from './dsk-viewports/TextLayersEditor.jsx';
 import { ImageSettingsTable } from './dsk-viewports/ImageSettingsTable.jsx';
@@ -7,6 +8,7 @@ import { ImageSettingsTable } from './dsk-viewports/ImageSettingsTable.jsx';
 // ── Component ─────────────────────────────────────────────────────────────────
 
 export function DskViewportsPage() {
+  useProjectRequired();
   const session   = useContext(SessionContext);
   const params    = new URLSearchParams(window.location.search);
   const serverUrl = (session?.backendUrl || params.get('server') || window.location.origin).replace(/\/$/, '');

--- a/packages/lcyt-web/src/components/PlannerPage.jsx
+++ b/packages/lcyt-web/src/components/PlannerPage.jsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useCallback, useContext } from 'react';
 import { useFileContext } from '../contexts/FileContext';
 import { useToastContext } from '../contexts/ToastContext';
 import { usePageThemeOverride } from '../hooks/usePageThemeOverride.js';
+import { useProjectRequired } from '../hooks/useProjectRequired.js';
 import { KEYS } from '../lib/storageKeys.js';
 import { uid, serializePlan, deserializePlan } from '../lib/plannerUtils.js';
 import { NormalizeLinesModal, normalizeLines } from './NormalizeLinesModal';
@@ -699,6 +700,7 @@ function useIsNarrow() {
 }
 
 export function PlannerPage() {
+  useProjectRequired();
   usePageThemeOverride(KEYS.ui.plannerTheme);
   const fileStore = useFileContext();
   const { showToast } = useToastContext();

--- a/packages/lcyt-web/src/components/ProductionBridgesPage.jsx
+++ b/packages/lcyt-web/src/components/ProductionBridgesPage.jsx
@@ -1,6 +1,7 @@
 import { KEYS } from '../lib/storageKeys.js';
 import { useState, useEffect, useCallback, useContext, forwardRef, useImperativeHandle } from 'react';
 import { SessionContext } from '../contexts/SessionContext';
+import { useProjectRequired } from '../hooks/useProjectRequired';
 import { Dialog } from './Dialog.jsx';
 import { SetupItemRow } from './setup-hub/SetupCard.jsx';
 
@@ -474,5 +475,6 @@ export const BridgesManager = forwardRef(function BridgesManager({ embedded = fa
 
 /** ProductionBridgesPage — standalone route wrapper around BridgesManager. */
 export function ProductionBridgesPage() {
+  useProjectRequired();
   return <BridgesManager />;
 }

--- a/packages/lcyt-web/src/components/ProductionCamerasPage.jsx
+++ b/packages/lcyt-web/src/components/ProductionCamerasPage.jsx
@@ -1,6 +1,7 @@
 import { KEYS } from '../lib/storageKeys.js';
 import { useState, useEffect, useCallback, useContext, forwardRef, useImperativeHandle } from 'react';
 import { SessionContext } from '../contexts/SessionContext';
+import { useProjectRequired } from '../hooks/useProjectRequired';
 import { ConnectionSourceSelect } from './ProductionEncodersPage.jsx';
 import { Dialog } from './Dialog.jsx';
 import { SetupItemRow } from './setup-hub/SetupCard.jsx';
@@ -461,5 +462,6 @@ export const CamerasManager = forwardRef(function CamerasManager({ embedded = fa
 
 /** ProductionCamerasPage — standalone route wrapper around CamerasManager. */
 export function ProductionCamerasPage() {
+  useProjectRequired();
   return <CamerasManager />;
 }

--- a/packages/lcyt-web/src/components/ProductionDevicesPage.jsx
+++ b/packages/lcyt-web/src/components/ProductionDevicesPage.jsx
@@ -1,9 +1,11 @@
+import { useProjectRequired } from '../hooks/useProjectRequired';
 import { ProductionCamerasPage } from './ProductionCamerasPage';
 import { ProductionMixersPage } from './ProductionMixersPage';
 import { ProductionBridgesPage } from './ProductionBridgesPage';
 import { ProductionEncodersPage } from './ProductionEncodersPage';
 
 export function ProductionDevicesPage() {
+  useProjectRequired();
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
       <div style={{

--- a/packages/lcyt-web/src/components/ProductionEncodersPage.jsx
+++ b/packages/lcyt-web/src/components/ProductionEncodersPage.jsx
@@ -1,6 +1,7 @@
 import { KEYS } from '../lib/storageKeys.js';
 import { useState, useEffect, useCallback, useContext, forwardRef, useImperativeHandle } from 'react';
 import { SessionContext } from '../contexts/SessionContext';
+import { useProjectRequired } from '../hooks/useProjectRequired';
 import { Dialog } from './Dialog.jsx';
 import { SetupItemRow } from './setup-hub/SetupCard.jsx';
 
@@ -376,6 +377,7 @@ export const EncodersManager = forwardRef(function EncodersManager({ embedded = 
 
 /** ProductionEncodersPage — standalone route wrapper around EncodersManager. */
 export function ProductionEncodersPage() {
+  useProjectRequired();
   return <EncodersManager />;
 }
 

--- a/packages/lcyt-web/src/components/ProductionMixersPage.jsx
+++ b/packages/lcyt-web/src/components/ProductionMixersPage.jsx
@@ -1,6 +1,7 @@
 import { KEYS } from '../lib/storageKeys.js';
 import { useState, useEffect, useCallback, useContext, forwardRef, useImperativeHandle } from 'react';
 import { SessionContext } from '../contexts/SessionContext';
+import { useProjectRequired } from '../hooks/useProjectRequired';
 import { ConnectionSourceSelect } from './ProductionEncodersPage.jsx';
 import { Dialog } from './Dialog.jsx';
 import { SetupItemRow } from './setup-hub/SetupCard.jsx';
@@ -488,5 +489,6 @@ export const MixersManager = forwardRef(function MixersManager({ embedded = fals
 
 /** ProductionMixersPage — standalone route wrapper around MixersManager. */
 export function ProductionMixersPage() {
+  useProjectRequired();
   return <MixersManager />;
 }

--- a/packages/lcyt-web/src/components/ProductionOperatorPage.jsx
+++ b/packages/lcyt-web/src/components/ProductionOperatorPage.jsx
@@ -1,3 +1,4 @@
+import { useProjectRequired } from '../hooks/useProjectRequired';
 import { useProductionData } from './production/workspace/useProductionData.js';
 import { useWorkspaceLayout } from './production/workspace/useWorkspaceLayout.js';
 import { ProductionHeader, ViewPills } from './production/workspace/Chrome.jsx';
@@ -13,6 +14,7 @@ import { C } from './production/workspace/theme.js';
 // Ported from the Claude Design mockup (project 9919ac53, "Production Page").
 
 export function ProductionOperatorPage() {
+  useProjectRequired();
   const D = useProductionData();
   const wl = useWorkspaceLayout(D.creds.apiKey || 'default');
 

--- a/packages/lcyt-web/src/components/ProductionVisualPage.jsx
+++ b/packages/lcyt-web/src/components/ProductionVisualPage.jsx
@@ -1,3 +1,4 @@
+import { useProjectRequired } from '../hooks/useProjectRequired';
 import { MermaidChart } from './MermaidChart.jsx';
 
 const VIDEO_SIGNAL_FLOW = `
@@ -159,6 +160,7 @@ function Section({ title, description, chart }) {
 }
 
 export function ProductionVisualPage() {
+  useProjectRequired();
   return (
     <div style={{ padding: '20px 24px', maxWidth: 1100 }}>
       <div style={{ marginBottom: 24 }}>

--- a/packages/lcyt-web/src/components/RootRoute.jsx
+++ b/packages/lcyt-web/src/components/RootRoute.jsx
@@ -30,7 +30,7 @@ const LiveTab             = lazyImport(() => import('./broadcast/LiveTab.jsx').t
 /**
  * RootRoute — resolves what `/` shows (see
  * docs/plans/plan_dashboard_console_redesign.md "Routing model"):
- *   - An active/connected project         → that project's summary view
+ *   - An active project (connected OR persisted)   → that project's summary view
  *     (ProjectSettingsPage, implicit key, Summary tab by default).
  *   - No active project + `login` feature → redirect to /projects (pick one).
  *   - No active project + no `login` feature (minimal-mode backend, or
@@ -38,9 +38,12 @@ const LiveTab             = lazyImport(() => import('./broadcast/LiveTab.jsx').t
  *     directly, since there's no multi-project concept to summarize.
  */
 export function RootRoute() {
-  const { connected, apiKey, projectId, backendFeatures } = useSessionContext();
+  const { connected, apiKey, projectId, backendFeatures, getPersistedConfig } = useSessionContext();
+  const persistedCfg = getPersistedConfig();
+  const hasPersistedProject = hasProjectSessionConfig(persistedCfg);
 
-  if (connected && (apiKey || projectId)) {
+  // Show project summary if connected OR if a project is persisted (auto-connect pending).
+  if ((connected || hasPersistedProject) && (apiKey || projectId)) {
     return (
       <Suspense fallback={null}>
         <ProjectSettingsPage implicitKey />

--- a/packages/lcyt-web/src/components/SettingsPage.jsx
+++ b/packages/lcyt-web/src/components/SettingsPage.jsx
@@ -2,6 +2,7 @@ import { useState, useRef } from 'react';
 import { SettingsModal } from './SettingsModal';
 import { CCModal } from './CCModal';
 import { useSessionContext } from '../contexts/SessionContext';
+import { useProjectRequired } from '../hooks/useProjectRequired';
 import { downloadSettings, importSettings } from '../lib/settingsIO.js';
 
 /**
@@ -26,6 +27,7 @@ const TOP_TABS = [
 ];
 
 export function SettingsPage() {
+  useProjectRequired();
   const [activeTab, setActiveTab] = useState('general');
   const { connected } = useSessionContext();
   const [importResult, setImportResult] = useState(null);

--- a/packages/lcyt-web/src/components/TranslationsPage.jsx
+++ b/packages/lcyt-web/src/components/TranslationsPage.jsx
@@ -1,3 +1,4 @@
+import { useProjectRequired } from '../hooks/useProjectRequired';
 import { LanguagesManager } from './LanguagesPage.jsx';
 
 /**
@@ -8,5 +9,6 @@ import { LanguagesManager } from './LanguagesPage.jsx';
  * logic here anymore.
  */
 export function TranslationsPage() {
+  useProjectRequired();
   return <LanguagesManager />;
 }

--- a/packages/lcyt-web/src/components/setup-hub/SetupHubPage.jsx
+++ b/packages/lcyt-web/src/components/setup-hub/SetupHubPage.jsx
@@ -21,6 +21,7 @@ import { useCardFavorites } from '../../lib/cardFavorites.js';
 import { useUserAuth } from '../../hooks/useUserAuth.js';
 import { useSessionContext } from '../../contexts/SessionContext.jsx';
 import { useProjectFeatures } from '../../hooks/useProjectFeatures.js';
+import { useProjectRequired } from '../../hooks/useProjectRequired.js';
 import { cardIdsForEnabledFeatures } from '../../lib/workflowFeatureMap.js';
 
 const FILTERS = [
@@ -54,6 +55,7 @@ const FILTERS = [
  * card below has an `id` for this reason.
  */
 export function SetupHubPage() {
+  useProjectRequired();
   const [filter, setFilter] = useState('all');
   const { favorites } = useCardFavorites();
 

--- a/packages/lcyt-web/src/hooks/useProjectRequired.js
+++ b/packages/lcyt-web/src/hooks/useProjectRequired.js
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+import { useLocation } from 'wouter';
+import { useSessionContext } from '../contexts/SessionContext';
+import { hasProjectSessionConfig } from '../lib/projectSession.js';
+
+/**
+ * Hook for project-scoped pages — redirects to /projects if no project is active.
+ * Usage: add at the top of a page component that requires a project context.
+ */
+export function useProjectRequired() {
+  const [, setLocation] = useLocation();
+  const { getPersistedConfig } = useSessionContext();
+  const persistedCfg = getPersistedConfig();
+  const hasProject = hasProjectSessionConfig(persistedCfg);
+
+  useEffect(() => {
+    if (!hasProject) {
+      setLocation('/projects');
+    }
+  }, [hasProject, setLocation]);
+
+  return hasProject;
+}


### PR DESCRIPTION
## Summary

Fixed two routing issues:

1. **Project summary page not opening**: When a user clicks "Enter" on a project from the Projects page, RootRoute now checks for persisted project config (in addition to connection status) and shows the project summary even while auto-connect is pending. Previously it would fall back to /projects or LiveTab because `connected` was still false.

2. **Unprotected project-scoped pages**: Added `useProjectRequired()` hook that redirects to /projects if no project is entered. Applied to all project-scoped pages:
   - `/assets`
   - `/setup` (and `/setup/*`)
   - `/broadcast`
   - `/graphics/editor`, `/graphics/control`, `/graphics/viewports`
   - `/production/cameras`, `/production/mixers`, `/production/bridges`, `/production/devices`, `/production/visual`, `/production`
   - `/audio`
   - `/planner`
   - `/translations`
   - `/ai`
   - `/settings`

User-scoped pages (`/projects`, `/team`, `/admin/*`, `/account`) remain accessible without a project context.

## Changes

- **RootRoute.jsx**: Check persisted project config alongside `connected` flag
- **useProjectRequired.js**: New hook to guard project-scoped pages
- **~20 component files**: Added hook to project-scoped page components

🤖 Generated with Claude Code
https://claude.ai/code/session_01RG8TrTETmuzm1tP7NrRSbw