### PR TITLE
Add tcp-sender testing tool for lcyt-bridge TCP targets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,8 @@ live-captions-yt/
 │   ├── lcyt-tools/             # Shared AI tool-schema/handler registry (MCP + agentic_chat roles)
 │   ├── shared-styles/          # Shared CSS design tokens consumed by lcyt-site and lcyt-web
 │   ├── tools/                  # Standalone utilities
-│   │   └── tcp-echo-server/    # TCP echo server for bridge connection testing
+│   │   ├── tcp-echo-server/    # TCP echo server for bridge connection testing
+│   │   └── tcp-sender/         # TCP command sender for bridge connection testing
 │   └── plugins/                # Plugin packages (npm workspaces glob: packages/plugins/*)
 │       ├── lcyt-agent/         # AI Agent plugin (AI config, embeddings, LLM event evaluation)
 │       ├── lcyt-connectors/    # API Connectors & Variables plugin ({{ }} bindings, metacode-triggered refresh)
@@ -117,6 +118,7 @@ Each row's `CLAUDE.md` is only loaded when Claude reads or edits files in that d
 | Compute orchestrator | `packages/lcyt-orchestrator/CLAUDE.md` |
 | Worker daemon | `packages/lcyt-worker-daemon/CLAUDE.md` |
 | TCP echo test server | `packages/tools/tcp-echo-server/CLAUDE.md` |
+| TCP command sender test tool | `packages/tools/tcp-sender/CLAUDE.md` |
 | MCP server (stdio) | `packages/lcyt-mcp-stdio/CLAUDE.md` |
 | MCP server (Streamable HTTP) | `packages/lcyt-mcp-http/CLAUDE.md` |
 | Marketing site | `packages/lcyt-site/CLAUDE.md` |

--- a/packages/tools/tcp-sender/.gitignore
+++ b/packages/tools/tcp-sender/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/packages/tools/tcp-sender/CLAUDE.md
+++ b/packages/tools/tcp-sender/CLAUDE.md
@@ -1,0 +1,7 @@
+# `packages/tools/tcp-sender` — TCP Command Sender
+
+Standalone development utility. Opens a TCP connection to a given host/port, sends one command payload, prints any response, then closes. Client-side counterpart to `packages/tools/tcp-echo-server` — used for manually testing `lcyt-bridge` TCP targets (the echo server, or real AMX/Roland hardware) without running the full bridge agent.
+
+**Entry:** `sender.js`
+**Usage:** `node sender.js <host> <port> <command>`
+**Env:** `TIMEOUT_MS` — how long to wait for a response before closing (default: 2000)

--- a/packages/tools/tcp-sender/README.md
+++ b/packages/tools/tcp-sender/README.md
@@ -1,0 +1,66 @@
+# tcp-sender
+
+A minimal TCP command sender for testing lcyt-bridge TCP targets — AMX/NetLinx masters, Roland mixers, the `tcp-echo-server` in this repo, or anything else that speaks plain TCP.
+
+## What it does
+
+Opens a TCP connection to `<host>:<port>`, writes a single command payload, prints anything the remote end sends back within a short window, then closes the connection. This is the client-side counterpart to `tcp-echo-server` — where the echo server gives you something to send *to*, `tcp-sender` gives you a way to send *from*, without needing the full `lcyt-bridge` agent or the lcyt-web UI running.
+
+## Usage
+
+```bash
+# Basic send
+node sender.js <host> <port> <command>
+
+# Against the local echo server
+node sender.js 127.0.0.1 9999 PING
+
+# Against a NetLinx bridge listener (see keskuskirkko-netlinx's
+# docs/plans/lcyt-bridge-tcp-camera-control.md for the wire format)
+node sender.js 192.168.1.50 6500 "CAM1:PRESET:3;"
+
+# Wait longer for a response
+TIMEOUT_MS=5000 node sender.js 192.168.1.50 6500 "CAM1:MOVE:UP;"
+```
+
+Quote the command if it contains spaces or shell-special characters (`;`, `$`, `'`, `"`).
+
+## Testing round-trip with the echo server
+
+```bash
+# Terminal 1
+node packages/tools/tcp-echo-server/server.js
+
+# Terminal 2
+node packages/tools/tcp-sender/sender.js 127.0.0.1 9999 "PING"
+```
+
+The sender should print the connection, the outgoing payload, and the echoed response back from the server.
+
+## Building standalone executables
+
+The sender can be compiled into self-contained executables that run without Node.js installed,
+using [esbuild](https://esbuild.github.io/) for bundling and [@yao-pkg/pkg](https://github.com/yao-pkg/pkg) for packaging.
+
+```bash
+# Install build dependencies first (one-time)
+npm install
+
+# Build for a specific platform
+npm run build:win          # → dist/tcp-sender-1.0.0.exe    (Windows x64)
+npm run build:mac          # → dist/tcp-sender-1.0.0-mac    (macOS x64)
+npm run build:linux        # → dist/tcp-sender-1.0.0-linux  (Linux x64)
+npm run build:linux-arm64  # → dist/tcp-sender-1.0.0-linux-arm64 (Linux ARM64)
+
+# Build all platforms at once
+npm run build:all
+```
+
+All platforms can be cross-compiled from any host operating system.
+The `dist/` directory is gitignored; binaries are not committed to the repository.
+
+## Notes
+
+- **Not a workspace package** — this tool lives in `packages/tools/` but is intentionally excluded from the npm workspace glob, same as `tcp-echo-server`.
+- Runtime has no external dependencies; uses Node.js `node:net` only.
+- Suitable for local dev and on-site network diagnostics (e.g. verifying a NetLinx master's TCP listener is reachable before wiring up `lcyt-bridge`).

--- a/packages/tools/tcp-sender/package.json
+++ b/packages/tools/tcp-sender/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "tcp-sender",
+  "version": "1.0.0",
+  "description": "Minimal TCP command sender for lcyt-bridge / hardware testing",
+  "type": "module",
+  "scripts": {
+    "start": "node sender.js",
+    "build:bundle": "node scripts/build.cjs",
+    "build:win": "node scripts/build.cjs win",
+    "build:mac": "node scripts/build.cjs mac",
+    "build:linux": "node scripts/build.cjs linux",
+    "build:linux-arm64": "node scripts/build.cjs linux-arm64",
+    "build:all": "node scripts/build.cjs win && node scripts/build.cjs mac && node scripts/build.cjs linux && node scripts/build.cjs linux-arm64"
+  },
+  "pkg": {
+    "assets": [],
+    "scripts": []
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "license": "",
+  "private": true,
+  "devDependencies": {
+    "@yao-pkg/pkg": "^5.16.1",
+    "esbuild": "^0.25.0"
+  }
+}

--- a/packages/tools/tcp-sender/scripts/build.cjs
+++ b/packages/tools/tcp-sender/scripts/build.cjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+/**
+ * tcp-sender build script — bundles with esbuild then packages with pkg.
+ * Output filenames include the version number, e.g.:
+ *   dist/tcp-sender-1.0.0.exe
+ *   dist/tcp-sender-1.0.0-mac
+ *   dist/tcp-sender-1.0.0-linux
+ *   dist/tcp-sender-1.0.0-linux-arm64
+ *
+ * Usage:
+ *   node scripts/build.cjs              # bundle only (esbuild step)
+ *   node scripts/build.cjs win          # bundle + package for Windows x64
+ *   node scripts/build.cjs mac          # bundle + package for macOS x64
+ *   node scripts/build.cjs linux        # bundle + package for Linux x64
+ *   node scripts/build.cjs linux-arm64  # bundle + package for Linux ARM64
+ */
+const { execSync } = require('child_process');
+const { version }  = require('../package.json');
+
+const targets = {
+  win:          { target: 'node18-win-x64',       output: `dist/tcp-sender-${version}.exe` },
+  mac:          { target: 'node18-macos-x64',     output: `dist/tcp-sender-${version}-mac` },
+  linux:        { target: 'node18-linux-x64',     output: `dist/tcp-sender-${version}-linux` },
+  'linux-arm64':{ target: 'node18-linux-arm64',   output: `dist/tcp-sender-${version}-linux-arm64` },
+};
+
+const run = (cmd) => { console.log(`[build] ${cmd}`); execSync(cmd, { stdio: 'inherit' }); };
+
+// Step 1: esbuild bundle (ESM → CJS so pkg can process it)
+console.log(`[build] tcp-sender v${version}`);
+run(`npx esbuild sender.js --bundle --platform=node --target=node18 --format=cjs --outfile=dist/bundle.cjs`);
+
+// Step 2: pkg (optional, controlled by CLI arg)
+const platform = process.argv[2];
+if (platform) {
+  const t = targets[platform];
+  if (!t) {
+    console.error(`[build] Unknown platform: ${platform}. Use win, mac, linux, or linux-arm64.`);
+    process.exit(1);
+  }
+  run(`npx @yao-pkg/pkg dist/bundle.cjs --target ${t.target} --output ${t.output}`);
+  console.log(`[build] → ${t.output}`);
+}

--- a/packages/tools/tcp-sender/sender.js
+++ b/packages/tools/tcp-sender/sender.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * tcp-sender — minimal TCP command sender for bridge/hardware testing.
+ *
+ * Opens a TCP connection to a host:port, writes a single command payload,
+ * prints whatever the remote end sends back within a short window, then
+ * closes the connection. Useful for manually testing lcyt-bridge TCP
+ * targets (the tcp-echo-server, or real AMX/Roland hardware) without
+ * spinning up the full bridge agent or lcyt-web UI.
+ *
+ * Usage:
+ *   node sender.js <host> <port> <command>
+ *
+ * Environment variables:
+ *   TIMEOUT_MS   How long to wait for a response before closing (default: 2000)
+ *
+ * Examples:
+ *   node sender.js 127.0.0.1 9999 PING
+ *   node sender.js 192.168.1.50 6500 "CAM1:PRESET:3;"
+ *   TIMEOUT_MS=5000 node sender.js 192.168.1.50 6500 "CAM1:MOVE:UP;"
+ */
+
+import { createConnection } from 'node:net';
+
+const [, , host, portArg, ...commandParts] = process.argv;
+const port = Number(portArg);
+const command = commandParts.join(' ');
+const TIMEOUT_MS = Number(process.env.TIMEOUT_MS ?? 2000);
+
+if (!host || !Number.isInteger(port) || port <= 0 || port > 65535 || !command) {
+  console.error('Usage: node sender.js <host> <port> <command>');
+  console.error('Example: node sender.js 127.0.0.1 9999 "CAM1:PRESET:3;"');
+  process.exit(1);
+}
+
+const socket = createConnection({ host, port }, () => {
+  console.log(`[sender] Connected to ${host}:${port}`);
+  console.log(`[sender] → ${JSON.stringify(command)}`);
+  socket.write(command);
+});
+
+socket.on('data', (chunk) => {
+  console.log(`[sender] ← ${JSON.stringify(chunk.toString())}`);
+});
+
+socket.on('error', (err) => {
+  console.error(`[sender] Error: ${err.message}`);
+  process.exitCode = 1;
+});
+
+socket.on('close', () => {
+  console.log('[sender] Connection closed');
+});
+
+setTimeout(() => {
+  socket.end();
+}, TIMEOUT_MS);


### PR DESCRIPTION
## Summary
- Adds `packages/tools/tcp-sender`, a standalone CLI counterpart to the existing `tcp-echo-server`: it opens a TCP connection to `<host> <port>`, writes a single `<command>` payload, prints any response within a timeout window, then closes the connection.
- Intended for manually testing `lcyt-bridge` TCP targets — the echo server, or real AMX/Roland/NetLinx hardware (see `keskuskirkko-netlinx`'s `docs/plans/lcyt-bridge-tcp-camera-control.md` for the planned wire format, e.g. `CAM1:PRESET:3;`) — without running the full bridge agent or the lcyt-web UI.
- Mirrors `tcp-echo-server`'s structure/conventions (package.json, `.gitignore`, README, CLAUDE.md, esbuild+pkg build scripts for standalone binaries), intentionally excluded from the npm workspace glob like its sibling.
- Updates root `CLAUDE.md`'s repository structure diagram and Package Index to reference the new tool.

## Test plan
- [x] Manual round-trip test: started `tcp-echo-server` on port 9999, sent `PING;` via `tcp-sender`, confirmed the echoed response was received and printed.
- [x] Verified argument validation (missing command, non-numeric port, out-of-range port) prints usage and exits non-zero.
- [x] `node -c sender.js` syntax check passes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DEHFLa8iCfZrVQuL9qtm4H)_